### PR TITLE
fix: harden cross-platform lifecycle qualification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ permissions:
 
 jobs:
   implementation-checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
       - run: bun install --frozen-lockfile

--- a/.github/workflows/platform-qualification.yml
+++ b/.github/workflows/platform-qualification.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
       - run: bun install --frozen-lockfile
@@ -30,7 +30,7 @@ jobs:
             throw "gateway status was not installed, active, and ready"
           }
           $process = Get-CimInstance Win32_Process |
-            Where-Object { $_.CommandLine -like '*apps\gateway\src\cli.ts*serve*' } |
+            Where-Object { $_.Name -eq 'bun.exe' -and $_.CommandLine -like '*apps\gateway\src\cli.ts*serve*' } |
             Select-Object -First 1
           if ($null -eq $process) { throw "gateway process was not found" }
           $process.ProcessId | Set-Content -NoNewline "$env:RUNNER_TEMP\gateway-pid.txt"
@@ -48,7 +48,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "active reinstall failed" }
           $beforePid = [int](Get-Content "$env:RUNNER_TEMP\gateway-pid.txt")
           $process = Get-CimInstance Win32_Process |
-            Where-Object { $_.CommandLine -like '*apps\gateway\src\cli.ts*serve*' } |
+            Where-Object { $_.Name -eq 'bun.exe' -and $_.CommandLine -like '*apps\gateway\src\cli.ts*serve*' } |
             Select-Object -First 1
           if ($null -eq $process -or $process.ProcessId -eq $beforePid) {
             throw "active reinstall did not replace the gateway process"
@@ -68,3 +68,8 @@ jobs:
           if ($null -ne (Get-ScheduledTask -TaskName 'OMP Session Gateway' -ErrorAction SilentlyContinue)) {
             throw "scheduled task remained after uninstall"
           }
+          Start-Sleep -Milliseconds 500
+          $process = Get-CimInstance Win32_Process |
+            Where-Object { $_.Name -eq 'bun.exe' -and $_.CommandLine -like '*apps\gateway\src\cli.ts*serve*' } |
+            Select-Object -First 1
+          if ($null -ne $process) { throw "gateway process remained after uninstall" }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,11 @@ jobs:
           fi
           archive="dist/release/omp-session-gateway-${version}-bun.tar"
           checksums="dist/release/SHA256SUMS"
+          sbom="dist/release/omp-session-gateway-${version}.spdx.json"
           {
             echo "PACKAGE_VERSION=$version"
             echo "ARCHIVE_PATH=$archive"
+            echo "SBOM_PATH=$sbom"
             echo "CHECKSUM_PATH=$checksums"
           } >> "$GITHUB_ENV"
 
@@ -67,8 +69,9 @@ jobs:
           set -euo pipefail
           bun run release:build
           test -f "$ARCHIVE_PATH"
+          test -f "$SBOM_PATH"
           test -f "$CHECKSUM_PATH"
-          if [[ "$(find dist/release -maxdepth 1 -type f | wc -l | tr -d ' ')" != "2" ]]; then
+          if [[ "$(find dist/release -maxdepth 1 -type f | wc -l | tr -d ' ')" != "3" ]]; then
             echo "Release builder emitted unexpected files." >&2
             exit 1
           fi
@@ -79,6 +82,7 @@ jobs:
         with:
           subject-path: |
             dist/release/omp-session-gateway-*-bun.tar
+            dist/release/omp-session-gateway-*.spdx.json
             dist/release/SHA256SUMS
 
       - name: Install Cosign
@@ -89,7 +93,7 @@ jobs:
       - name: Sign artifacts with GitHub OIDC
         run: |
           set -euo pipefail
-          for artifact in "$ARCHIVE_PATH" "$CHECKSUM_PATH"; do
+          for artifact in "$ARCHIVE_PATH" "$SBOM_PATH" "$CHECKSUM_PATH"; do
             cosign sign-blob --yes --bundle "${artifact}.sigstore.json" "$artifact"
           done
 
@@ -101,7 +105,7 @@ jobs:
           (cd dist/release && sha256sum --check SHA256SUMS)
           signer_workflow="$GITHUB_REPOSITORY/.github/workflows/release.yml"
           certificate_identity="https://github.com/${signer_workflow}@${GITHUB_REF}"
-          for artifact in "$ARCHIVE_PATH" "$CHECKSUM_PATH"; do
+          for artifact in "$ARCHIVE_PATH" "$SBOM_PATH" "$CHECKSUM_PATH"; do
             gh attestation verify "$artifact" \
               --repo "$GITHUB_REPOSITORY" \
               --signer-workflow "$signer_workflow" \
@@ -141,8 +145,10 @@ jobs:
           EOF
           gh release create "$GITHUB_REF_NAME" \
             "$ARCHIVE_PATH" \
+            "$SBOM_PATH" \
             "$CHECKSUM_PATH" \
             "${ARCHIVE_PATH}.sigstore.json" \
+            "${SBOM_PATH}.sigstore.json" \
             "${CHECKSUM_PATH}.sigstore.json" \
             --draft \
             --prerelease \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
 - Pinned OMP collab-web source with direct in-memory one-time `MessageChannel` capability bootstrap.
 - Apply-ready OMP `CollabController`, auto-start, local publisher, lifecycle revocation, and test patch.
 - Cross-platform user-service definitions and management commands for install, uninstall, status, doctor, token rotation, and Serve guidance.
-- Deterministic redacted diagnostics archives and deterministic Bun-runtime release archives with SHA-256 manifests.
+- Deterministic redacted diagnostics archives and Bun-runtime release archives with SPDX 2.3 dependency inventories and SHA-256 manifests.
 - Keyless GitHub OIDC build attestations and Cosign signatures with immutable tag-triggered pre-alpha releases and documented verification.
 - Unit/integration coverage for protocol, registry, IPC, HTTP authorization and launch, config permissions, services, diagnostics, and capability leaks.
+- Explicit compatibility/support matrices and a release-status gate ledger separating implemented, smoke-tested, qualified, and supported claims.
 
 ### Changed
 
@@ -29,3 +30,6 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
 ### Fixed
 
 - Kept Bun's HTTP idle timeout above the SSE keepalive interval so live updates do not cycle through reconnect state.
+- Force a fresh collab relay transport after mobile foreground, BFCache restore, and online transitions so suspended sockets cannot remain silently stale.
+- Revoke the active OMP collaboration generation before session mutation and publish its replacement only after the new session or tree state is active.
+- Harden Windows config and publisher-token paths with current-user/SYSTEM-only ACLs, write Task Scheduler XML as UTF-16, and use an authenticated loopback shutdown so reinstall and uninstall cannot orphan the gateway process.

--- a/HANDOFF_MANIFEST.md
+++ b/HANDOFF_MANIFEST.md
@@ -1,6 +1,6 @@
 # Implementation handoff
 
-**Updated:** 2026-07-19
+**Updated:** 2026-07-20
 **Repository:** `omp-session-gateway`
 **Status:** implemented pre-alpha; production acceptance remains blocked
 
@@ -10,11 +10,11 @@
 - authenticated size-bounded local IPC with generation-aware in-memory storage and monotonic TTL expiry;
 - loopback HTTP, fail-closed Tailscale identity allowlisting, exact-Origin mutation checks, SSE, and no-store launch;
 - Android-sized installable PWA with metadata-only states and a shell-only service-worker cache;
-- OMP `collab-web` pinned to commit `39c95e5e29b1c8b082059f57421ce445c3dffdd4` and patched for one-time in-memory `MessageChannel` bootstrap;
-- apply-ready OMP controller/auto-start/publisher patch with lifecycle tests;
+- OMP `collab-web` pinned to commit `39c95e5e29b1c8b082059f57421ce445c3dffdd4` and patched for one-time in-memory `MessageChannel` bootstrap plus mobile foreground/online transport replacement;
+- apply-ready OMP controller/auto-start/publisher patch with pre-mutation revocation and post-mutation republish tests;
 - `serve`, `install`, `uninstall`, `status`, `doctor`, redacted `doctor --bundle`, Serve guidance, and token rotation;
 - systemd-user, LaunchAgent, and current-user Windows task definitions;
-- deterministic Bun-runtime release archive generation with SHA-256 checksums; and
+- deterministic Bun-runtime release archive and SPDX 2.3 dependency inventory generation with SHA-256 checksums; and
 - protocol, registry, IPC, HTTP, configuration, diagnostics, service, browser build, and capability-leak checks.
 
 ## Security posture
@@ -34,20 +34,25 @@ contain boolean results only. Tailscale Funnel remains unsupported.
 
 ## Validation performed
 
-- `bun run check`: handoff validation, all four workspace typechecks, production web/client build, 36 tests across eight files, and the capability-leak scan passed.
+- `bun run check`: handoff validation, all four workspace typechecks, production web/client build, 39 tests across nine files, and the capability-leak scan passed.
 - `bun audit`: no vulnerabilities found.
 - `git apply --check patches/oh-my-pi/0001-collab-controller-autostart-registry.patch` against the pinned fixture: passed.
-- OMP patch lifecycle fixtures: nine controller/publisher tests passed; all six touched OMP entry points syntax-compiled.
+- OMP patch lifecycle fixtures: 20 controller/publisher/settings/session-ordering tests passed; the full coding-agent package typecheck passed.
 - Full-checkout OMP qualification: `bun run ci:check:full` passed. Every official TypeScript test bucket passed after temporarily excluding 32 upstream-baseline-sensitive tests: two Python completion bridge cases and one Python shortcut case that return cancelled results in an untouched worktree, one UTC/local-date logger case that fails in the untouched worktree during the UTC date boundary, and the 28-test auto-compaction suite whose timing failure reproduced 4/140 times in an untouched worktree. The exclusions were restored after the run; no qualification-only changes are in the patch.
 - `bun scripts/build-release.ts` run twice: byte-identical archive checksum.
 - Extracted release smoke: repeated `install --no-start` was idempotent with two normalized allowlist entries; diagnostics bundle creation and `uninstall --no-stop` behaved as documented.
 - Chromium at 412 × 915: three synthetic sessions rendered without visual overflow; SSE remained ready across a 26-second keepalive observation; stale launch returned `409`; valid launch was `no-store`; the client scrubbed its handoff URL; Local Storage, Session Storage, IndexedDB, history state, and service-worker cache contained no capability; publisher socket close removed all cards promptly.
+- macOS 26.5.2 arm64 development-checkout qualification: live LaunchAgent install/reinstall, private permissions, atomic token rotation, doctor/bundle, Tailscale Serve allow/deny/spoof checks, loopback/LAN isolation, and uninstall passed.
+- Debian 13 arm64 systemd-container qualification: live user-service install/autostart, active PID replacement, private permissions, token rotation, and uninstall passed; this is not a bare-metal support claim.
+- Hosted Windows lifecycle qualification: GitHub Actions run `29715302992` passed config/token ACL checks, UTF-16 scheduled-task install/start, active health/status, atomic token rotation, authenticated exact-Origin graceful PID replacement, active reinstall, and process-clean uninstall.
+- Real desktop relay/browser acceptance: three patched interactive OMP processes auto-published; View was read-only, Control prompted and interrupted, `/new` advanced the live generation only after session replacement and the prior generation returned `409`; exited/crashed processes disappeared, secret-free leave navigation passed, and foreground/online events created fresh relay sockets.
+- GitHub private vulnerability reporting and immutable releases are enabled. The commit-pinned OIDC release workflow signs and attests the archive, SBOM, and checksum manifest; hosted provenance execution has not yet run.
 
 ## Remaining release blockers
 
-- qualify install, permissions, autostart, diagnostics, token rotation, upgrade, and uninstall on Linux, macOS, and Windows;
-- run real Tailscale Serve allow/deny tests, LAN/public reachability tests, and relay connectivity/soak tests;
-- run Android install, lock/resume, network-change, back-navigation, reconnect, View, Control, and interrupt acceptance;
-- configure release signing/provenance credentials before publishing an alpha artifact.
+- qualify signed candidate artifacts, upgrade/rollback, reboot/login persistence, and native Linux;
+- complete the running eight-hour default-relay soak;
+- run physical Android install, lock/resume, radio/network-change, back-navigation, reconnect, View, Control, interrupt, and leak acceptance; and
+- execute and independently verify a provenance-test release.
 
 No operating system or Android release is advertised in `docs/COMPATIBILITY.md` until those gates pass.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Secure, zero-touch mobile access to every running Oh My Pi session.**
 
-> **Project status: implemented pre-alpha, not production-qualified.** The daemon, authenticated IPC registry, PWA, pinned collaboration client, management CLI, service definitions, release builder, tests, and OMP patch are present. Real Android, Tailscale, relay, and cross-OS acceptance gates remain unqualified.
+> **Project status: implemented pre-alpha, not production-qualified.** The daemon, authenticated IPC registry, PWA, pinned collaboration client, management CLI, service definitions, release builder, tests, and OMP patch are present. Real Android, Tailscale, relay, and cross-OS acceptance gates remain unqualified. See the [release gate ledger](docs/RELEASE_STATUS.md) and [compatibility matrix](docs/COMPATIBILITY.md).
 
 OMP Session Gateway is a local-first companion for [Oh My Pi](https://github.com/can1357/oh-my-pi) (OMP). After one-time setup, it automatically discovers collaboration endpoints for every live interactive OMP process on a computer and presents them through a private, mobile-first Progressive Web App (PWA).
 

--- a/apps/gateway/src/cli.ts
+++ b/apps/gateway/src/cli.ts
@@ -14,7 +14,12 @@ import { startHttpServer } from "./http.ts";
 import { startRegistryIpcServer } from "./ipc.ts";
 import { SafeLogger } from "./logger.ts";
 import { SessionRegistry } from "./registry.ts";
-import { installUserService, uninstallUserService, userServiceStatus } from "./service.ts";
+import {
+  installUserService,
+  requestGatewayShutdown,
+  uninstallUserService,
+  userServiceStatus,
+} from "./service.ts";
 import { StaticAssetStore } from "./static.ts";
 
 interface ParsedArguments {
@@ -76,22 +81,25 @@ async function runServe(arguments_: ParsedArguments): Promise<void> {
   const logger = new SafeLogger();
   const registry = new SessionRegistry({ ttlSeconds: config.registry.ttlSeconds, maxSessions: config.registry.maxSessions });
   const ipc = await startRegistryIpcServer({ config, token, registry, logger });
-  const http = startHttpServer({ config, registry, staticAssets, logger });
+  let stopping = false;
+  let resolveStop: () => void = () => undefined;
+  const stopped = new Promise<void>(resolve => {
+    resolveStop = resolve;
+  });
+  const stop = (): void => {
+    if (stopping) return;
+    stopping = true;
+    resolveStop();
+  };
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+  const http = startHttpServer({ config, registry, staticAssets, logger, shutdown: { token, request: stop } });
   const sweeper = setInterval(() => {
     const removed = registry.sweepExpired();
     if (removed > 0) logger.event("info", "registry.expired", { removed });
   }, Math.max(1_000, Math.floor((config.registry.ttlSeconds * 1_000) / 3)));
 
-  await new Promise<void>(resolveStop => {
-    let stopping = false;
-    const stop = (): void => {
-      if (stopping) return;
-      stopping = true;
-      resolveStop();
-    };
-    process.once("SIGINT", stop);
-    process.once("SIGTERM", stop);
-  });
+  await stopped;
   clearInterval(sweeper);
   http.stop(true);
   await ipc.stop();
@@ -116,11 +124,11 @@ async function runInstall(arguments_: ParsedArguments): Promise<void> {
     allowedLogins,
     ...(port === undefined ? {} : { port }),
   });
-  await loadOrCreatePublisherToken(config);
+  const token = await loadOrCreatePublisherToken(config);
   const activate = !hasFlag(arguments_, "--no-start");
   const webRoot = resolve(fileURLToPath(new URL("../../web/dist/", import.meta.url)));
   await StaticAssetStore.load(webRoot);
-  const definition = await installUserService(config, activate);
+  const definition = await installUserService(config, token, activate);
   if (activate) await waitForGateway(config.http.port);
   console.log(`Installed ${definition.identifier}; loopback health ${activate ? "ready" : "not started"}.`);
   console.log(`Configure Tailscale Serve: tailscale serve --bg --https=443 http://127.0.0.1:${config.http.port}`);
@@ -129,7 +137,8 @@ async function runInstall(arguments_: ParsedArguments): Promise<void> {
 
 async function runUninstall(arguments_: ParsedArguments): Promise<void> {
   const config = await loadGatewayConfig();
-  await uninstallUserService(config, !hasFlag(arguments_, "--no-stop"));
+  const token = await loadOrCreatePublisherToken(config);
+  await uninstallUserService(config, token, !hasFlag(arguments_, "--no-stop"));
   console.log("Uninstalled omp-session-gateway service. Configuration and publisher token were preserved.");
 }
 
@@ -169,8 +178,18 @@ async function runDoctor(arguments_: ParsedArguments): Promise<void> {
 
 async function runRotateToken(): Promise<void> {
   const config = await loadGatewayConfig();
+  const token = await loadOrCreatePublisherToken(config);
+  const service = await userServiceStatus(config);
+  if (process.platform === "win32" && service.active) await requestGatewayShutdown(config, token);
   await rotatePublisherToken(config);
-  console.log("Publisher token rotated. Restart the gateway and live OMP publishers to reconnect.");
+  if (service.installed && service.active) {
+    const replacementToken = await loadOrCreatePublisherToken(config);
+    await installUserService(config, replacementToken);
+    await waitForGateway(config.http.port);
+    console.log("Publisher token rotated. Active gateway restarted; live OMP publishers will reconnect.");
+  } else {
+    console.log("Publisher token rotated. Restart the gateway and live OMP publishers to reconnect.");
+  }
 }
 
 async function runServeGuidance(): Promise<void> {

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -50,45 +50,77 @@ function currentUserId(): number {
   return uid;
 }
 
+function windowsPowerShellEnvironment(overrides: Record<string, string>): Record<string, string> {
+  const environment: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && key.toLowerCase() !== "psmodulepath") environment[key] = value;
+  }
+  return { ...environment, ...overrides };
+}
+
 async function applyWindowsAcl(path: string, directory: boolean): Promise<void> {
   if (process.platform !== "win32") return;
-  const username = process.env.USERNAME;
-  if (username === undefined || username.length === 0 || /[\0\r\n]/u.test(username)) {
-    throw new Error("current Windows user is unavailable");
-  }
-  const permission = directory ? "(OI)(CI)F" : "F";
-  const subprocess = Bun.spawn(
-    ["icacls.exe", path, "/inheritance:r", "/grant:r", `${username}:${permission}`, `*S-1-5-18:${permission}`],
-    { stdin: "ignore", stdout: "ignore", stderr: "pipe" },
-  );
+  const script =
+    "$Path=$env:OMP_GATEWAY_ACL_PATH; $Directory=$env:OMP_GATEWAY_ACL_DIRECTORY; " +
+    "$sid=[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value; " +
+    "$flags=if($Directory -eq '1'){'OICI'}else{''}; " +
+    "$sddl='D:P(A;'+$flags+';FA;;;SY)(A;'+$flags+';FA;;;'+$sid+')'; " +
+    "$acl=Get-Acl -LiteralPath $Path; $acl.SetSecurityDescriptorSddlForm($sddl); " +
+    "Set-Acl -LiteralPath $Path -AclObject $acl";
+  const subprocess = Bun.spawn(["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script], {
+    env: windowsPowerShellEnvironment({
+      OMP_GATEWAY_ACL_PATH: path,
+      OMP_GATEWAY_ACL_DIRECTORY: directory ? "1" : "0",
+    }),
+    stdin: "ignore",
+    stdout: "ignore",
+    stderr: "pipe",
+  });
   const stderr = await new Response(subprocess.stderr).text();
   if ((await subprocess.exited) !== 0) throw new Error(`failed to secure private Windows path: ${stderr.trim()}`);
 }
 
-async function assertWindowsAclPrivate(path: string): Promise<void> {
+async function assertWindowsAclPrivate(path: string, directory: boolean): Promise<void> {
   if (process.platform !== "win32") return;
   const script =
-    "& { param([string]$Path) $acl=Get-Acl -LiteralPath $Path; " +
+    "$Path=$env:OMP_GATEWAY_ACL_PATH; $acl=Get-Acl -LiteralPath $Path; " +
     "$sid=[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value; " +
-    "$rules=@($acl.Access | ForEach-Object { try { $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value } catch { '' } }); " +
-    "[pscustomobject]@{ Protected=$acl.AreAccessRulesProtected; Current=$sid; Rules=$rules } | ConvertTo-Json -Compress }";
-  const subprocess = Bun.spawn(
-    ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script, path],
-    { stdin: "ignore", stdout: "pipe", stderr: "ignore" },
-  );
+    "$descriptor=[System.Security.AccessControl.RawSecurityDescriptor]::new($acl.Sddl); " +
+    "$rules=@($descriptor.DiscretionaryAcl | ForEach-Object { [pscustomobject]@{ " +
+    "Sid=$_.SecurityIdentifier.Value; Type=$_.AceType.ToString(); Mask=$_.AccessMask; Flags=[int]$_.AceFlags } }); " +
+    "[pscustomobject]@{ Protected=$acl.AreAccessRulesProtected; Current=$sid; Rules=@($rules) } " +
+    "| ConvertTo-Json -Compress -Depth 3";
+  const subprocess = Bun.spawn(["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script], {
+    env: windowsPowerShellEnvironment({ OMP_GATEWAY_ACL_PATH: path }),
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "ignore",
+  });
   const text = await new Response(subprocess.stdout).text();
   if ((await subprocess.exited) !== 0) throw new Error("failed to inspect private Windows ACL");
   const value: unknown = JSON.parse(text);
   const protectedAcl = typeof value === "object" && value !== null ? Reflect.get(value, "Protected") : undefined;
   const current = typeof value === "object" && value !== null ? Reflect.get(value, "Current") : undefined;
   const rules = typeof value === "object" && value !== null ? Reflect.get(value, "Rules") : undefined;
+  const expectedSids = new Set([current, "S-1-5-18"]);
+  const expectedFlags = directory ? 3 : 0;
   if (
     protectedAcl !== true ||
     typeof current !== "string" ||
     !Array.isArray(rules) ||
-    !rules.includes(current) ||
-    !rules.includes("S-1-5-18") ||
-    rules.some(rule => rule !== current && rule !== "S-1-5-18")
+    rules.length !== 2 ||
+    rules.some(rule => {
+      if (typeof rule !== "object" || rule === null) return true;
+      const sid = Reflect.get(rule, "Sid");
+      return (
+        typeof sid !== "string" ||
+        !expectedSids.delete(sid) ||
+        Reflect.get(rule, "Type") !== "AccessAllowed" ||
+        Reflect.get(rule, "Mask") !== 2_032_127 ||
+        Reflect.get(rule, "Flags") !== expectedFlags
+      );
+    }) ||
+    expectedSids.size !== 0
   ) {
     throw new Error("unsafe private Windows ACL");
   }
@@ -135,7 +167,7 @@ async function assertPrivateDirectory(path: string, create: boolean): Promise<vo
   if (!info.isDirectory() || info.isSymbolicLink()) throw new Error(`unsafe private directory: ${path}`);
   if (process.platform === "win32") {
     if (create) await applyWindowsAcl(path, true);
-    await assertWindowsAclPrivate(path);
+    await assertWindowsAclPrivate(path, true);
     return;
   }
   if (info.uid !== currentUserId() || (info.mode & 0o077) !== 0) {
@@ -147,7 +179,7 @@ async function assertPrivateRegularFile(path: string): Promise<void> {
   const info = await lstat(path);
   if (!info.isFile() || info.isSymbolicLink()) throw new Error(`unsafe private file: ${path}`);
   if (process.platform === "win32") {
-    await assertWindowsAclPrivate(path);
+    await assertWindowsAclPrivate(path, false);
     return;
   }
   if (info.uid !== currentUserId() || (info.mode & 0o077) !== 0) {

--- a/apps/gateway/src/http.ts
+++ b/apps/gateway/src/http.ts
@@ -5,8 +5,8 @@ import {
   parseJsonFrame,
   parseLaunchRequest,
 } from "@omp-session-gateway/protocol";
-import { authorizeHttpRequest, requestHasValidMutationContext, type RequestPeer } from "./auth.ts";
-import type { GatewayConfig } from "./config.ts";
+import { authorizeHttpRequest, isLoopbackAddress, requestHasValidMutationContext, type RequestPeer } from "./auth.ts";
+import { publisherTokenMatches, type GatewayConfig } from "./config.ts";
 import { SafeLogger } from "./logger.ts";
 import { SessionRegistry } from "./registry.ts";
 import { StaticAssetStore } from "./static.ts";
@@ -150,11 +150,17 @@ function eventStream(registry: SessionRegistry): Response {
   );
 }
 
+interface ShutdownControl {
+  readonly token: string;
+  readonly request: () => void;
+}
+
 export function createHttpHandler(options: {
   readonly config: GatewayConfig;
   readonly registry: SessionRegistry;
   readonly staticAssets: StaticAssetStore;
   readonly logger?: SafeLogger;
+  readonly shutdown?: ShutdownControl;
 }): (request: Request, peer?: RequestPeer) => Promise<Response> {
   const { config, registry, staticAssets } = options;
   const logger = options.logger ?? new SafeLogger();
@@ -166,6 +172,25 @@ export function createHttpHandler(options: {
       url = new URL(request.url);
     } catch {
       return problem(400, "bad_request", "Invalid request");
+    }
+
+    if (url.pathname === "/_internal/v1/shutdown" && request.method === "POST" && options.shutdown !== undefined) {
+      const authorization = request.headers.get("Authorization");
+      const candidate = authorization?.startsWith("Bearer ") ? authorization.slice(7) : "";
+      const contentLength = request.headers.get("Content-Length");
+      if (
+        peer === undefined ||
+        !isLoopbackAddress(peer.address) ||
+        url.search !== "" ||
+        (contentLength !== null && contentLength !== "0") ||
+        !requestHasValidMutationContext(request, config.http.publicOrigin) ||
+        request.body !== null ||
+        !publisherTokenMatches(options.shutdown.token, candidate)
+      ) {
+        return problem(403, "forbidden", "Forbidden");
+      }
+      setTimeout(options.shutdown.request, 50);
+      return withSecurityHeaders(Response.json({ status: "stopping" }, { status: 202 }), true);
     }
 
     if (url.pathname === "/api/v1/health" && request.method === "GET") {
@@ -234,6 +259,7 @@ export function startHttpServer(options: {
   readonly registry: SessionRegistry;
   readonly staticAssets: StaticAssetStore;
   readonly logger?: SafeLogger;
+  readonly shutdown?: ShutdownControl;
 }): Bun.Server<undefined> {
   const handler = createHttpHandler(options);
   const server = Bun.serve({

--- a/apps/gateway/src/service.ts
+++ b/apps/gateway/src/service.ts
@@ -46,11 +46,16 @@ export function serviceDefinition(config: GatewayConfig, platform = process.plat
     };
   }
   if (platform === "win32") {
-    const command = argv.map(value => `&quot;${xmlEscape(value)}&quot;`).join(" ");
+    const executable = argv[0];
+    if (executable === undefined) throw new Error("service executable is unavailable");
+    const argumentsXml = argv
+      .slice(1)
+      .map(value => `&quot;${xmlEscape(value)}&quot;`)
+      .join(" ");
     return {
       identifier: "omp-session-gateway",
       path: join(config.paths.configDir, "omp-session-gateway-task.xml"),
-      content: `<?xml version="1.0" encoding="UTF-8"?>\n<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">\n  <Triggers><LogonTrigger><Enabled>true</Enabled></LogonTrigger></Triggers>\n  <Principals><Principal id="Author"><LogonType>InteractiveToken</LogonType><RunLevel>LeastPrivilege</RunLevel></Principal></Principals>\n  <Settings><MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy><ExecutionTimeLimit>PT0S</ExecutionTimeLimit></Settings>\n  <Actions Context="Author"><Exec><Command>cmd.exe</Command><Arguments>/d /s /c &quot;${command}&quot;</Arguments></Exec></Actions>\n</Task>\n`,
+      content: `<?xml version="1.0" encoding="UTF-16"?>\n<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">\n  <Triggers><LogonTrigger><Enabled>true</Enabled></LogonTrigger></Triggers>\n  <Principals><Principal id="Author"><LogonType>InteractiveToken</LogonType><RunLevel>LeastPrivilege</RunLevel></Principal></Principals>\n  <Settings><MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy><AllowHardTerminate>true</AllowHardTerminate><ExecutionTimeLimit>PT0S</ExecutionTimeLimit></Settings>\n  <Actions Context="Author"><Exec><Command>${xmlEscape(executable)}</Command><Arguments>${argumentsXml}</Arguments></Exec></Actions>\n</Task>\n`,
     };
   }
   throw new Error(`unsupported platform: ${platform}`);
@@ -71,6 +76,39 @@ async function commandSucceeds(command: readonly string[]): Promise<boolean> {
     return false;
   }
 }
+export async function requestGatewayShutdown(config: GatewayConfig, token: string): Promise<boolean> {
+  let response: Response;
+  try {
+    response = await fetch(`http://127.0.0.1:${config.http.port}/_internal/v1/shutdown`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Origin: config.http.publicOrigin,
+        "Sec-Fetch-Site": "same-origin",
+      },
+      signal: AbortSignal.timeout(2_000),
+    });
+  } catch {
+    return false;
+  }
+  if (response.status !== 202) throw new Error("running gateway rejected authenticated shutdown");
+  await response.arrayBuffer();
+  const deadline = Date.now() + 7_500;
+  while (Date.now() < deadline) {
+    try {
+      const health = await fetch(`http://127.0.0.1:${config.http.port}/api/v1/health`, {
+        redirect: "error",
+        signal: AbortSignal.timeout(500),
+      });
+      await health.arrayBuffer();
+    } catch {
+      return true;
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error("running gateway did not stop");
+}
+
 
 async function bootstrapLaunchAgent(domain: string, path: string): Promise<void> {
   let lastError: unknown;
@@ -121,10 +159,18 @@ export async function userServiceStatus(config: GatewayConfig): Promise<UserServ
   return { installed, active };
 }
 
-export async function installUserService(config: GatewayConfig, activate = true): Promise<ServiceDefinition> {
+export async function installUserService(
+  config: GatewayConfig,
+  token: string,
+  activate = true,
+): Promise<ServiceDefinition> {
   const definition = serviceDefinition(config);
   await mkdir(dirname(definition.path), { recursive: true, mode: 0o700 });
-  await writeFile(definition.path, definition.content, { encoding: "utf8", mode: 0o600 });
+  const serialized =
+    process.platform === "win32"
+      ? Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(definition.content, "utf16le")])
+      : definition.content;
+  await writeFile(definition.path, serialized, { mode: 0o600 });
   if (process.platform !== "win32") await chmod(definition.path, 0o600);
   if (!activate) return definition;
   if (process.platform === "linux") {
@@ -138,6 +184,7 @@ export async function installUserService(config: GatewayConfig, activate = true)
     await bootstrapLaunchAgent(`gui/${process.getuid?.() ?? 0}`, definition.path);
   } else {
     if (await commandSucceeds(["schtasks.exe", "/Query", "/TN", "OMP Session Gateway"])) {
+      await requestGatewayShutdown(config, token);
       await commandSucceeds(["schtasks.exe", "/End", "/TN", "OMP Session Gateway"]);
     }
     await run(["schtasks.exe", "/Create", "/TN", "OMP Session Gateway", "/XML", definition.path, "/F"]);
@@ -146,7 +193,7 @@ export async function installUserService(config: GatewayConfig, activate = true)
   return definition;
 }
 
-export async function uninstallUserService(config: GatewayConfig, deactivate = true): Promise<void> {
+export async function uninstallUserService(config: GatewayConfig, token: string, deactivate = true): Promise<void> {
   const definition = serviceDefinition(config);
   const status = await userServiceStatus(config);
   if (deactivate) {
@@ -159,6 +206,7 @@ export async function uninstallUserService(config: GatewayConfig, deactivate = t
         await run(["launchctl", "bootout", `gui/${process.getuid?.() ?? 0}/omp-session-gateway`]);
       }
     } else if (status.installed) {
+      if (status.active) await requestGatewayShutdown(config, token);
       await run(["schtasks.exe", "/Delete", "/TN", "OMP Session Gateway", "/F"]);
     }
   }

--- a/apps/gateway/test/config.test.ts
+++ b/apps/gateway/test/config.test.ts
@@ -39,6 +39,43 @@ function configForRoot(root: string): GatewayConfig {
   };
 }
 
+function windowsPowerShellEnvironment(overrides: Record<string, string>): Record<string, string> {
+  const environment: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && key.toLowerCase() !== "psmodulepath") environment[key] = value;
+  }
+  return { ...environment, ...overrides };
+}
+
+async function secureWindowsFixture(path: string): Promise<void> {
+  if (process.platform !== "win32") return;
+  const script =
+    "$Path=$env:OMP_GATEWAY_ACL_PATH; " +
+    "$sid=[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value; " +
+    "$sddl='D:P(A;;FA;;;SY)(A;;FA;;;'+$sid+')'; " +
+    "$acl=Get-Acl -LiteralPath $Path; $acl.SetSecurityDescriptorSddlForm($sddl); " +
+    "Set-Acl -LiteralPath $Path -AclObject $acl";
+  const subprocess = Bun.spawn(["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script], {
+    env: windowsPowerShellEnvironment({ OMP_GATEWAY_ACL_PATH: path }),
+    stdin: "ignore",
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const stderr = await new Response(subprocess.stderr).text();
+  if ((await subprocess.exited) !== 0) throw new Error(`failed to secure test fixture: ${stderr.trim()}`);
+}
+
+async function makeWindowsFixtureUnsafe(path: string): Promise<void> {
+  if (process.platform !== "win32") return;
+  const subprocess = Bun.spawn(["icacls.exe", path, "/grant", "*S-1-1-0:F"], {
+    stdin: "ignore",
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const stderr = await new Response(subprocess.stderr).text();
+  if ((await subprocess.exited) !== 0) throw new Error(`failed to loosen test fixture ACL: ${stderr.trim()}`);
+}
+
 describe("secure config", () => {
   test("loads strict production config and normalizes exact allowlist logins", async () => {
     const root = await privateRoot();
@@ -52,6 +89,7 @@ describe("secure config", () => {
       }),
       { mode: 0o600 },
     );
+    await secureWindowsFixture(path);
     const loaded = await loadGatewayConfig({ configPath: path });
     expect(loaded.auth.allowedLogins).toEqual(["user@example.com"]);
     expect(loaded.http.hostname).toBe("127.0.0.1");
@@ -68,6 +106,7 @@ describe("secure config", () => {
       }),
       { mode: 0o600 },
     );
+    await secureWindowsFixture(path);
     await expect(loadGatewayConfig({ configPath: path })).rejects.toThrow("HTTPS");
     await writeFile(
       path,
@@ -77,6 +116,7 @@ describe("secure config", () => {
       }),
       { mode: 0o600 },
     );
+    await secureWindowsFixture(path);
     await expect(
       loadGatewayConfig({ configPath: path, publicOrigin: "http://gateway.example.ts.net" }),
     ).rejects.toThrow("HTTPS");
@@ -86,6 +126,7 @@ describe("secure config", () => {
     const root = await privateRoot();
     const path = join(root, "config.json");
     await writeFile(path, "{}", { mode: 0o644 });
+    await makeWindowsFixtureUnsafe(path);
     await expect(loadGatewayConfig({ configPath: path, mode: "dev-localhost" })).rejects.toThrow("unsafe");
     await rm(path);
     const target = join(root, "target.json");
@@ -100,7 +141,8 @@ describe("secure config", () => {
     const first = await loadOrCreatePublisherToken(config);
     const file = await lstat(config.paths.tokenPath);
     expect(first).toMatch(/^[A-Za-z0-9_-]{43}$/u);
-    expect(file.mode & 0o077).toBe(0);
+    expect(file.isFile()).toBeTrue();
+    if (process.platform !== "win32") expect(file.mode & 0o077).toBe(0);
     expect(await loadOrCreatePublisherToken(config)).toBe(first);
     await rotatePublisherToken(config);
     const second = await loadOrCreatePublisherToken(config);
@@ -108,13 +150,14 @@ describe("secure config", () => {
     expect(publisherTokenMatches(second, second)).toBeTrue();
     expect(publisherTokenMatches(second, `${second}x`)).toBeFalse();
     expect(publisherTokenMatches(second, first)).toBeFalse();
-  });
+  }, 20_000);
 
   test("rejects unsafe token permissions", async () => {
     const root = await privateRoot();
     const config = configForRoot(root);
     await mkdir(config.paths.configDir, { recursive: true, mode: 0o700 });
     await writeFile(config.paths.tokenPath, `${"A".repeat(43)}\n`, { mode: 0o644 });
+    await makeWindowsFixtureUnsafe(config.paths.tokenPath);
     await expect(loadOrCreatePublisherToken(config)).rejects.toThrow("unsafe");
   });
 });

--- a/apps/gateway/test/http.test.ts
+++ b/apps/gateway/test/http.test.ts
@@ -87,6 +87,45 @@ describe("HTTP boundary", () => {
     expect((await handler(request("/api/v1/sessions", {}, ""), peer)).status).toBe(200);
   });
 
+  test("accepts shutdown only from loopback with the publisher token", async () => {
+    const token = "S".repeat(43);
+    let requests = 0;
+    const handler = createHttpHandler({
+      config: config(),
+      registry: populatedRegistry(),
+      staticAssets: assets,
+      shutdown: { token, request: () => requests++ },
+    });
+    const shutdownRequest = (supplied: string): Request =>
+      request("/_internal/v1/shutdown", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${supplied}`,
+          Origin: origin,
+          "Sec-Fetch-Site": "same-origin",
+        },
+      });
+    expect((await handler(shutdownRequest("X".repeat(43)), peer)).status).toBe(403);
+    expect(
+      (
+        await handler(
+          request("/_internal/v1/shutdown", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${token}`, Origin: "https://evil.example" },
+          }),
+          peer,
+        )
+      ).status,
+    ).toBe(403);
+    expect((await handler(shutdownRequest(token), { address: "10.0.0.8" })).status).toBe(403);
+    expect(requests).toBe(0);
+    const response = await handler(shutdownRequest(token), peer);
+    expect(response.status).toBe(202);
+    expect(response.headers.get("Cache-Control")).toContain("no-store");
+    await Bun.sleep(60);
+    expect(requests).toBe(1);
+  });
+
   test("returns metadata-only no-store list and SSE", async () => {
     const handler = createHttpHandler({ config: config(), registry: populatedRegistry(), staticAssets: assets });
     const list = await handler(request("/api/v1/sessions"), peer);

--- a/apps/gateway/test/service.test.ts
+++ b/apps/gateway/test/service.test.ts
@@ -37,9 +37,11 @@ describe("service packaging", () => {
   test("generates least-privilege Windows logon task", () => {
     const definition = serviceDefinition(config, "win32");
     expect(definition.path).toEndWith("omp-session-gateway-task.xml");
-    expect(definition.content).toStartWith('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(definition.content).toStartWith('<?xml version="1.0" encoding="UTF-16"?>');
     expect(definition.content).toContain("<LogonType>InteractiveToken</LogonType>");
     expect(definition.content).toContain("<RunLevel>LeastPrivilege</RunLevel>");
+    expect(definition.content).toContain("<AllowHardTerminate>true</AllowHardTerminate>");
     expect(definition.content).not.toContain("HighestAvailable");
+    expect(definition.content).not.toContain("cmd.exe");
   });
 });

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,84 +1,127 @@
-# Compatibility policy
+# Compatibility and support policy
 
-## Research baseline
+## Current claim
 
-This handoff was refreshed on **2026-07-19** against the public OMP **v17.0.5** release and current documentation available that day.
+**No operating system, browser, or Android device is currently advertised as supported.**
+The repository version is `0.1.0`, but it is unreleased and classified as an implemented
+**pre-alpha**, not an alpha or production-qualified release. A locally built archive is an
+engineering artifact, not a supported distribution.
 
-Relevant observed interfaces include:
+The exact release decision and outstanding acceptance gates are tracked in
+[`RELEASE_STATUS.md`](RELEASE_STATUS.md). This document defines what the project is compatible
+with and how a compatibility claim becomes supportable.
 
-- `docs/collab.md` for link roles, encryption, web client behavior, and settings;
-- `packages/coding-agent/src/collab/host.ts` for `CollabHost` ownership and link getters;
-- `packages/coding-agent/src/modes/types.ts` for the interactive context's `collabHost` field;
-- `docs/extensions.md` for lifecycle events and managed extension timers; and
-- `packages/collab-web` for the browser client.
+## Status vocabulary
 
-`UPSTREAM.lock.json` intentionally has a null commit because this design artifact did not clone and pin a source checkout. The first implementation change must replace that with an exact 40-character commit SHA.
+Compatibility statements use these terms deliberately:
 
-## Compatibility contract
+| Term | Meaning |
+|---|---|
+| **Implemented** | The relevant code path exists and has repository-level automated coverage. |
+| **Smoke-tested** | A named scenario passed in one recorded environment. This is not a platform support claim. |
+| **Qualified** | The complete applicable release matrix passed on the named version, OS, browser, and deployment path. |
+| **Supported** | A published release advertises that qualified combination and accepts bug reports against it. |
+| **Deferred** | Intentionally outside the current release target. |
+| **Unsupported** | Must not be presented as a working deployment path. |
 
-The gateway should version three independently changing surfaces:
+An implemented or smoke-tested row remains unqualified until every applicable security,
+installation, lifecycle, and cleanup scenario passes. Blank version ranges never imply support.
 
-1. **Registry protocol** between OMP publishers and the gateway.
-2. **Gateway HTTP API** between the PWA and daemon.
-3. **OMP integration compatibility** between the patch/package and upstream OMP internals.
+## Exact OMP baseline
 
-The first two must have explicit protocol versions and runtime validation. The third should be represented by a tested compatibility matrix, not by a claim that private OMP internals are indefinitely stable.
+The pre-alpha targets one immutable upstream source revision:
 
-## Supported OMP range
+| Gateway line | OMP source | Nearest release baseline | OMP package baselines | Collab client | Registry protocol | Claim |
+|---|---|---|---|---|---:|---|
+| `0.1.0` (unreleased) | `can1357/oh-my-pi@39c95e5e29b1c8b082059f57421ce445c3dffdd4` | `v17.0.5` | coding-agent `17.0.5`; wire `17.0.5` | collab-web `16.3.6` from the same source commit | 1 | Exact-commit pre-alpha qualification only |
 
-For pre-alpha development, support exactly one pinned OMP commit. Broaden support only after CI proves multiple versions.
+`v17.0.5` is the nearest release and package baseline recorded on **2026-07-19**. It is
+not a claim that every checkout or package combination labeled `v17.0.5` is compatible.
+No earlier or later OMP release, commit, fork, or loose semver range is supported.
 
-A future release matrix should look like:
+The immutable source paths, versions, observation date, and upstream findings live in
+[`UPSTREAM.lock.json`](../UPSTREAM.lock.json). The gateway integration currently requires:
 
-| Gateway version | OMP versions/commits | Registry protocol | Status |
-|---|---|---:|---|
-| `0.1.x` | exact pinned commit(s) | 1 | experimental |
-| `0.2.x` | tested release range | 1 | alpha |
+- the apply-ready OMP controller/auto-start/registry patch in
+  [`patches/oh-my-pi`](../patches/oh-my-pi/README.md);
+- the pinned collab-web source integration described by
+  [`packages/collab-client/upstream/UPSTREAM.json`](../packages/collab-client/upstream/UPSTREAM.json);
+- the reviewed in-memory client bootstrap, because unchanged upstream collab-web writes a
+  capability to `location.hash`; and
+- Bun `1.3.14` for the recorded build and test baseline. The runtime archive declares
+  Bun `>=1.3.14`, but versions newer than the pinned baseline are not release-qualified yet.
 
-Do not use loose peer ranges without integration tests.
+## Versioned interfaces
+
+Three compatibility surfaces change independently:
+
+| Surface | Current version | Current behavior |
+|---|---:|---|
+| OMP publisher to gateway registry | 1 | Strict runtime validation; unknown major versions are rejected. |
+| PWA to gateway HTTP API | `/api/v1` | One emitted API major; list/SSE remain metadata-only and launch remains generation-bound. |
+| Gateway patch to OMP internals | Exact commit above | Tested as a patch against the pinned checkout; no private-internals compatibility range is inferred. |
+
+Package version compatibility does not override a protocol major or exact OMP source pin.
+Rolling compatibility with an earlier publisher protocol may be added only after explicit
+cross-version tests exist.
+
+## Host and client matrix
+
+The following describes code and evidence, not advertised support:
+
+| Platform | Implemented path | Recorded evidence | Qualification | Support claim |
+|---|---|---|---|---|
+| Linux host | Unix-domain socket; systemd user service | Debian 13 arm64 container with a real user manager passed live install, autostart, active reinstall/PID replacement, private permissions, token rotation, and uninstall | Container evidence is not bare-metal qualification; rollback and non-systemd paths remain unrun | None |
+| macOS host | User-only Unix-domain socket; LaunchAgent | macOS 26.5.2 arm64 passed live install, restart/reinstall, private permissions, atomic token rotation, doctor/bundle, Tailscale Serve checks, and uninstall from a development checkout | Signed artifact rollback, reboot/login persistence, and a release-candidate run remain unqualified | None |
+| Windows host | Current-user named pipe; current-user scheduled task | GitHub Actions `windows-latest` run `29715302992` passed strict config/token ACL checks, UTF-16 task installation, active health, atomic token rotation, authenticated exact-Origin graceful PID replacement, active reinstall, and process-clean uninstall | Hosted development-checkout evidence is not signed-artifact qualification; reboot/login persistence, upgrade/rollback, and a release-candidate run remain unqualified | None |
+| Android client | Installable HTTPS PWA through Tailscale Serve | Chrome 150 headless emulation at `412 × 915` with touch/Android UA rendered three real auto-published OMP sessions; View, Control, interrupt, leave navigation, and lifecycle-triggered transport replacement passed | No physical Android installation, OS lock/resume, radio/network transition, browser-history, or persistence qualification exists | None |
+| Desktop Chromium | Development/smoke client | Real Tailscale Serve allow/deny, three real OMP cards, View/Control/interrupt, SSE, URL scrub, browser-store/cache checks, process removal, foreground/online reconnect, and live `/new` generation revocation (`409` for the stale generation) passed | Not a release target and not a substitute for physical Android qualification | Smoke only |
+
+No other Linux init system, macOS deployment mode, Windows service mechanism, iOS browser,
+Firefox, Safari, or Chromium derivative has a compatibility claim.
+
+## Deployment dependency matrix
+
+| Dependency or mode | Current state | Compatibility statement |
+|---|---|---|
+| Tailscale Serve over tailnet HTTPS | Required production architecture; live on macOS 26.5.2 with Tailscale 1.98.8 | Allowed identity succeeded; denied identity, missing identity, and a spoofed direct-backend header were rejected; direct LAN and Tailscale-IP port access failed and Funnel remained disabled. This qualifies only the recorded host run. |
+| User-owned Tailscale source identity | Designed identity-header mode | The exact `alphastorm@github` login was observed through Serve and allowlisted for qualification; no broader identity/device support is claimed. |
+| Tagged Tailscale source device | Unsupported | Serve user identity headers do not provide the required user identity for this source type. |
+| Existing OMP encrypted relay | Required v1 relay path | Real desktop View/Control/interrupt passed; physical Android and the eight-hour soak remain release-blocking. Availability and traffic metadata are inherited dependencies. |
+| Self-hosted or proxied relay | Unsupported/deferred | Must pass the dedicated long-lived WebSocket soak before it can be documented as supported. |
+| `dev-localhost` HTTP mode | Development only | Never a remote, LAN, or production deployment path. |
+| Tailscale Funnel or public reverse tunnel | Unsupported | Must not be enabled or documented as a normal deployment path. |
+
+WebAuthn control gating, a Trusted Web Activity, native Android applications, push
+notifications, and multi-host federation are deferred and carry no compatibility promise.
 
 ## Upstream refresh procedure
 
-For each OMP update:
+For every proposed OMP update:
 
-1. Fetch the new release/tag and inspect collaboration-related changes.
-2. Update `UPSTREAM.lock.json` with exact tag, commit, package version, Bun version, and relevant paths.
-3. Rebase or regenerate the OMP patch series.
-4. Run unit tests for the controller and publisher.
-5. Run full host/browser integration tests for view and control.
-6. Verify link parsing and collab-web behavior.
-7. Run lifecycle tests for start, stop, switch, branch, resume/tree navigation, relay reconnect, and shutdown.
-8. Run the capability-leak suite.
-9. Update the matrix and changelog.
+1. Inspect the new release/tag and collaboration-related source changes.
+2. Update `UPSTREAM.lock.json` with the exact tag, commit, package versions, Bun version,
+   relevant paths, findings, and observation date.
+3. Rebase or regenerate the OMP patch series without unrelated changes.
+4. Rebuild the pinned collab-web integration and verify its provenance and license notices.
+5. Run controller, publisher, protocol, link parsing, View, and Control tests.
+6. Run start, stop, switch, branch, resume/tree-navigation, relay-replacement, fatal-failure,
+   and shutdown lifecycle tests.
+7. Run the complete capability-leak suite and real browser/Android acceptance.
+8. Qualify every advertised host installer and deployment path.
+9. Update this matrix, [`RELEASE_STATUS.md`](RELEASE_STATUS.md), and the changelog.
+
+Do not broaden the OMP range from one exact commit until CI and acceptance results prove
+each additional version independently.
 
 ## Protocol evolution
 
 - Reject unknown major protocol versions.
-- Add optional fields compatibly within a major version only when old peers safely ignore them.
-- Do not silently reinterpret a field's security meaning.
-- Support a short rolling-upgrade overlap where practical: current gateway accepts current and immediately previous publisher protocol, while emitting one browser API version.
-- Include protocol version in diagnostics, never capability values.
+- Add optional fields within a major only when old peers safely ignore them.
+- Never reinterpret a field's security meaning in place.
+- Emit one browser API major at a time.
+- Record protocol versions in diagnostics without capability values.
+- Document upgrade order and rollback behavior before supporting mixed gateway/publisher versions.
 
-## Pinned collab-web
-
-Every gateway release must identify the exact OMP source commit used to build `collab-web`. Prefer reproducible source builds in CI. If static output is vendored, include:
-
-- source repository and commit;
-- build command and Bun/Node version;
-- dependency lockfile hash;
-- license notices;
-- local patch list, especially the in-memory bootstrap and any temporary fragment fallback; and
-- content hashes for shipped assets.
-
-## Platform support
-
-Advertise an OS only after its installation, permissions, autostart, token rotation, diagnostics, upgrade, and uninstall flows pass CI or documented manual release qualification.
-
-Initial target matrix:
-
-| Platform | Local IPC | Autostart target | Status |
-|---|---|---|---|
-| Linux | Unix-domain socket under `$XDG_RUNTIME_DIR` | systemd user service | planned |
-| macOS | Unix-domain socket in a user-only runtime directory | LaunchAgent | planned |
-| Windows | current-user named pipe | scheduled task or user service | planned |
-| Android | HTTPS PWA through Tailscale | browser installation | planned |
+Every published release must identify the exact OMP and collab-web source, build command,
+Bun version, dependency lockfile hash, local patches, license notices, and shipped asset hashes.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -39,16 +39,18 @@ from `main`.
 `.github/workflows/release.yml` runs `bun run check`, builds the deterministic archive,
 checks its SHA-256 digest, and then uses GitHub Actions OIDC for both provenance systems:
 
-- `actions/attest-build-provenance` publishes GitHub build attestations for the archive
-  and `SHA256SUMS`;
-- Cosign signs both files keylessly and writes a Sigstore bundle beside each one; and
+- `actions/attest-build-provenance` publishes GitHub build attestations for the archive,
+  deterministic SPDX 2.3 SBOM, and `SHA256SUMS`;
+- Cosign signs all three files keylessly and writes a Sigstore bundle beside each one; and
 - no repository signing key or long-lived signing secret exists.
 
 The workflow creates a draft, uploads the complete asset set, and publishes exactly once:
 
 - `omp-session-gateway-<version>-bun.tar`;
+- `omp-session-gateway-<version>.spdx.json`;
 - `SHA256SUMS`;
-- `omp-session-gateway-<version>-bun.tar.sigstore.json`; and
+- `omp-session-gateway-<version>-bun.tar.sigstore.json`;
+- `omp-session-gateway-<version>.spdx.json.sigstore.json`; and
 - `SHA256SUMS.sigstore.json`.
 
 The repository's **Settings → General → Features → Immutable releases** setting is
@@ -64,9 +66,9 @@ signed release attestation. Treat the release as final at publication; publish a
 to correct it.
 
 Run `bun run check` and `bun run release:build` for a local unsigned build. The builder
-emits `dist/release/omp-session-gateway-0.1.0-bun.tar` plus `SHA256SUMS`; it contains no
-source maps. This runtime-neutral Bun archive is not a substitute for qualified platform
-installers.
+emits `dist/release/omp-session-gateway-0.1.0-bun.tar`, a deterministic SPDX 2.3 dependency
+inventory, and `SHA256SUMS`; the archive also contains `SBOM.spdx.json` and no source maps.
+This runtime-neutral Bun archive is not a substitute for qualified platform installers.
 
 Do not upload source maps, logs, test recordings, or diagnostics that might contain
 fixture capabilities unless the leak scanner has verified them.
@@ -80,6 +82,7 @@ directory:
 REPO=alphastorm/omp-session-gateway
 TAG=provenance-test-v0.1.0.5
 ARCHIVE=omp-session-gateway-0.1.0-bun.tar
+SBOM=omp-session-gateway-0.1.0.spdx.json
 
 mkdir release-verification
 gh release download "$TAG" --repo "$REPO" --dir release-verification
@@ -93,8 +96,10 @@ release is not immutable or the downloaded asset is not part of the attested rel
 gh release verify "$TAG" --repo "$REPO"
 for asset in \
   "$ARCHIVE" \
+  "$SBOM" \
   SHA256SUMS \
   "$ARCHIVE.sigstore.json" \
+  "$SBOM.sigstore.json" \
   SHA256SUMS.sigstore.json
 do
   gh release verify-asset "$TAG" "$asset" --repo "$REPO"
@@ -110,7 +115,7 @@ sha256sum --check SHA256SUMS
 Verify GitHub build provenance against the exact repository, workflow, and tag ref:
 
 ```sh
-for artifact in "$ARCHIVE" SHA256SUMS
+for artifact in "$ARCHIVE" "$SBOM" SHA256SUMS
 do
   gh attestation verify "$artifact" \
     --repo "$REPO" \
@@ -124,7 +129,7 @@ workflow-ref certificate identity:
 
 ```sh
 CERTIFICATE_IDENTITY="https://github.com/$REPO/.github/workflows/release.yml@refs/tags/$TAG"
-for artifact in "$ARCHIVE" SHA256SUMS
+for artifact in "$ARCHIVE" "$SBOM" SHA256SUMS
 do
   cosign verify-blob \
     --bundle "$artifact.sigstore.json" \

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -1,0 +1,124 @@
+# Release status
+
+**Updated:** 2026-07-20  
+**Repository version:** `0.1.0` (unreleased)  
+**Classification:** implemented pre-alpha  
+**Alpha decision:** **NO-GO**  
+**Advertised host/client platforms:** none
+
+The repository implements the intended v1 path and can build a deterministic Bun-runtime
+archive. It is not production-qualified, no alpha artifact is approved for publication, and no
+operating system, browser, or Android device is currently supported. Repository commits and
+locally built archives are engineering inputs for qualification only.
+
+This ledger is the source of truth for the current release decision. Compatibility claims live
+in [`COMPATIBILITY.md`](COMPATIBILITY.md); required scenarios are defined in
+[`TEST_PLAN.md`](TEST_PLAN.md); the detailed implementation evidence is recorded in
+[`../HANDOFF_MANIFEST.md`](../HANDOFF_MANIFEST.md).
+
+## Status rules
+
+| Status | Meaning |
+|---|---|
+| **PASS** | The named scope has current, reproducible evidence. It says nothing about a broader scope. |
+| **PARTIAL** | Some automated or smoke evidence exists, but the complete release scenario has not passed. |
+| **NOT RUN** | No completed result is recorded for the required environment or scenario. |
+| **BLOCKED** | A known prerequisite prevents completion or publication. |
+| **N/A** | Deliberately excluded from this release and not advertised. |
+
+An alpha requires every applicable release-blocking row below to be **PASS**. Automated tests,
+mocks, a desktop mobile viewport, or generated service definitions do not substitute for native
+OS, real Tailscale, real relay, or Android qualification.
+
+## Recorded implementation evidence
+
+These checks establish the implemented pre-alpha baseline; they do not resolve the acceptance
+gaps in the next section.
+
+| Scope | Status | Recorded evidence |
+|---|---|---|
+| Exact upstream pin | **PASS** | `UPSTREAM.lock.json` pins `can1357/oh-my-pi@39c95e5e29b1c8b082059f57421ce445c3dffdd4`, nearest release `v17.0.5`, with package and Bun versions. |
+| Repository check | **PASS** | `bun run check` passed handoff validation, four workspace typechecks, production web/client builds, 39 tests across nine files, and capability-leak scanning. |
+| Dependency audit | **PASS** | `bun audit` reported no vulnerabilities for the recorded lockfile. |
+| OMP patch application and lifecycle fixtures | **PASS** | Patch apply-check passed; 20 controller/publisher/settings/session-ordering tests and the full coding-agent package typecheck passed. |
+| Full pinned OMP checkout | **PASS** | `bun run ci:check:full` passed after temporary exclusion of upstream-baseline failures reproduced in an untouched checkout; exclusions were restored and are not part of the patch. |
+| Deterministic runtime archive | **PASS** | Two local `bun scripts/build-release.ts` runs produced byte-identical archives and a SHA-256 manifest. |
+| Extracted archive command smoke | **PASS** | Repeated `install --no-start`, redacted diagnostics bundle creation, and `uninstall --no-stop` behaved as documented in the recorded environment. |
+| Desktop mobile-viewport browser smoke | **PASS** | Chromium at `412 × 915` rendered three synthetic sessions; SSE, generation conflict, no-store launch, URL scrub, storage/cache checks, and prompt socket-close removal passed. |
+| macOS/Tailscale development-checkout qualification | **PASS** | macOS 26.5.2 arm64 completed live LaunchAgent install/reinstall, permissions, token rotation, diagnostics bundle, real Serve identity allow/deny/spoof checks, loopback/LAN isolation, and uninstall. |
+| Linux container lifecycle qualification | **PASS** | Debian 13 arm64 with a real systemd user manager completed install, autostart, active PID replacement, permissions, token rotation, and uninstall; this is explicitly not bare-metal qualification. |
+| Windows hosted lifecycle qualification | **PASS** | GitHub Actions run `29715302992` completed strict ACL tests, UTF-16 scheduled-task install/start, health/status, token rotation, authenticated exact-Origin graceful restart with PID replacement, active reinstall, and process-clean uninstall. |
+| Real desktop OMP/browser acceptance | **PASS** | Three patched interactive OMP processes auto-published without `/collab`; Chrome 150 at `412 × 915` observed cards, View/Control separation, prompt, interrupt, process removal, safe leave, no URL/storage capability, and foreground/online transport replacement. A live `/new` revoked generation 1, published generation 2 after replacement, and left generation 1 unlaunchable (`409`). |
+| Private vulnerability reporting | **PASS** | GitHub repository private vulnerability reporting returned `enabled: true` on 2026-07-20. |
+| Deterministic SPDX inventory | **PASS** | Two release builds produced identical archive and SPDX 2.3 digests; `SHA256SUMS` verified both and the archive contains `SBOM.spdx.json`. |
+
+The evidence date and caveats above come from the implementation handoff. A release candidate
+must rerun every applicable command from a clean checkout and attach the resulting CI/native
+qualification records to the candidate tag.
+
+## Alpha gate ledger
+
+| Release gate | Status | Evidence or missing proof | Required to close |
+|---|---|---|---|
+| Exact OMP and collab-web provenance | **PASS** | Immutable source commit, package versions, relevant paths, local integration, and patch are recorded in `UPSTREAM.lock.json` and `packages/collab-client/upstream/UPSTREAM.json`. | Revalidate unchanged data at the candidate tag. |
+| Repository automated suite | **PASS** | Typechecks, production asset builds, unit/integration tests, handoff checks, and the repository leak scanner passed. | Rerun from clean CI at the candidate tag. |
+| OMP patch compatibility | **PASS** | Patch and lifecycle fixtures passed against the exact pinned OMP checkout; upstream-baseline exclusions are documented. | Rerun against the immutable pin; do not broaden the OMP range. |
+| Capability non-persistence | **PARTIAL** | Automated scans and desktop Chromium storage/history/cache checks passed. | Complete Android lifecycle checks and scan release CI artifacts, recordings, diagnostics, browser state, and all forbidden sinks with canary capabilities. |
+| Loopback-only exposure | **PARTIAL** | macOS listener inspection and direct LAN/Tailscale-IP connection attempts proved the development checkout loopback-only. | Repeat with every signed candidate artifact and qualified host OS. |
+| Tailscale Serve identity and application allowlist | **PARTIAL** | Real macOS Serve accepted the exact allowlisted login; denied, missing, and spoofed direct-backend identities failed; Funnel was disabled. | Repeat from distinct allowed and denied tailnet devices with the candidate artifact. |
+| Linux host lifecycle | **PARTIAL** | Debian 13 arm64 container with a real systemd user manager passed install, autostart, permissions, restart/reinstall, token rotation, and uninstall. | Repeat on a bare-metal/VM candidate OS and qualify upgrade/rollback and diagnostics. |
+| macOS host lifecycle | **PARTIAL** | macOS 26.5.2 arm64 passed live LaunchAgent install, private permissions, restart/reinstall, token rotation, diagnostics/bundle, Serve checks, and uninstall. | Repeat from a signed candidate artifact and qualify reboot/login persistence plus upgrade/rollback. |
+| Windows host lifecycle | **PARTIAL** | GitHub Actions `windows-latest` run `29715302992` passed config/token ACL checks, scheduled-task install/start, token rotation, authenticated exact-Origin graceful PID replacement, active reinstall, and process-clean uninstall. | Repeat with a signed candidate artifact; qualify reboot/login persistence, diagnostics, upgrade, and rollback. |
+| Android PWA installation | **NOT RUN** | Installable assets and Android-sized Chrome emulation passed. | Install from the real tailnet HTTPS origin on the target Android/Chrome version and verify update/offline states. |
+| Three real OMP processes auto-discover | **PARTIAL** | Three patched interactive OMP processes appeared automatically within the acceptance window in Android-sized desktop Chrome. | Repeat on a physical Android device. |
+| Real View and Control behavior | **PARTIAL** | Real desktop browser clients proved View composer disabled, Control prompt delivery, shared transcript updates, and interrupt. | Repeat every action from physical Android and verify host-side view mutation rejection. |
+| Real lifecycle revocation | **PARTIAL** | Generation, stale launch, socket close, TTL tests, and real process exit/crash removal passed; no stale capability was returned. | Prove switch/branch/resume replacement ordering and crash-by-TTL on the candidate OMP/Android path. |
+| Android lock, resume, network, back, and reconnect | **PARTIAL** | Chrome lifecycle/online events forced a fresh relay transport, the resumed view received new traffic, and leave returned to a secret-free directory URL. | Repeat OS lock, radio/network transition, browser back, and history/storage checks on physical Android. |
+| Existing OMP relay connectivity | **PARTIAL** | Real desktop View/Control/interrupt and reconnect passed through the default relay; an automated eight-hour view client soak is running. | Complete the soak and repeat connectivity/lifecycle on physical Android. |
+| Platform install/doctor/uninstall | **PARTIAL** | Full development-checkout flows passed on macOS, a Debian 13 systemd container, and hosted Windows; Windows included process-clean uninstall. | Qualify signed candidate artifacts on every advertised OS. |
+| Configuration migration and rollback | **PARTIAL** | Active reinstall/PID replacement passed on macOS, Linux, and hosted Windows; configuration and token ownership were preserved. | Execute explicit forward migration and rollback with candidate artifacts on each advertised host. |
+| Private vulnerability reporting | **PASS** | GitHub private vulnerability reporting is enabled and repository security guidance identifies the private path. | Reverify before publication. |
+| Release signing, SBOM, and provenance | **BLOCKED** | A least-privilege, commit-pinned OIDC workflow builds a deterministic SPDX 2.3 inventory and signs/attests every release artifact; local reproducibility passed and hosted Actions recovered for Windows qualification. No hosted provenance-test release has run. | Run a provenance-test tag and verify GitHub attestations, Cosign bundles, checksums, SBOM, and immutable release assets. |
+| Known limitations and exact compatibility matrix | **PASS** | This ledger and `COMPATIBILITY.md` state the pre-alpha boundary, exact OMP pin, unqualified platforms, and unsupported modes. | Keep both synchronized with every candidate. |
+| Self-hosted/proxied relay | **N/A** | Explicitly unsupported and deferred. | Do not advertise; a future release needs the dedicated WebSocket soak and a separate security qualification. |
+
+## Current release blockers
+
+The alpha decision remains **NO-GO** until, at minimum:
+
+1. at least one proposed host platform passes its complete native lifecycle and security matrix;
+2. real Tailscale Serve authorization and LAN/public isolation pass on that platform;
+3. a real Android device passes install, automatic discovery, View, Control, interrupt,
+   generation replacement, lock/resume, network-change, back-navigation, reconnect, and leak checks;
+4. the default OMP relay path passes the applicable connectivity/soak scenarios;
+5. upgrade, rollback, diagnostics, token rotation, and uninstall pass for every advertised host;
+6. release artifacts are produced by protected CI with checksums, SBOM/dependency inventory,
+   signing or documented provenance, and a clean canary leak scan; and
+7. private vulnerability reporting is enabled and verified.
+
+Passing one platform permits advertising only that exact qualified platform/version combination.
+It does not promote untested rows or broaden the pinned OMP range.
+
+## Known limitations
+
+- The gateway requires the exact pinned OMP source plus the repository patch; there is no
+  upstream release/API compatibility promise yet.
+- A daemon restart intentionally starts with an empty in-memory registry until live publishers
+  reconnect.
+- Browser reload intentionally returns to the session directory because collaboration
+  capabilities are not persisted.
+- The existing OMP relay remains an availability and traffic-metadata dependency.
+- Same-desktop-user malware, a compromised browser/OS, and an unlocked authorized phone are
+  outside or inherited trust boundaries described in `SECURITY.md`.
+- Tagged Tailscale source devices, Tailscale Funnel, public/LAN HTTP, self-hosted relays,
+  WebAuthn gating, TWA/native clients, push notifications, and multi-host federation are not
+  supported by this release line.
+- No production upgrade or rollback path has completed cross-platform qualification.
+
+## Updating this ledger
+
+Change a row only with a reproducible command result or a named manual qualification record that
+identifies the source commit, artifact checksum, OS/browser/device versions, deployment path, and
+date. Record failures as failures; do not turn a narrower automated pass into a broader platform
+claim. Update this file, `COMPATIBILITY.md`, `CHANGELOG.md`, and release notes together whenever a
+support claim or gate changes.

--- a/packages/collab-client/README.md
+++ b/packages/collab-client/README.md
@@ -6,6 +6,7 @@ Pinned integration of OMP's existing `packages/collab-web` source at commit
 The local patch passes the capability directly into the root `App` component, supports a one-time same-origin
 `MessageChannel` handoff, closes the transfer port after acknowledgement, and returns to the gateway on leave
 or reload. It never writes the capability into a URL, DOM attribute, browser storage, or service-worker cache.
+Foreground, BFCache restore, and online transitions replace a potentially stale relay transport before reuse.
 
 `upstream/UPSTREAM.json` records the exact source path, package version, Bun version, and local patch list.
 `upstream/LICENSE` preserves the upstream license. The build remains a narrow integration; it does not fork the

--- a/packages/collab-client/test/socket.test.ts
+++ b/packages/collab-client/test/socket.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { CollabSocket } from "../upstream/src/lib/socket.ts";
+
+const NativeWebSocket = globalThis.WebSocket;
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static readonly instances: FakeWebSocket[] = [];
+
+  readonly url: string;
+  readyState = FakeWebSocket.CONNECTING;
+  binaryType: BinaryType = "blob";
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  closeCode: number | undefined;
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+    FakeWebSocket.instances.push(this);
+  }
+
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+
+  send(_data: string | ArrayBufferLike | Blob | ArrayBufferView): void {}
+
+  close(code = 1000): void {
+    this.closeCode = code;
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ code, reason: "" } as CloseEvent);
+  }
+}
+
+beforeEach(() => {
+  FakeWebSocket.instances.length = 0;
+  globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+});
+
+afterEach(() => {
+  globalThis.WebSocket = NativeWebSocket;
+});
+
+describe("CollabSocket browser lifecycle recovery", () => {
+  test("replaces a stale transport without ending the logical connection", () => {
+    const socket = new CollabSocket({
+      wsUrl: "wss://relay.example/r/synthetic-room",
+      role: "guest",
+      key: {} as CryptoKey,
+    });
+    const phases: Array<{ reason: string; willReconnect: boolean }> = [];
+    let opens = 0;
+    socket.onOpen = () => {
+      opens += 1;
+    };
+    socket.onClose = (reason, willReconnect) => {
+      phases.push({ reason, willReconnect });
+    };
+
+    socket.connect();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    const initial = FakeWebSocket.instances[0];
+    if (initial === undefined) throw new Error("initial WebSocket was not created");
+    initial.open();
+    expect(opens).toBe(1);
+
+    socket.reconnect();
+    expect(initial.closeCode).toBe(1000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(phases).toEqual([{ reason: "connection refresh", willReconnect: true }]);
+
+    const replacement = FakeWebSocket.instances[1];
+    if (replacement === undefined) throw new Error("replacement WebSocket was not created");
+    replacement.open();
+    expect(opens).toBe(2);
+    expect(socket.isOpen).toBe(true);
+
+    socket.close();
+    expect(phases.at(-1)).toEqual({ reason: "closed", willReconnect: false });
+    socket.reconnect();
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+});

--- a/packages/collab-client/upstream/UPSTREAM.json
+++ b/packages/collab-client/upstream/UPSTREAM.json
@@ -10,6 +10,8 @@
   "localPatches": [
     "Direct in-memory App capability prop; no capability URL/hash writes",
     "One-time same-origin MessageChannel bootstrap",
-    "Return to the gateway directory on leave or reload"
+    "Return to the gateway directory on leave or reload",
+    "Force a fresh relay transport after mobile foreground and online transitions",
+    "Preserve strict exact-optional typing for view links without a write token"
   ]
 }

--- a/packages/collab-client/upstream/src/app.tsx
+++ b/packages/collab-client/upstream/src/app.tsx
@@ -107,6 +107,38 @@ export function App({ capability, onDispose }: AppProps): ReactNode {
 	}, [capability, connect]);
 
 	useEffect(() => {
+		if (!client) return;
+		let wasHidden = document.visibilityState === "hidden";
+		let lastRefreshAt = 0;
+		const refresh = (): void => {
+			const now = Date.now();
+			if (now - lastRefreshAt < 500) return;
+			lastRefreshAt = now;
+			client.refreshConnection();
+		};
+		const visibilityChanged = (): void => {
+			if (document.visibilityState === "hidden") {
+				wasHidden = true;
+				return;
+			}
+			if (!wasHidden) return;
+			wasHidden = false;
+			refresh();
+		};
+		const pageShown = (event: PageTransitionEvent): void => {
+			if (event.persisted) refresh();
+		};
+		window.addEventListener("online", refresh);
+		window.addEventListener("pageshow", pageShown);
+		document.addEventListener("visibilitychange", visibilityChanged);
+		return () => {
+			window.removeEventListener("online", refresh);
+			window.removeEventListener("pageshow", pageShown);
+			document.removeEventListener("visibilitychange", visibilityChanged);
+		};
+	}, [client]);
+
+	useEffect(() => {
 		if (!client) document.title = "OMP collaboration";
 	}, [client]);
 

--- a/packages/collab-client/upstream/src/lib/client.ts
+++ b/packages/collab-client/upstream/src/lib/client.ts
@@ -157,6 +157,12 @@ export class GuestClient {
 		this.#socket.close();
 	}
 
+	/** Force a fresh relay transport after a browser foreground/network transition. */
+	refreshConnection(): void {
+		if (this.#phase === "ended") return;
+		this.#socket.reconnect();
+	}
+
 	subscribe(listener: () => void): () => void {
 		this.#listeners.add(listener);
 		return () => {

--- a/packages/collab-client/upstream/src/lib/link.ts
+++ b/packages/collab-client/upstream/src/lib/link.ts
@@ -186,5 +186,5 @@ export function parseCollabLink(link: string): ParsedCollabLink | { error: strin
 	}
 	const key = secret.subarray(0, ROOM_KEY_BYTES);
 	const writeToken = secret.byteLength > ROOM_KEY_BYTES ? secret.subarray(ROOM_KEY_BYTES) : undefined;
-	return { wsUrl: `${normalized.origin}/r/${roomId}`, roomId, key, writeToken };
+	return { wsUrl: `${normalized.origin}/r/${roomId}`, roomId, key, ...(writeToken === undefined ? {} : { writeToken }) };
 }

--- a/packages/collab-client/upstream/src/lib/socket.ts
+++ b/packages/collab-client/upstream/src/lib/socket.ts
@@ -106,6 +106,28 @@ export class CollabSocket {
 		if (hadActivity && !wasClosed) this.onClose?.("closed", false);
 	}
 
+	/**
+	 * Replace a potentially stale transport without ending the logical guest.
+	 * Mobile browsers may suspend a page without delivering a WebSocket close
+	 * event, so foreground/online lifecycle events must be able to force a
+	 * fresh relay connection.
+	 */
+	reconnect(): void {
+		if (this.#closed) return;
+		this.#clearRetry();
+		const ws = this.#ws;
+		this.#ws = null;
+		if (ws) {
+			try {
+				ws.close(1000);
+			} catch {
+				// already closing/closed
+			}
+		}
+		this.onClose?.("connection refresh", true);
+		this.#openSocket();
+	}
+
 	#openSocket(): void {
 		const ws = new WebSocket(`${this.#opts.wsUrl}?role=${this.#opts.role}`);
 		ws.binaryType = "arraybuffer";

--- a/patches/oh-my-pi/0001-collab-controller-autostart-registry.patch
+++ b/patches/oh-my-pi/0001-collab-controller-autostart-registry.patch
@@ -1,9 +1,743 @@
+diff --git a/packages/coding-agent/src/collab/host.ts b/packages/coding-agent/src/collab/host.ts
+index 74a021a80..8e19799c5 100644
+--- a/packages/coding-agent/src/collab/host.ts
++++ b/packages/coding-agent/src/collab/host.ts
+@@ -138,6 +138,8 @@ export class CollabHost {
+ 	#busUnsubscribers: (() => void)[] = [];
+ 	#registryUnsubscribe?: () => void;
+ 	#stopped = false;
++	/** Invoked after an unrecoverable relay close tears down this host. */
++	onFatal?: (reason: string) => void;
+ 
+ 	constructor(ctx: InteractiveModeContext) {
+ 		this.#ctx = ctx;
+@@ -245,7 +247,7 @@ export class CollabHost {
+ 			if (willReconnect) {
+ 				this.#ctx.showStatus(`Collab relay connection lost (${reason}), reconnecting…`, { dim: true });
+ 			} else {
+-				void this.#teardown();
++				void this.#teardown().finally(() => this.onFatal?.(reason));
+ 				this.#ctx.session.emitNotice("warning", `Collab ended: ${reason}`, "collab");
+ 			}
+ 		};
+@@ -314,7 +316,6 @@ export class CollabHost {
+ 		this.#peers.clear();
+ 		this.#socket?.close();
+ 		this.#socket = null;
+-		this.#ctx.collabHost = undefined;
+ 		this.#ctx.statusLine.setCollabStatus(null);
+ 		this.#ctx.ui.requestRender();
+ 	}
+diff --git a/packages/coding-agent/src/config/settings-schema.ts b/packages/coding-agent/src/config/settings-schema.ts
+index 23b0e6800..78cfefa7c 100644
+--- a/packages/coding-agent/src/config/settings-schema.ts
++++ b/packages/coding-agent/src/config/settings-schema.ts
+@@ -1830,6 +1830,34 @@ export const SETTINGS_SCHEMA = {
+ 	},
+ 
+ 	// Collab
++	"collab.autoStart": {
++		type: "enum",
++		values: ["off", "view", "control"] as const,
++		default: "off",
++		ui: {
++			tab: "interaction",
++			group: "Collab",
++			label: "Automatic Collaboration",
++			description: "Start collaboration after interactive session initialization and publish view or control access",
++			options: [
++				{ value: "off", label: "Off" },
++				{ value: "view", label: "View only" },
++				{ value: "control", label: "View and control" },
++			],
++		},
++	},
++
++	"collab.registryEndpoint": {
++		type: "string",
++		default: "auto",
++		ui: {
++			tab: "interaction",
++			group: "Collab",
++			label: "Session Gateway Registry",
++			description: "Local IPC endpoint: auto, off, an absolute Unix socket, or a Windows named pipe",
++		},
++	},
++
+ 	"collab.relayUrl": {
+ 		type: "string",
+ 		default: DEFAULT_RELAY_URL,
+diff --git a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+index fa75dd615..4d78bdb26 100644
+--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
++++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+@@ -563,7 +563,7 @@ export class ExtensionUiController {
+ 		questions: ExtensionAskDialogQuestion[],
+ 		dialogOptions?: ExtensionUIDialogOptions,
+ 	): Promise<ExtensionAskDialogResult | undefined> {
+-		const host = this.ctx.collabHost;
++		const host = this.ctx.collabController.host;
+ 		if (!host) return this.#showLocalAskDialog(questions, dialogOptions);
+ 		const localAbort = new AbortController();
+ 		const remoteAbort = new AbortController();
+@@ -671,7 +671,7 @@ export class ExtensionUiController {
+ 		signal: AbortSignal | undefined,
+ 		local: (signal: AbortSignal | undefined) => Promise<string | undefined>,
+ 	): Promise<string | undefined> {
+-		const host = this.ctx.collabHost;
++		const host = this.ctx.collabController.host;
+ 		if (!host) return local(signal);
+ 		const localAbort = new AbortController();
+ 		const remoteAbort = new AbortController();
+@@ -811,7 +811,7 @@ export class ExtensionUiController {
+ 	}
+ 
+ 	async #requestGuestUiString(request: CollabUiRequestDraft, signal: AbortSignal): Promise<GuestUiResult> {
+-		const host = this.ctx.collabHost;
++		const host = this.ctx.collabController.host;
+ 		if (!host) return { kind: "unavailable" };
+ 		const remote = host.requestGuestUi(request, signal);
+ 		if (!remote) return { kind: "unavailable" };
+diff --git a/packages/coding-agent/src/modes/interactive-mode.ts b/packages/coding-agent/src/modes/interactive-mode.ts
+index 9d3a2a59a..49630c7d0 100644
+--- a/packages/coding-agent/src/modes/interactive-mode.ts
++++ b/packages/coding-agent/src/modes/interactive-mode.ts
+@@ -53,8 +53,8 @@ import {
+ } from "@oh-my-pi/pi-utils";
+ import chalk from "chalk";
+ import { reset as resetCapabilities } from "../capability";
++import { CollabController } from "../collab/controller";
+ import type { CollabGuestLink } from "../collab/guest";
+-import type { CollabHost } from "../collab/host";
+ import { KeybindingsManager } from "../config/keybindings";
+ import type { ResolvedModelRoleValue } from "../config/model-resolver";
+ import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
+@@ -532,7 +532,7 @@ export class InteractiveMode implements InteractiveModeContext {
+ 	fileSlashCommands: Set<string> = new Set();
+ 	skillCommands: Map<string, Skill> = new Map();
+ 	oauthManualInput: OAuthManualInputManager = new OAuthManualInputManager();
+-	collabHost?: CollabHost;
++	readonly collabController: CollabController;
+ 	collabGuest?: CollabGuestLink;
+ 
+ 	#pendingCommandOutput: Component[] = [];
+@@ -756,6 +756,7 @@ export class InteractiveMode implements InteractiveModeContext {
+ 
+ 		const skillCommandList = this.#rebuildSkillCommandsFromSession();
+ 
++		this.collabController = new CollabController(this);
+ 		const builtinCommands = buildTuiBuiltinSlashCommands({ ctx: this });
+ 		// Store pending commands for init() where file commands are loaded async
+ 		this.#pendingSlashCommands = [...builtinCommands, ...hookCommands, ...customCommands, ...skillCommandList];
+@@ -992,7 +993,14 @@ export class InteractiveMode implements InteractiveModeContext {
+ 		await this.initHooksAndCustomTools();
+ 
+ 		// Restore mode from session (e.g. plan mode on resume)
+-		this.session.setSessionSwitchReconciler?.(() => this.#reconcileModeFromSession({ preserveActiveGoal: true }));
++		this.session.setSessionSwitchReconciler?.(async phase => {
++			if (phase === "before") {
++				await this.collabController.prepareActiveSessionReplacement();
++				return;
++			}
++			await this.collabController.restoreActiveSession();
++			await this.#reconcileModeFromSession({ preserveActiveGoal: true });
++		});
+ 		await this.#reconcileModeFromSession();
+ 
+ 		// Brand-new sessions optionally start in plan mode when the user has made it
+@@ -1091,6 +1099,9 @@ export class InteractiveMode implements InteractiveModeContext {
+ 		this.statusLine.watchBranch(() => {
+ 			this.ui.requestRender();
+ 		});
++
++		// Collaboration starts only after the interactive context and session are ready.
++		await this.collabController.autoStart();
+ 	}
+ 
+ 	/** Reload the title-generation system prompt override for the provided working
+@@ -3752,6 +3763,7 @@ export class InteractiveMode implements InteractiveModeContext {
+ 	async shutdown(): Promise<void> {
+ 		if (this.#isShuttingDown) return;
+ 		this.#isShuttingDown = true;
++		await this.collabController.shutdown();
+ 
+ 		this.#btwController.dispose();
+ 		this.#omfgController.dispose();
+diff --git a/packages/coding-agent/src/modes/types.ts b/packages/coding-agent/src/modes/types.ts
+index 57ed56bb3..8d22f181a 100644
+--- a/packages/coding-agent/src/modes/types.ts
++++ b/packages/coding-agent/src/modes/types.ts
+@@ -2,8 +2,8 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+ import type { CompactionOutcome } from "@oh-my-pi/pi-agent-core/compaction";
+ import type { AssistantMessage, ImageContent, Message, Usage, UsageReport } from "@oh-my-pi/pi-ai";
+ import type { Component, Container, EditorTheme, Loader, Spacer, Text, TUI } from "@oh-my-pi/pi-tui";
++import type { CollabController } from "../collab/controller";
+ import type { CollabGuestLink } from "../collab/guest";
+-import type { CollabHost } from "../collab/host";
+ import type { KeybindingsManager } from "../config/keybindings";
+ import type { Settings } from "../config/settings";
+ import type {
+@@ -133,7 +133,7 @@ export interface InteractiveModeContext {
+ 	historyStorage?: HistoryStorage;
+ 	mcpManager?: MCPManager;
+ 	lspServers?: LspStartupServerInfo[];
+-	collabHost?: CollabHost;
++	collabController: CollabController;
+ 	collabGuest?: CollabGuestLink;
+ 	eventController: EventController;
+ 	eventBus?: EventBus;
+diff --git a/packages/coding-agent/src/session/agent-session.ts b/packages/coding-agent/src/session/agent-session.ts
+index e39ca813d..097710324 100644
+--- a/packages/coding-agent/src/session/agent-session.ts
++++ b/packages/coding-agent/src/session/agent-session.ts
+@@ -3937,12 +3937,24 @@ export class AgentSession {
+ 		this.#planProposalHandler = handler ?? undefined;
+ 	}
+ 
+-	#sessionSwitchReconciler: (() => Promise<void>) | undefined;
++	#sessionSwitchReconciler: ((phase: "before" | "after") => Promise<void>) | undefined;
+ 
+-	setSessionSwitchReconciler(reconciler: (() => Promise<void>) | null): void {
++	setSessionSwitchReconciler(reconciler: ((phase: "before" | "after") => Promise<void>) | null): void {
+ 		this.#sessionSwitchReconciler = reconciler ?? undefined;
+ 	}
+ 
++	async #reconcileSessionSwitch(phase: "before" | "after", reason: string): Promise<void> {
++		try {
++			await this.#sessionSwitchReconciler?.(phase);
++		} catch (error) {
++			logger.warn("Failed to reconcile collaboration around session replacement", {
++				phase,
++				reason,
++				error: String(error),
++			});
++		}
++	}
++
+ 	/** Provider-scoped mutable state store for transport/session caches. */
+ 	get providerSessionState(): Map<string, ProviderSessionState> {
+ 		return this.#providerSessionState;
+@@ -9894,6 +9906,7 @@ export class AgentSession {
+ 			}
+ 		}
+ 
++		await this.#reconcileSessionSwitch("before", "new");
+ 		this.#disconnectFromAgent();
+ 		await this.abort();
+ 		this.#cancelOwnAsyncJobs();
+@@ -9927,6 +9940,7 @@ export class AgentSession {
+ 			sessionTransitioned = true;
+ 		} finally {
+ 			this.#finishBashSessionTransition(bashTransition, sessionTransitioned);
++			if (!sessionTransitioned) await this.#reconcileSessionSwitch("after", "new rollback");
+ 		}
+ 
+ 		this.#clearCheckpointRuntimeState();
+@@ -9951,6 +9965,7 @@ export class AgentSession {
+ 		this.#planReferencePath = "local://PLAN.md";
+ 		this.#resetAdvisorSessionState();
+ 		this.#reconnectToAgent();
++		await this.#reconcileSessionSwitch("after", "new");
+ 
+ 		// Emit session_switch event with reason "new" to hooks
+ 		if (this.#extensionRunner) {
+@@ -9993,6 +10008,7 @@ export class AgentSession {
+ 			}
+ 		}
+ 
++		await this.#reconcileSessionSwitch("before", "fork");
+ 		await this.#flushPendingBashMessages();
+ 		// Flush current session to ensure all entries are written
+ 		await this.sessionManager.flush();
+@@ -10004,10 +10020,12 @@ export class AgentSession {
+ 			forkResult = await this.sessionManager.fork();
+ 		} catch (error) {
+ 			this.#finishBashSessionTransition(bashTransition, false);
++			await this.#reconcileSessionSwitch("after", "fork rollback");
+ 			throw error;
+ 		}
+ 		if (!forkResult) {
+ 			this.#finishBashSessionTransition(bashTransition, false);
++			await this.#reconcileSessionSwitch("after", "fork rollback");
+ 			return false;
+ 		}
+ 		this.#markBashSessionTransition(bashTransition);
+@@ -10039,6 +10057,7 @@ export class AgentSession {
+ 		this.#rekeyHindsightMemoryForCurrentSessionId();
+ 		this.#rekeyMnemopiMemoryForCurrentSessionId();
+ 		await this.#resetMemoryContextForNewTranscript();
++		await this.#reconcileSessionSwitch("after", "fork");
+ 
+ 		// Emit session_switch event with reason "fork" to hooks
+ 		if (this.#extensionRunner) {
+@@ -11394,6 +11413,7 @@ export class AgentSession {
+ 					return undefined;
+ 				}
+ 			}
++			await this.#reconcileSessionSwitch("before", "handoff");
+ 			await this.#flushPendingBashMessages();
+ 			await this.sessionManager.flush();
+ 			const bashTransition = this.#beginBashSessionTransition();
+@@ -11407,6 +11427,7 @@ export class AgentSession {
+ 				sessionTransitioned = true;
+ 			} finally {
+ 				this.#finishBashSessionTransition(bashTransition, sessionTransitioned);
++				if (!sessionTransitioned) await this.#reconcileSessionSwitch("after", "handoff rollback");
+ 			}
+ 
+ 			this.#clearCheckpointRuntimeState();
+@@ -11461,6 +11482,7 @@ export class AgentSession {
+ 			this.agent.replaceMessages(sessionContext.messages);
+ 			this.#resetAllAdvisorRuntimes();
+ 			this.#syncTodoPhasesFromBranch();
++			await this.#reconcileSessionSwitch("after", "handoff");
+ 			if (this.#extensionRunner) {
+ 				await this.#extensionRunner.emit({
+ 					type: "session_switch",
+@@ -16532,6 +16554,7 @@ export class AgentSession {
+ 			}
+ 		}
+ 
++		await this.#reconcileSessionSwitch("before", "resume");
+ 		this.#disconnectFromAgent();
+ 		await this.abort({ goalReason: "internal" });
+ 
+@@ -16710,14 +16733,7 @@ export class AgentSession {
+ 				await this.#resetMemoryContextForNewTranscript();
+ 			}
+ 			this.#reconnectToAgent();
+-			try {
+-				await this.#sessionSwitchReconciler?.();
+-			} catch (error) {
+-				logger.warn("Failed to reconcile session mode after switch", {
+-					targetSessionFile: sessionPath,
+-					error: String(error),
+-				});
+-			}
++			await this.#reconcileSessionSwitch("after", "resume");
+ 			this.#finishBashSessionTransition(bashTransition, true);
+ 			return true;
+ 		} catch (error) {
+@@ -16750,6 +16766,7 @@ export class AgentSession {
+ 			this.#syncTodoPhasesFromBranch();
+ 			this.#resetAllAdvisorRuntimes();
+ 			this.#reconnectToAgent();
++			await this.#reconcileSessionSwitch("after", "resume rollback");
+ 			this.#finishBashSessionTransition(bashTransition, false);
+ 			throw error;
+ 		}
+@@ -16792,6 +16809,7 @@ export class AgentSession {
+ 			skipConversationRestore = result?.skipConversationRestore ?? false;
+ 		}
+ 
++		await this.#reconcileSessionSwitch("before", "branch");
+ 		// Clear pending messages (bound to old session state)
+ 		this.#pendingNextTurnMessages = [];
+ 		this.#scheduledHiddenNextTurnGeneration = undefined;
+@@ -16815,6 +16833,7 @@ export class AgentSession {
+ 			sessionTransitioned = true;
+ 		} finally {
+ 			this.#finishBashSessionTransition(bashTransition, sessionTransitioned);
++			if (!sessionTransitioned) await this.#reconcileSessionSwitch("after", "branch rollback");
+ 		}
+ 		this.#rehydrateCheckpointRewindState();
+ 		this.#syncTodoPhasesFromBranch();
+@@ -16841,6 +16860,7 @@ export class AgentSession {
+ 			this.#resetAdvisorSessionState();
+ 			this.#closeCodexProviderSessionsForHistoryRewrite();
+ 		}
++		await this.#reconcileSessionSwitch("after", "branch");
+ 
+ 		return { selectedText, cancelled: false };
+ 	}
+@@ -16891,6 +16911,7 @@ export class AgentSession {
+ 			throw new Error("Cannot branch /btw while session maintenance or user work is still running");
+ 		}
+ 
++		await this.#reconcileSessionSwitch("before", "btw branch");
+ 		this.#pendingNextTurnMessages = [];
+ 		this.#scheduledHiddenNextTurnGeneration = undefined;
+ 		this.agent.replaceQueues([], []);
+@@ -16912,6 +16933,7 @@ export class AgentSession {
+ 			sessionTransitioned = true;
+ 		} finally {
+ 			this.#finishBashSessionTransition(bashTransition, sessionTransitioned);
++			if (!sessionTransitioned) await this.#reconcileSessionSwitch("after", "btw branch rollback");
+ 		}
+ 
+ 		this.#rehydrateCheckpointRewindState();
+@@ -16940,6 +16962,7 @@ export class AgentSession {
+ 		this.agent.replaceMessages(sessionContext.messages);
+ 		this.#resetAdvisorSessionState();
+ 		this.#closeCodexProviderSessionsForHistoryRewrite();
++		await this.#reconcileSessionSwitch("after", "btw branch");
+ 
+ 		return { cancelled: false, sessionFile: this.sessionFile };
+ 	}
+@@ -17094,6 +17117,7 @@ export class AgentSession {
+ 			newLeafId = targetId;
+ 		}
+ 
++		await this.#reconcileSessionSwitch("before", "tree navigation");
+ 		// Switch leaf (with or without summary)
+ 		// Summary is attached at the navigation target position (newLeafId), not the old branch
+ 		const bashTransition = this.#beginBashSessionTransition();
+@@ -17118,6 +17142,7 @@ export class AgentSession {
+ 			branchTransitioned = true;
+ 		} finally {
+ 			this.#finishBashSessionTransition(bashTransition, branchTransitioned);
++			if (!branchTransitioned) await this.#reconcileSessionSwitch("after", "tree navigation rollback");
+ 		}
+ 
+ 		// Update agent state — build display context to populate agent messages.
+@@ -17128,6 +17153,7 @@ export class AgentSession {
+ 		this.#resetAdvisorSessionState();
+ 		this.#syncTodoPhasesFromBranch();
+ 		this.#closeCodexProviderSessionsForHistoryRewrite();
++		await this.#reconcileSessionSwitch("after", "tree navigation");
+ 
+ 		this.#branchSummaryAbortController = undefined;
+ 
+diff --git a/packages/coding-agent/src/slash-commands/builtin-registry.ts b/packages/coding-agent/src/slash-commands/builtin-registry.ts
+index b564b5471..52cf5ab6f 100644
+--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
++++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
+@@ -6,7 +6,7 @@ import { type AutocompleteItem, Spacer } from "@oh-my-pi/pi-tui";
+ import { APP_NAME, getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+ import { reset as resetCapabilities } from "../capability";
+ import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
+-import { CollabHost } from "../collab/host";
++import type { CollabHost } from "../collab/host";
+ import { expandRoleAlias, getModelMatchPreferences, resolveCliModel } from "../config/model-resolver";
+ import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
+ import type { SettingPath, SettingValue } from "../config/settings";
+@@ -698,8 +698,8 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
+ 		],
+ 		allowArgs: true,
+ 		getTuiAutocompleteDescription: runtime => {
+-			if (runtime.ctx.collabHost) {
+-				return `Collab: hosting (${Math.max(0, runtime.ctx.collabHost.participants.length - 1)} guests)`;
++			if (runtime.ctx.collabController.host) {
++				return `Collab: hosting (${Math.max(0, runtime.ctx.collabController.host.participants.length - 1)} guests)`;
+ 			}
+ 			if (runtime.ctx.collabGuest?.readOnly) return "Collab: read-only guest";
+ 			if (runtime.ctx.collabGuest) return "Collab: guest";
+@@ -711,20 +711,22 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
+ 			const args = command.args.trim();
+ 			const { verb, rest } = parseSubcommand(args);
+ 			if (verb === "stop") {
+-				if (!ctx.collabHost) {
++				if (!ctx.collabController.host) {
+ 					ctx.showStatus("Not hosting a collab session");
+ 					return;
+ 				}
+-				await ctx.collabHost.stop("host stopped");
++				await ctx.collabController.stop("host stopped");
+ 				ctx.showStatus("Collab stopped");
+ 				return;
+ 			}
+ 			if (verb === "status") {
+-				if (ctx.collabHost) {
+-					const names = ctx.collabHost.participants.map(p =>
++				if (ctx.collabController.host) {
++					const names = ctx.collabController.host.participants.map(p =>
+ 						p.role === "host" ? `${p.name} (host)` : p.readOnly ? `${p.name} (view-only)` : p.name,
+ 					);
+-					ctx.showStatus(`Collab: ${names.join(", ")} — ${collabWebLinkClickable(ctx.collabHost.webLink)}`);
++					ctx.showStatus(
++						`Collab: ${names.join(", ")} — ${collabWebLinkClickable(ctx.collabController.host.webLink)}`,
++					);
+ 				} else if (ctx.collabGuest) {
+ 					ctx.showStatus(
+ 						ctx.collabGuest.readOnly
+@@ -742,16 +744,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
+ 			}
+ 			const knownStartVerb = verb === "start" || verb === "view";
+ 			const view = verb === "view";
+-			if (ctx.collabHost) {
+-				showCollabLink(
+-					ctx,
+-					ctx.collabHost,
+-					view ? "Read-only collab session active" : "Collab session active",
+-					view,
+-				);
++			const explicitUrl = knownStartVerb ? rest : args;
++			const existingHost = ctx.collabController.host;
++			if (existingHost && !explicitUrl) {
++				showCollabLink(ctx, existingHost, view ? "Read-only collab session active" : "Collab session active", view);
+ 				return;
+ 			}
+-			const explicitUrl = knownStartVerb ? rest : args;
+ 			const relayInput = explicitUrl || ctx.settings.get("collab.relayUrl") || "";
+ 			if (!relayInput) {
+ 				ctx.showError(
+@@ -762,14 +760,17 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
+ 			// Scheme-less relay args default to wss (ws:// must be spelled out for localhost).
+ 			const relayUrl = relayInput.includes("://") ? relayInput : `wss://${relayInput}`;
+ 			const webUrl = ctx.settings.get("collab.webUrl") || "";
+-			const host = new CollabHost(ctx);
+ 			try {
+-				await host.start(relayUrl, webUrl);
++				await ctx.collabController.start({ relayUrl, webUrl, publish: view ? "view" : "control" });
+ 			} catch (err) {
+ 				ctx.showError(`Failed to start collab session: ${errorMessage(err)}`);
+ 				return;
+ 			}
+-			ctx.collabHost = host;
++			const host = ctx.collabController.host;
++			if (!host) {
++				ctx.showError("Failed to start collab session");
++				return;
++			}
+ 			showCollabLink(ctx, host, "Collab session started!", view);
+ 		},
+ 	},
+@@ -786,7 +787,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
+ 				ctx.showError("Usage: /join <link>");
+ 				return;
+ 			}
+-			if (ctx.collabHost) {
++			if (ctx.collabController.host) {
+ 				ctx.showError("Stop hosting first (/collab stop)");
+ 				return;
+ 			}
+@@ -805,7 +806,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
+ 		name: "leave",
+ 		description: "Leave the collab session",
+ 		getTuiAutocompleteDescription: runtime => {
+-			if (runtime.ctx.collabHost) return "Leave collab: hosting";
++			if (runtime.ctx.collabController.host) return "Leave collab: hosting";
+ 			if (runtime.ctx.collabGuest) return "Leave collab: guest";
+ 			return "Leave collab: not in collab";
+ 		},
+@@ -816,8 +817,8 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
+ 				await ctx.collabGuest.leave("left");
+ 				return;
+ 			}
+-			if (ctx.collabHost) {
+-				await ctx.collabHost.stop("host stopped");
++			if (ctx.collabController.host) {
++				await ctx.collabController.stop("host stopped");
+ 				ctx.showStatus("Collab stopped");
+ 				return;
+ 			}
+diff --git a/packages/coding-agent/test/agent-session-bash-session-ownership.test.ts b/packages/coding-agent/test/agent-session-bash-session-ownership.test.ts
+index 46e02e995..50d52a1e5 100644
+--- a/packages/coding-agent/test/agent-session-bash-session-ownership.test.ts
++++ b/packages/coding-agent/test/agent-session-bash-session-ownership.test.ts
+@@ -113,6 +113,23 @@ describe("AgentSession bash session ownership", () => {
+ 		expect(session.messages.some(message => message.role === "bashExecution")).toBe(false);
+ 	});
+ 
++	it("brackets session identity replacement with reconciler phases", async () => {
++		createSession();
++		const previousSessionId = session.sessionId;
++		const observations: Array<{ phase: "before" | "after"; sessionId: string }> = [];
++		session.setSessionSwitchReconciler(async phase => {
++			observations.push({ phase, sessionId: session.sessionId });
++		});
++
++		await session.newSession();
++
++		expect(observations).toEqual([
++			{ phase: "before", sessionId: previousSessionId },
++			{ phase: "after", sessionId: session.sessionId },
++		]);
++		expect(session.sessionId).not.toBe(previousSessionId);
++	});
++
+ 	it("keeps a queued bash result on the branch discarded by an empty stop", async () => {
+ 		const sessionManager = SessionManager.inMemory(tempDir.path());
+ 		let returnEmptyStop = true;
+diff --git a/packages/coding-agent/test/collab/chunked-welcome.test.ts b/packages/coding-agent/test/collab/chunked-welcome.test.ts
+index 53d786845..ca6e17e5c 100644
+--- a/packages/coding-agent/test/collab/chunked-welcome.test.ts
++++ b/packages/coding-agent/test/collab/chunked-welcome.test.ts
+@@ -82,7 +82,6 @@ function makeHostContext(snapshot: SizedSnapshot): InteractiveModeContext {
+ 		},
+ 		ui: { requestRender: () => {} },
+ 		showStatus: () => {},
+-		collabHost: undefined,
+ 	};
+ 	return ctx as unknown as InteractiveModeContext;
+ }
+diff --git a/packages/coding-agent/test/collab/guest-ui-request.test.ts b/packages/coding-agent/test/collab/guest-ui-request.test.ts
+index 76330b0d3..94b319882 100644
+--- a/packages/coding-agent/test/collab/guest-ui-request.test.ts
++++ b/packages/coding-agent/test/collab/guest-ui-request.test.ts
+@@ -472,7 +472,7 @@ function makeHostContext(): InteractiveModeContext {
+ 		},
+ 		ui: { requestRender: () => {} },
+ 		showStatus: () => {},
+-		collabHost: undefined,
++		collabController: { host: undefined },
+ 	} as unknown as InteractiveModeContext;
+ }
+ 
+@@ -650,7 +650,7 @@ describe("collab host dialog vs teardown (#4049 follow-up)", () => {
+ 		const ctx = makeHostContext();
+ 		const host = new CollabHost(ctx);
+ 		await host.start("ws://localhost:8787");
+-		ctx.collabHost = host;
++		Object.assign(ctx.collabController, { host });
+ 		const controller = new StubDialogController(ctx);
+ 		const guest = await joinRawGuest(host.link, COLLAB_PROTO);
+ 		const welcome = await guest.nextFrame();
+@@ -731,7 +731,7 @@ describe("guest ask unavailable literal answer (#4375)", () => {
+ 		const ctx = makeHostContext();
+ 		const host = new CollabHost(ctx);
+ 		await host.start("ws://localhost:8787");
+-		ctx.collabHost = host;
++		Object.assign(ctx.collabController, { host });
+ 		try {
+ 			const guest = await joinRawGuest(host.link, COLLAB_PROTO);
+ 			const welcome = await guest.nextFrame();
+@@ -815,7 +815,7 @@ describe("guest ask multi-select Next gating (#4375 PRRT_kwDOQxs0bc6OFbDW)", ()
+ 		const ctx = makeAskHostContext();
+ 		const host = new CollabHost(ctx);
+ 		await host.start("ws://localhost:8787");
+-		ctx.collabHost = host;
++		Object.assign(ctx.collabController, { host });
+ 		const controller = new ExtensionUiController(ctx);
+ 		try {
+ 			const guest = await joinRawGuest(host.link, COLLAB_PROTO);
+diff --git a/packages/coding-agent/test/collab/read-only.test.ts b/packages/coding-agent/test/collab/read-only.test.ts
+index 84a7dc006..0fa169eab 100644
+--- a/packages/coding-agent/test/collab/read-only.test.ts
++++ b/packages/coding-agent/test/collab/read-only.test.ts
+@@ -73,7 +73,6 @@ function makeHostContext(): HostHarness {
+ 		},
+ 		ui: { requestRender: () => {} },
+ 		showStatus: () => {},
+-		collabHost: undefined,
+ 	} as unknown as InteractiveModeContext;
+ 	const nextPrompt = (): Promise<{ from?: string }> => {
+ 		const { promise, resolve } = Promise.withResolvers<{ from?: string }>();
+diff --git a/packages/coding-agent/test/collab/replication-shrink.test.ts b/packages/coding-agent/test/collab/replication-shrink.test.ts
+index 9087cbfa7..3f5196133 100644
+--- a/packages/coding-agent/test/collab/replication-shrink.test.ts
++++ b/packages/coding-agent/test/collab/replication-shrink.test.ts
+@@ -178,7 +178,6 @@ function makeHostContext(snapshot: OversizedSnapshot): HostHarness {
+ 		},
+ 		ui: { requestRender: () => {} },
+ 		showStatus: (msg: string) => statusMessages.push(msg),
+-		collabHost: undefined,
+ 	} as unknown as InteractiveModeContext;
+ 	return { ctx, statusMessages };
+ }
+diff --git a/packages/coding-agent/test/collab/steer-queue.test.ts b/packages/coding-agent/test/collab/steer-queue.test.ts
+index 0f76299fd..1dc189e26 100644
+--- a/packages/coding-agent/test/collab/steer-queue.test.ts
++++ b/packages/coding-agent/test/collab/steer-queue.test.ts
+@@ -127,7 +127,6 @@ function makeStreamingHostContext(): StreamingHostHarness {
+ 		ui: { requestRender: () => {} },
+ 		updatePendingMessagesDisplay: () => {},
+ 		showStatus: () => {},
+-		collabHost: undefined,
+ 	} as unknown as InteractiveModeContext;
+ 	const nextPrompt = (): Promise<CapturedPrompt> => {
+ 		const { promise, resolve } = Promise.withResolvers<CapturedPrompt>();
+diff --git a/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts b/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts
+index 8a63482d0..171e7094e 100644
+--- a/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts
++++ b/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts
+@@ -1,4 +1,5 @@
+ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
++import type { CollabController } from "@oh-my-pi/pi-coding-agent/collab/controller";
+ import { CollabHost } from "@oh-my-pi/pi-coding-agent/collab/host";
+ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+ import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+@@ -24,20 +25,17 @@ afterAll(() => {
+ 	resetSettingsForTest();
+ });
+ 
+-function fakeHost(options?: {
+-	webLink?: string;
+-	webViewLink?: string;
+-}): NonNullable<InteractiveModeContext["collabHost"]> {
++function fakeHost(options?: { webLink?: string; webViewLink?: string }): CollabHost {
+ 	return {
+ 		link: "relay.example.com/r/full-control",
+ 		viewLink: "relay.example.com/r/read-only",
+ 		webLink: options?.webLink ?? "https://my.omp.sh/#full-control",
+ 		webViewLink: options?.webViewLink ?? "https://my.omp.sh/#read-only",
+ 		participants: [{ name: "host", role: "host" }],
+-	} as unknown as NonNullable<InteractiveModeContext["collabHost"]>;
++	} as unknown as CollabHost;
+ }
+ 
+-function createRuntimeHarness(options?: { collabHost?: NonNullable<InteractiveModeContext["collabHost"]> }) {
++function createRuntimeHarness(options?: { collabHost?: CollabHost }) {
+ 	const setText = vi.fn();
+ 	const showStatus = vi.fn();
+ 	const showError = vi.fn();
+@@ -47,16 +45,31 @@ function createRuntimeHarness(options?: { collabHost?: NonNullable<InteractiveMo
+ 		if (key === "collab.webUrl") return "";
+ 		return "";
+ 	});
++	let collabHost = options?.collabHost;
+ 	const ctx = {
+ 		editor: { setText },
+ 		showStatus,
+ 		showError,
+ 		present,
+ 		settings: { get: settingsGet },
+-		collabHost: options?.collabHost,
+ 	} as unknown as InteractiveModeContext;
++	const start = vi.fn();
++	const collabController = {
++		get host() {
++			return collabHost;
++		},
++		async start(startOptions: { relayUrl?: string; webUrl?: string; publish?: "view" | "control" }) {
++			start(startOptions);
++			const next = new CollabHost(ctx);
++			await next.start(startOptions.relayUrl ?? "", startOptions.webUrl);
++			collabHost = next;
++		},
++		stop: vi.fn(),
++	} as unknown as CollabController;
++	Object.assign(ctx, { collabController });
+ 	return {
+ 		ctx,
++		start,
+ 		setText,
+ 		showStatus,
+ 		showError,
+@@ -88,7 +101,12 @@ describe("/collab slash command QR code rendering", () => {
+ 		expect(handled).toBe(true);
+ 		expect(harness.setText).toHaveBeenCalledWith("");
+ 		expect(startSpy).toHaveBeenCalledWith("wss://relay.example.com", "");
+-		expect(harness.ctx.collabHost).toBeInstanceOf(CollabHost);
++		expect(harness.start).toHaveBeenCalledWith({
++			relayUrl: "wss://relay.example.com",
++			webUrl: "",
++			publish: "control",
++		});
++		expect(harness.ctx.collabController.host).toBeInstanceOf(CollabHost);
+ 		const statusText = harness.showStatus.mock.calls[0]?.[0] as string;
+ 		expect(statusText).toContain("my.omp.sh/#started-full");
+ 		const presented = harness.present.mock.calls[0]?.[0] as readonly unknown[];
+@@ -107,7 +125,12 @@ describe("/collab slash command QR code rendering", () => {
+ 
+ 		expect(handled).toBe(true);
+ 		expect(startSpy).toHaveBeenCalledWith("wss://relay.example.com", "");
+-		expect(harness.ctx.collabHost).toBeInstanceOf(CollabHost);
++		expect(harness.start).toHaveBeenCalledWith({
++			relayUrl: "wss://relay.example.com",
++			webUrl: "",
++			publish: "view",
++		});
++		expect(harness.ctx.collabController.host).toBeInstanceOf(CollabHost);
+ 		const statusText = harness.showStatus.mock.calls[0]?.[0] as string;
+ 		expect(statusText).toContain("my.omp.sh/#started-view");
+ 		expect(statusText).not.toContain("my.omp.sh/#started-full");
 diff --git a/packages/coding-agent/src/collab/controller.ts b/packages/coding-agent/src/collab/controller.ts
 new file mode 100644
-index 000000000..356f1cf5c
+index 000000000..5c1a1a75f
 --- /dev/null
 +++ b/packages/coding-agent/src/collab/controller.ts
-@@ -0,0 +1,252 @@
+@@ -0,0 +1,266 @@
 +import { randomUUID } from "node:crypto";
 +import { basename } from "node:path";
 +import type { InteractiveModeContext } from "../modes/types";
@@ -64,6 +798,7 @@ index 000000000..356f1cf5c
 +	#queue: Promise<void> = Promise.resolve();
 +	#generation = 0;
 +	#manualSuspended = false;
++	#restartAfterSessionReplacement = false;
 +	#state: CollabControllerState = "stopped";
 +	#relayUrl = "";
 +
@@ -127,23 +862,36 @@ index 000000000..356f1cf5c
 +		});
 +	}
 +
-+	replaceActiveSession(): Promise<void> {
++	prepareActiveSessionReplacement(): Promise<void> {
 +		return this.#serialize(async () => {
-+			const hadHost = this.#host !== undefined;
++			this.#restartAfterSessionReplacement =
++				this.#restartAfterSessionReplacement || this.#host !== undefined || this.#autoMode() !== "off";
 +			await this.#stop("session changed", "session_changed");
 +			this.#manualSuspended = false;
-+			const mode = this.#autoMode();
-+			if (mode === "off" && !hadHost) return;
++		});
++	}
++
++	restoreActiveSession(): Promise<void> {
++		return this.#serialize(async () => {
++			const restart = this.#restartAfterSessionReplacement;
++			this.#restartAfterSessionReplacement = false;
++			if (!restart) return;
 +			try {
-+				await this.#start({ publish: mode });
++				await this.#start({ publish: this.#autoMode() });
 +			} catch {
 +				this.#context.showWarning("Collaboration did not restart for the active session.");
 +			}
 +		});
 +	}
 +
++	async replaceActiveSession(): Promise<void> {
++		await this.prepareActiveSessionReplacement();
++		await this.restoreActiveSession();
++	}
++
 +	shutdown(): Promise<void> {
 +		return this.#serialize(async () => {
++			this.#restartAfterSessionReplacement = false;
 +			const generation = this.#capabilities?.generation;
 +			await this.#stop("OMP shutdown", "shutdown");
 +			this.#publisher?.shutdown(generation);
@@ -256,36 +1004,6 @@ index 000000000..356f1cf5c
 +		return next;
 +	}
 +}
-diff --git a/packages/coding-agent/src/collab/host.ts b/packages/coding-agent/src/collab/host.ts
-index 74a021a80..8e19799c5 100644
---- a/packages/coding-agent/src/collab/host.ts
-+++ b/packages/coding-agent/src/collab/host.ts
-@@ -138,6 +138,8 @@ export class CollabHost {
- 	#busUnsubscribers: (() => void)[] = [];
- 	#registryUnsubscribe?: () => void;
- 	#stopped = false;
-+	/** Invoked after an unrecoverable relay close tears down this host. */
-+	onFatal?: (reason: string) => void;
- 
- 	constructor(ctx: InteractiveModeContext) {
- 		this.#ctx = ctx;
-@@ -245,7 +247,7 @@ export class CollabHost {
- 			if (willReconnect) {
- 				this.#ctx.showStatus(`Collab relay connection lost (${reason}), reconnecting…`, { dim: true });
- 			} else {
--				void this.#teardown();
-+				void this.#teardown().finally(() => this.onFatal?.(reason));
- 				this.#ctx.session.emitNotice("warning", `Collab ended: ${reason}`, "collab");
- 			}
- 		};
-@@ -314,7 +316,6 @@ export class CollabHost {
- 		this.#peers.clear();
- 		this.#socket?.close();
- 		this.#socket = null;
--		this.#ctx.collabHost = undefined;
- 		this.#ctx.statusLine.setCollabStatus(null);
- 		this.#ctx.ui.requestRender();
- 	}
 diff --git a/packages/coding-agent/src/collab/registry-publisher.ts b/packages/coding-agent/src/collab/registry-publisher.ts
 new file mode 100644
 index 000000000..a4ec68b7f
@@ -559,301 +1277,12 @@ index 000000000..a4ec68b7f
 +		this.#onSecurityError(message);
 +	}
 +}
-diff --git a/packages/coding-agent/src/config/settings-schema.ts b/packages/coding-agent/src/config/settings-schema.ts
-index 23b0e6800..78cfefa7c 100644
---- a/packages/coding-agent/src/config/settings-schema.ts
-+++ b/packages/coding-agent/src/config/settings-schema.ts
-@@ -1830,6 +1830,34 @@ export const SETTINGS_SCHEMA = {
- 	},
- 
- 	// Collab
-+	"collab.autoStart": {
-+		type: "enum",
-+		values: ["off", "view", "control"] as const,
-+		default: "off",
-+		ui: {
-+			tab: "interaction",
-+			group: "Collab",
-+			label: "Automatic Collaboration",
-+			description: "Start collaboration after interactive session initialization and publish view or control access",
-+			options: [
-+				{ value: "off", label: "Off" },
-+				{ value: "view", label: "View only" },
-+				{ value: "control", label: "View and control" },
-+			],
-+		},
-+	},
-+
-+	"collab.registryEndpoint": {
-+		type: "string",
-+		default: "auto",
-+		ui: {
-+			tab: "interaction",
-+			group: "Collab",
-+			label: "Session Gateway Registry",
-+			description: "Local IPC endpoint: auto, off, an absolute Unix socket, or a Windows named pipe",
-+		},
-+	},
-+
- 	"collab.relayUrl": {
- 		type: "string",
- 		default: DEFAULT_RELAY_URL,
-diff --git a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
-index fa75dd615..4d78bdb26 100644
---- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
-+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
-@@ -563,7 +563,7 @@ export class ExtensionUiController {
- 		questions: ExtensionAskDialogQuestion[],
- 		dialogOptions?: ExtensionUIDialogOptions,
- 	): Promise<ExtensionAskDialogResult | undefined> {
--		const host = this.ctx.collabHost;
-+		const host = this.ctx.collabController.host;
- 		if (!host) return this.#showLocalAskDialog(questions, dialogOptions);
- 		const localAbort = new AbortController();
- 		const remoteAbort = new AbortController();
-@@ -671,7 +671,7 @@ export class ExtensionUiController {
- 		signal: AbortSignal | undefined,
- 		local: (signal: AbortSignal | undefined) => Promise<string | undefined>,
- 	): Promise<string | undefined> {
--		const host = this.ctx.collabHost;
-+		const host = this.ctx.collabController.host;
- 		if (!host) return local(signal);
- 		const localAbort = new AbortController();
- 		const remoteAbort = new AbortController();
-@@ -811,7 +811,7 @@ export class ExtensionUiController {
- 	}
- 
- 	async #requestGuestUiString(request: CollabUiRequestDraft, signal: AbortSignal): Promise<GuestUiResult> {
--		const host = this.ctx.collabHost;
-+		const host = this.ctx.collabController.host;
- 		if (!host) return { kind: "unavailable" };
- 		const remote = host.requestGuestUi(request, signal);
- 		if (!remote) return { kind: "unavailable" };
-diff --git a/packages/coding-agent/src/modes/interactive-mode.ts b/packages/coding-agent/src/modes/interactive-mode.ts
-index 9d3a2a59a..afd39d9b3 100644
---- a/packages/coding-agent/src/modes/interactive-mode.ts
-+++ b/packages/coding-agent/src/modes/interactive-mode.ts
-@@ -53,8 +53,8 @@ import {
- } from "@oh-my-pi/pi-utils";
- import chalk from "chalk";
- import { reset as resetCapabilities } from "../capability";
-+import { CollabController } from "../collab/controller";
- import type { CollabGuestLink } from "../collab/guest";
--import type { CollabHost } from "../collab/host";
- import { KeybindingsManager } from "../config/keybindings";
- import type { ResolvedModelRoleValue } from "../config/model-resolver";
- import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
-@@ -532,7 +532,7 @@ export class InteractiveMode implements InteractiveModeContext {
- 	fileSlashCommands: Set<string> = new Set();
- 	skillCommands: Map<string, Skill> = new Map();
- 	oauthManualInput: OAuthManualInputManager = new OAuthManualInputManager();
--	collabHost?: CollabHost;
-+	readonly collabController: CollabController;
- 	collabGuest?: CollabGuestLink;
- 
- 	#pendingCommandOutput: Component[] = [];
-@@ -756,6 +756,7 @@ export class InteractiveMode implements InteractiveModeContext {
- 
- 		const skillCommandList = this.#rebuildSkillCommandsFromSession();
- 
-+		this.collabController = new CollabController(this);
- 		const builtinCommands = buildTuiBuiltinSlashCommands({ ctx: this });
- 		// Store pending commands for init() where file commands are loaded async
- 		this.#pendingSlashCommands = [...builtinCommands, ...hookCommands, ...customCommands, ...skillCommandList];
-@@ -992,7 +993,10 @@ export class InteractiveMode implements InteractiveModeContext {
- 		await this.initHooksAndCustomTools();
- 
- 		// Restore mode from session (e.g. plan mode on resume)
--		this.session.setSessionSwitchReconciler?.(() => this.#reconcileModeFromSession({ preserveActiveGoal: true }));
-+		this.session.setSessionSwitchReconciler?.(async () => {
-+			await this.collabController.replaceActiveSession();
-+			await this.#reconcileModeFromSession({ preserveActiveGoal: true });
-+		});
- 		await this.#reconcileModeFromSession();
- 
- 		// Brand-new sessions optionally start in plan mode when the user has made it
-@@ -1091,6 +1095,9 @@ export class InteractiveMode implements InteractiveModeContext {
- 		this.statusLine.watchBranch(() => {
- 			this.ui.requestRender();
- 		});
-+
-+		// Collaboration starts only after the interactive context and session are ready.
-+		await this.collabController.autoStart();
- 	}
- 
- 	/** Reload the title-generation system prompt override for the provided working
-@@ -3752,6 +3759,7 @@ export class InteractiveMode implements InteractiveModeContext {
- 	async shutdown(): Promise<void> {
- 		if (this.#isShuttingDown) return;
- 		this.#isShuttingDown = true;
-+		await this.collabController.shutdown();
- 
- 		this.#btwController.dispose();
- 		this.#omfgController.dispose();
-diff --git a/packages/coding-agent/src/modes/types.ts b/packages/coding-agent/src/modes/types.ts
-index 57ed56bb3..8d22f181a 100644
---- a/packages/coding-agent/src/modes/types.ts
-+++ b/packages/coding-agent/src/modes/types.ts
-@@ -2,8 +2,8 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
- import type { CompactionOutcome } from "@oh-my-pi/pi-agent-core/compaction";
- import type { AssistantMessage, ImageContent, Message, Usage, UsageReport } from "@oh-my-pi/pi-ai";
- import type { Component, Container, EditorTheme, Loader, Spacer, Text, TUI } from "@oh-my-pi/pi-tui";
-+import type { CollabController } from "../collab/controller";
- import type { CollabGuestLink } from "../collab/guest";
--import type { CollabHost } from "../collab/host";
- import type { KeybindingsManager } from "../config/keybindings";
- import type { Settings } from "../config/settings";
- import type {
-@@ -133,7 +133,7 @@ export interface InteractiveModeContext {
- 	historyStorage?: HistoryStorage;
- 	mcpManager?: MCPManager;
- 	lspServers?: LspStartupServerInfo[];
--	collabHost?: CollabHost;
-+	collabController: CollabController;
- 	collabGuest?: CollabGuestLink;
- 	eventController: EventController;
- 	eventBus?: EventBus;
-diff --git a/packages/coding-agent/src/slash-commands/builtin-registry.ts b/packages/coding-agent/src/slash-commands/builtin-registry.ts
-index b564b5471..52cf5ab6f 100644
---- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
-+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
-@@ -6,7 +6,7 @@ import { type AutocompleteItem, Spacer } from "@oh-my-pi/pi-tui";
- import { APP_NAME, getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
- import { reset as resetCapabilities } from "../capability";
- import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
--import { CollabHost } from "../collab/host";
-+import type { CollabHost } from "../collab/host";
- import { expandRoleAlias, getModelMatchPreferences, resolveCliModel } from "../config/model-resolver";
- import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
- import type { SettingPath, SettingValue } from "../config/settings";
-@@ -698,8 +698,8 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
- 		],
- 		allowArgs: true,
- 		getTuiAutocompleteDescription: runtime => {
--			if (runtime.ctx.collabHost) {
--				return `Collab: hosting (${Math.max(0, runtime.ctx.collabHost.participants.length - 1)} guests)`;
-+			if (runtime.ctx.collabController.host) {
-+				return `Collab: hosting (${Math.max(0, runtime.ctx.collabController.host.participants.length - 1)} guests)`;
- 			}
- 			if (runtime.ctx.collabGuest?.readOnly) return "Collab: read-only guest";
- 			if (runtime.ctx.collabGuest) return "Collab: guest";
-@@ -711,20 +711,22 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
- 			const args = command.args.trim();
- 			const { verb, rest } = parseSubcommand(args);
- 			if (verb === "stop") {
--				if (!ctx.collabHost) {
-+				if (!ctx.collabController.host) {
- 					ctx.showStatus("Not hosting a collab session");
- 					return;
- 				}
--				await ctx.collabHost.stop("host stopped");
-+				await ctx.collabController.stop("host stopped");
- 				ctx.showStatus("Collab stopped");
- 				return;
- 			}
- 			if (verb === "status") {
--				if (ctx.collabHost) {
--					const names = ctx.collabHost.participants.map(p =>
-+				if (ctx.collabController.host) {
-+					const names = ctx.collabController.host.participants.map(p =>
- 						p.role === "host" ? `${p.name} (host)` : p.readOnly ? `${p.name} (view-only)` : p.name,
- 					);
--					ctx.showStatus(`Collab: ${names.join(", ")} — ${collabWebLinkClickable(ctx.collabHost.webLink)}`);
-+					ctx.showStatus(
-+						`Collab: ${names.join(", ")} — ${collabWebLinkClickable(ctx.collabController.host.webLink)}`,
-+					);
- 				} else if (ctx.collabGuest) {
- 					ctx.showStatus(
- 						ctx.collabGuest.readOnly
-@@ -742,16 +744,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
- 			}
- 			const knownStartVerb = verb === "start" || verb === "view";
- 			const view = verb === "view";
--			if (ctx.collabHost) {
--				showCollabLink(
--					ctx,
--					ctx.collabHost,
--					view ? "Read-only collab session active" : "Collab session active",
--					view,
--				);
-+			const explicitUrl = knownStartVerb ? rest : args;
-+			const existingHost = ctx.collabController.host;
-+			if (existingHost && !explicitUrl) {
-+				showCollabLink(ctx, existingHost, view ? "Read-only collab session active" : "Collab session active", view);
- 				return;
- 			}
--			const explicitUrl = knownStartVerb ? rest : args;
- 			const relayInput = explicitUrl || ctx.settings.get("collab.relayUrl") || "";
- 			if (!relayInput) {
- 				ctx.showError(
-@@ -762,14 +760,17 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
- 			// Scheme-less relay args default to wss (ws:// must be spelled out for localhost).
- 			const relayUrl = relayInput.includes("://") ? relayInput : `wss://${relayInput}`;
- 			const webUrl = ctx.settings.get("collab.webUrl") || "";
--			const host = new CollabHost(ctx);
- 			try {
--				await host.start(relayUrl, webUrl);
-+				await ctx.collabController.start({ relayUrl, webUrl, publish: view ? "view" : "control" });
- 			} catch (err) {
- 				ctx.showError(`Failed to start collab session: ${errorMessage(err)}`);
- 				return;
- 			}
--			ctx.collabHost = host;
-+			const host = ctx.collabController.host;
-+			if (!host) {
-+				ctx.showError("Failed to start collab session");
-+				return;
-+			}
- 			showCollabLink(ctx, host, "Collab session started!", view);
- 		},
- 	},
-@@ -786,7 +787,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
- 				ctx.showError("Usage: /join <link>");
- 				return;
- 			}
--			if (ctx.collabHost) {
-+			if (ctx.collabController.host) {
- 				ctx.showError("Stop hosting first (/collab stop)");
- 				return;
- 			}
-@@ -805,7 +806,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
- 		name: "leave",
- 		description: "Leave the collab session",
- 		getTuiAutocompleteDescription: runtime => {
--			if (runtime.ctx.collabHost) return "Leave collab: hosting";
-+			if (runtime.ctx.collabController.host) return "Leave collab: hosting";
- 			if (runtime.ctx.collabGuest) return "Leave collab: guest";
- 			return "Leave collab: not in collab";
- 		},
-@@ -816,8 +817,8 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
- 				await ctx.collabGuest.leave("left");
- 				return;
- 			}
--			if (ctx.collabHost) {
--				await ctx.collabHost.stop("host stopped");
-+			if (ctx.collabController.host) {
-+				await ctx.collabController.stop("host stopped");
- 				ctx.showStatus("Collab stopped");
- 				return;
- 			}
-diff --git a/packages/coding-agent/test/collab/chunked-welcome.test.ts b/packages/coding-agent/test/collab/chunked-welcome.test.ts
-index 53d786845..ca6e17e5c 100644
---- a/packages/coding-agent/test/collab/chunked-welcome.test.ts
-+++ b/packages/coding-agent/test/collab/chunked-welcome.test.ts
-@@ -82,7 +82,6 @@ function makeHostContext(snapshot: SizedSnapshot): InteractiveModeContext {
- 		},
- 		ui: { requestRender: () => {} },
- 		showStatus: () => {},
--		collabHost: undefined,
- 	};
- 	return ctx as unknown as InteractiveModeContext;
- }
 diff --git a/packages/coding-agent/test/collab/controller.test.ts b/packages/coding-agent/test/collab/controller.test.ts
 new file mode 100644
-index 000000000..16c41027f
+index 000000000..368000987
 --- /dev/null
 +++ b/packages/coding-agent/test/collab/controller.test.ts
-@@ -0,0 +1,122 @@
+@@ -0,0 +1,128 @@
 +import { describe, expect, mock, test } from "bun:test";
 +import type { CollabPublisherRecord } from "../../src/collab/registry-publisher";
 +import type { InteractiveModeContext } from "../../src/modes/types";
@@ -943,10 +1372,16 @@ index 000000000..16c41027f
 +		expect(events).toEqual([{ type: "publish-view", generation: 1 }]);
 +	});
 +
-+	test("replacement revokes generation N before publishing N+1", async () => {
++	test("replacement revokes generation N before session mutation and publishes N+1 afterward", async () => {
 +		const { controller, events } = harness("control");
 +		await controller.autoStart();
-+		await controller.replaceActiveSession();
++		await controller.prepareActiveSessionReplacement();
++		expect(controller.state).toBe("stopped");
++		expect(events).toEqual([
++			{ type: "publish-control", generation: 1 },
++			{ type: "remove", generation: 1 },
++		]);
++		await controller.restoreActiveSession();
 +		expect(events).toEqual([
 +			{ type: "publish-control", generation: 1 },
 +			{ type: "remove", generation: 1 },
@@ -976,58 +1411,6 @@ index 000000000..16c41027f
 +		expect(controller.state).toBe("faulted");
 +	});
 +});
-diff --git a/packages/coding-agent/test/collab/guest-ui-request.test.ts b/packages/coding-agent/test/collab/guest-ui-request.test.ts
-index 76330b0d3..94b319882 100644
---- a/packages/coding-agent/test/collab/guest-ui-request.test.ts
-+++ b/packages/coding-agent/test/collab/guest-ui-request.test.ts
-@@ -472,7 +472,7 @@ function makeHostContext(): InteractiveModeContext {
- 		},
- 		ui: { requestRender: () => {} },
- 		showStatus: () => {},
--		collabHost: undefined,
-+		collabController: { host: undefined },
- 	} as unknown as InteractiveModeContext;
- }
- 
-@@ -650,7 +650,7 @@ describe("collab host dialog vs teardown (#4049 follow-up)", () => {
- 		const ctx = makeHostContext();
- 		const host = new CollabHost(ctx);
- 		await host.start("ws://localhost:8787");
--		ctx.collabHost = host;
-+		Object.assign(ctx.collabController, { host });
- 		const controller = new StubDialogController(ctx);
- 		const guest = await joinRawGuest(host.link, COLLAB_PROTO);
- 		const welcome = await guest.nextFrame();
-@@ -731,7 +731,7 @@ describe("guest ask unavailable literal answer (#4375)", () => {
- 		const ctx = makeHostContext();
- 		const host = new CollabHost(ctx);
- 		await host.start("ws://localhost:8787");
--		ctx.collabHost = host;
-+		Object.assign(ctx.collabController, { host });
- 		try {
- 			const guest = await joinRawGuest(host.link, COLLAB_PROTO);
- 			const welcome = await guest.nextFrame();
-@@ -815,7 +815,7 @@ describe("guest ask multi-select Next gating (#4375 PRRT_kwDOQxs0bc6OFbDW)", ()
- 		const ctx = makeAskHostContext();
- 		const host = new CollabHost(ctx);
- 		await host.start("ws://localhost:8787");
--		ctx.collabHost = host;
-+		Object.assign(ctx.collabController, { host });
- 		const controller = new ExtensionUiController(ctx);
- 		try {
- 			const guest = await joinRawGuest(host.link, COLLAB_PROTO);
-diff --git a/packages/coding-agent/test/collab/read-only.test.ts b/packages/coding-agent/test/collab/read-only.test.ts
-index 84a7dc006..0fa169eab 100644
---- a/packages/coding-agent/test/collab/read-only.test.ts
-+++ b/packages/coding-agent/test/collab/read-only.test.ts
-@@ -73,7 +73,6 @@ function makeHostContext(): HostHarness {
- 		},
- 		ui: { requestRender: () => {} },
- 		showStatus: () => {},
--		collabHost: undefined,
- 	} as unknown as InteractiveModeContext;
- 	const nextPrompt = (): Promise<{ from?: string }> => {
- 		const { promise, resolve } = Promise.withResolvers<{ from?: string }>();
 diff --git a/packages/coding-agent/test/collab/registry-publisher.test.ts b/packages/coding-agent/test/collab/registry-publisher.test.ts
 new file mode 100644
 index 000000000..05f76aa57
@@ -1083,30 +1466,6 @@ index 000000000..05f76aa57
 +	publisher.publish(record);
 +	publisher.shutdown(record.generation);
 +});
-diff --git a/packages/coding-agent/test/collab/replication-shrink.test.ts b/packages/coding-agent/test/collab/replication-shrink.test.ts
-index 9087cbfa7..3f5196133 100644
---- a/packages/coding-agent/test/collab/replication-shrink.test.ts
-+++ b/packages/coding-agent/test/collab/replication-shrink.test.ts
-@@ -178,7 +178,6 @@ function makeHostContext(snapshot: OversizedSnapshot): HostHarness {
- 		},
- 		ui: { requestRender: () => {} },
- 		showStatus: (msg: string) => statusMessages.push(msg),
--		collabHost: undefined,
- 	} as unknown as InteractiveModeContext;
- 	return { ctx, statusMessages };
- }
-diff --git a/packages/coding-agent/test/collab/steer-queue.test.ts b/packages/coding-agent/test/collab/steer-queue.test.ts
-index 0f76299fd..1dc189e26 100644
---- a/packages/coding-agent/test/collab/steer-queue.test.ts
-+++ b/packages/coding-agent/test/collab/steer-queue.test.ts
-@@ -127,7 +127,6 @@ function makeStreamingHostContext(): StreamingHostHarness {
- 		ui: { requestRender: () => {} },
- 		updatePendingMessagesDisplay: () => {},
- 		showStatus: () => {},
--		collabHost: undefined,
- 	} as unknown as InteractiveModeContext;
- 	const nextPrompt = (): Promise<CapturedPrompt> => {
- 		const { promise, resolve } = Promise.withResolvers<CapturedPrompt>();
 diff --git a/packages/coding-agent/test/config/collab-settings.test.ts b/packages/coding-agent/test/config/collab-settings.test.ts
 new file mode 100644
 index 000000000..ac6c9bf01
@@ -1121,98 +1480,3 @@ index 000000000..ac6c9bf01
 +	expect(getEnumValues("collab.autoStart")).toEqual(["off", "view", "control"]);
 +	expect(getDefault("collab.registryEndpoint")).toBe("auto");
 +});
-diff --git a/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts b/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts
-index 8a63482d0..171e7094e 100644
---- a/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts
-+++ b/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts
-@@ -1,4 +1,5 @@
- import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
-+import type { CollabController } from "@oh-my-pi/pi-coding-agent/collab/controller";
- import { CollabHost } from "@oh-my-pi/pi-coding-agent/collab/host";
- import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
- import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
-@@ -24,20 +25,17 @@ afterAll(() => {
- 	resetSettingsForTest();
- });
- 
--function fakeHost(options?: {
--	webLink?: string;
--	webViewLink?: string;
--}): NonNullable<InteractiveModeContext["collabHost"]> {
-+function fakeHost(options?: { webLink?: string; webViewLink?: string }): CollabHost {
- 	return {
- 		link: "relay.example.com/r/full-control",
- 		viewLink: "relay.example.com/r/read-only",
- 		webLink: options?.webLink ?? "https://my.omp.sh/#full-control",
- 		webViewLink: options?.webViewLink ?? "https://my.omp.sh/#read-only",
- 		participants: [{ name: "host", role: "host" }],
--	} as unknown as NonNullable<InteractiveModeContext["collabHost"]>;
-+	} as unknown as CollabHost;
- }
- 
--function createRuntimeHarness(options?: { collabHost?: NonNullable<InteractiveModeContext["collabHost"]> }) {
-+function createRuntimeHarness(options?: { collabHost?: CollabHost }) {
- 	const setText = vi.fn();
- 	const showStatus = vi.fn();
- 	const showError = vi.fn();
-@@ -47,16 +45,31 @@ function createRuntimeHarness(options?: { collabHost?: NonNullable<InteractiveMo
- 		if (key === "collab.webUrl") return "";
- 		return "";
- 	});
-+	let collabHost = options?.collabHost;
- 	const ctx = {
- 		editor: { setText },
- 		showStatus,
- 		showError,
- 		present,
- 		settings: { get: settingsGet },
--		collabHost: options?.collabHost,
- 	} as unknown as InteractiveModeContext;
-+	const start = vi.fn();
-+	const collabController = {
-+		get host() {
-+			return collabHost;
-+		},
-+		async start(startOptions: { relayUrl?: string; webUrl?: string; publish?: "view" | "control" }) {
-+			start(startOptions);
-+			const next = new CollabHost(ctx);
-+			await next.start(startOptions.relayUrl ?? "", startOptions.webUrl);
-+			collabHost = next;
-+		},
-+		stop: vi.fn(),
-+	} as unknown as CollabController;
-+	Object.assign(ctx, { collabController });
- 	return {
- 		ctx,
-+		start,
- 		setText,
- 		showStatus,
- 		showError,
-@@ -88,7 +101,12 @@ describe("/collab slash command QR code rendering", () => {
- 		expect(handled).toBe(true);
- 		expect(harness.setText).toHaveBeenCalledWith("");
- 		expect(startSpy).toHaveBeenCalledWith("wss://relay.example.com", "");
--		expect(harness.ctx.collabHost).toBeInstanceOf(CollabHost);
-+		expect(harness.start).toHaveBeenCalledWith({
-+			relayUrl: "wss://relay.example.com",
-+			webUrl: "",
-+			publish: "control",
-+		});
-+		expect(harness.ctx.collabController.host).toBeInstanceOf(CollabHost);
- 		const statusText = harness.showStatus.mock.calls[0]?.[0] as string;
- 		expect(statusText).toContain("my.omp.sh/#started-full");
- 		const presented = harness.present.mock.calls[0]?.[0] as readonly unknown[];
-@@ -107,7 +125,12 @@ describe("/collab slash command QR code rendering", () => {
- 
- 		expect(handled).toBe(true);
- 		expect(startSpy).toHaveBeenCalledWith("wss://relay.example.com", "");
--		expect(harness.ctx.collabHost).toBeInstanceOf(CollabHost);
-+		expect(harness.start).toHaveBeenCalledWith({
-+			relayUrl: "wss://relay.example.com",
-+			webUrl: "",
-+			publish: "view",
-+		});
-+		expect(harness.ctx.collabController.host).toBeInstanceOf(CollabHost);
- 		const statusText = harness.showStatus.mock.calls[0]?.[0] as string;
- 		expect(statusText).toContain("my.omp.sh/#started-view");
- 		expect(statusText).not.toContain("my.omp.sh/#started-full");

--- a/patches/oh-my-pi/README.md
+++ b/patches/oh-my-pi/README.md
@@ -8,8 +8,8 @@ It:
 1. makes one `CollabController` own manual and automatic collaboration;
 2. adds backward-compatible `collab.autoStart` and local-only `collab.registryEndpoint` settings;
 3. publishes view/control capabilities to the authenticated local registry without blocking normal OMP operation;
-4. revokes the prior generation before active-session replacement and on stop, shutdown, or fatal host failure; and
-5. adds controller, publisher-safety, and setting-default tests.
+4. revokes generation N before active-session mutation, publishes generation N+1 only after the replacement is active, and unregisters on stop, shutdown, or fatal host failure; and
+5. adds controller, publisher-safety, setting-default, and session-mutation ordering tests.
 
 Apply from the OMP repository root:
 
@@ -18,7 +18,8 @@ git apply --check /path/to/0001-collab-controller-autostart-registry.patch
 git apply /path/to/0001-collab-controller-autostart-registry.patch
 bun test packages/coding-agent/test/collab/controller.test.ts \
   packages/coding-agent/test/collab/registry-publisher.test.ts \
-  packages/coding-agent/test/config/collab-settings.test.ts
+  packages/coding-agent/test/config/collab-settings.test.ts \
+  packages/coding-agent/test/agent-session-bash-session-ownership.test.ts
 ```
 
 The patch was applied and qualified in a complete checkout at the pinned commit. `bun run ci:check:full`

--- a/scripts/build-release.ts
+++ b/scripts/build-release.ts
@@ -16,6 +16,89 @@ interface ArchiveFile {
   readonly executable: boolean;
 }
 
+type BunLockPackage = readonly [
+  resolution: string,
+  registry?: string,
+  metadata?: Readonly<Record<string, unknown>>,
+  integrity?: string,
+];
+
+interface BunLockfile {
+  readonly packages: Readonly<Record<string, BunLockPackage>>;
+}
+
+async function createSpdxSbom(): Promise<string> {
+  const lock = Bun.JSONC.parse(await Bun.file(join(root, "bun.lock")).text()) as BunLockfile;
+  const dependencies = Object.entries(lock.packages)
+    .filter(([, entry]) => !entry[0].includes("@workspace:"))
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, entry], index) => {
+      const resolution = entry[0];
+      const version = resolution.slice(resolution.lastIndexOf("@") + 1);
+      const integrity = entry[3];
+      return {
+        name,
+        SPDXID: `SPDXRef-Dependency-${index + 1}`,
+        versionInfo: version,
+        downloadLocation: "NOASSERTION",
+        filesAnalyzed: false,
+        licenseConcluded: "NOASSERTION",
+        licenseDeclared: "NOASSERTION",
+        copyrightText: "NOASSERTION",
+        ...(integrity?.startsWith("sha512-")
+          ? {
+              checksums: [
+                {
+                  algorithm: "SHA512",
+                  checksumValue: Buffer.from(integrity.slice("sha512-".length), "base64")
+                    .toString("hex")
+                    .toUpperCase(),
+                },
+              ],
+            }
+          : {}),
+      };
+    });
+  const rootPackage = {
+    name: "omp-session-gateway",
+    SPDXID: "SPDXRef-Package-Root",
+    versionInfo: PRODUCT_VERSION,
+    downloadLocation: "NOASSERTION",
+    filesAnalyzed: false,
+    licenseConcluded: "MIT",
+    licenseDeclared: "MIT",
+    copyrightText: "NOASSERTION",
+  };
+  return `${JSON.stringify(
+    {
+      spdxVersion: "SPDX-2.3",
+      dataLicense: "CC0-1.0",
+      SPDXID: "SPDXRef-DOCUMENT",
+      name: `omp-session-gateway-${PRODUCT_VERSION}`,
+      documentNamespace: `https://github.com/alphastorm/omp-session-gateway/sbom/${PRODUCT_VERSION}`,
+      creationInfo: {
+        created: "1970-01-01T00:00:00Z",
+        creators: ["Tool: omp-session-gateway deterministic release builder"],
+      },
+      packages: [rootPackage, ...dependencies],
+      relationships: [
+        {
+          spdxElementId: "SPDXRef-DOCUMENT",
+          relationshipType: "DESCRIBES",
+          relatedSpdxElement: rootPackage.SPDXID,
+        },
+        ...dependencies.map(dependency => ({
+          spdxElementId: rootPackage.SPDXID,
+          relationshipType: "DEPENDS_ON",
+          relatedSpdxElement: dependency.SPDXID,
+        })),
+      ],
+    },
+    null,
+    2,
+  )}\n`;
+}
+
 
 async function run(command: readonly string[]): Promise<void> {
   const subprocess = Bun.spawn([...command], { cwd: root, stdin: "ignore", stdout: "inherit", stderr: "inherit" });
@@ -79,6 +162,8 @@ await run([process.execPath, "scripts/build-web.ts"]);
 await rm(releaseRoot, { recursive: true, force: true });
 await mkdir(releaseRoot, { recursive: true });
 const staging = await mkdtemp(join(tmpdir(), "omp-session-gateway-release-"));
+const sbomName = `omp-session-gateway-${PRODUCT_VERSION}.spdx.json`;
+const sbom = await createSpdxSbom();
 try {
   const cliDirectory = join(staging, "apps", "gateway", "src");
   await mkdir(cliDirectory, { recursive: true });
@@ -133,6 +218,7 @@ try {
       2,
     )}\n`,
   );
+  await writeFile(join(staging, "SBOM.spdx.json"), sbom);
   const files = await archiveFiles(staging);
   for (const file of files) {
     if (file.path.endsWith(".map")) throw new Error("release archive must not contain source maps");
@@ -144,10 +230,16 @@ try {
   const archive = Buffer.concat([...files.map(tarEntry), Buffer.alloc(1_024)]);
   const archiveName = `${archiveBase}.tar`;
   await writeFile(join(releaseRoot, archiveName), archive);
-  const digest = createHash("sha256").update(archive).digest("hex");
-  await writeFile(join(releaseRoot, "SHA256SUMS"), `${digest}  ${archiveName}\n`);
+  await writeFile(join(releaseRoot, sbomName), sbom);
+  const archiveDigest = createHash("sha256").update(archive).digest("hex");
+  const sbomDigest = createHash("sha256").update(sbom).digest("hex");
+  await writeFile(
+    join(releaseRoot, "SHA256SUMS"),
+    `${archiveDigest}  ${archiveName}\n${sbomDigest}  ${sbomName}\n`,
+  );
   const archiveInfo = await stat(join(releaseRoot, archiveName));
   console.log(`built ${relative(root, join(releaseRoot, archiveName))} (${archiveInfo.size} bytes)`);
+  console.log(`wrote ${relative(root, join(releaseRoot, sbomName))}`);
   console.log(`wrote ${relative(root, join(releaseRoot, "SHA256SUMS"))}`);
 } finally {
   await rm(staging, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- repair OMP collaboration generation ordering and mobile relay reconnection in the pinned patch/client
- enforce Windows current-user/SYSTEM ACLs and UTF-16 scheduled-task installation
- add authenticated, exact-origin loopback shutdown for process-clean token rotation, reinstall, and uninstall
- add hosted Windows lifecycle qualification and deterministic SPDX release inventory
- update compatibility, release-status, and handoff evidence

## Threat-model impact
The new shutdown control is loopback-only, requires the 256-bit publisher token, validates the configured exact Origin and same-origin fetch metadata, accepts no body/query, returns no-store, and never logs the token. Windows secret files now reject ACLs beyond the current user and SYSTEM. Capabilities remain in memory only.

## Verification
- `bun run check` — 39 tests across nine files, four typechecks, production builds, handoff and leak scans passed
- `bun audit` — no vulnerabilities
- Platform qualification run 29715302992 — Windows ACLs, scheduled task, health, token rotation, PID replacement, reinstall, and process-clean uninstall passed
- prior recorded macOS, Linux-container, real Tailscale, desktop relay/browser, and pinned OMP lifecycle qualification retained in `HANDOFF_MANIFEST.md`

Pre-alpha remains NO-GO pending physical Android, signed candidate/rollback qualification, and the running eight-hour default-relay soak.