### PR TITLE
docs: compare gateway with omp-deck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
 - Qualified the final source-review-hardened OMP patch in the complete pinned upstream checkout; checks and every official TypeScript test bucket passed with documented upstream-baseline exclusions restored afterward.
 - Completed an eight-hour default-relay endurance run: the read-only client remained connected for 28,804 seconds and finished in the live phase.
 - Published and independently verified the immutable provenance-test `provenance-test-v0.1.0.8` from the post-soak `main` commit, including deterministic archive/SBOM/checksum reproduction, GitHub build attestations, Cosign bundles, and immutable release-asset attestations.
+- Documented the distinct product boundaries and best-fit workflows for OMP Session Gateway and `omp-deck` without presenting either as a universal replacement.
 
 - Made production install a config/service/runtime transaction with prior-endpoint checks, instance-bound HMAC readiness, verified legacy-runtime rollback, exact external Serve-port guidance, and recovery uninstall that does not require a readable application config.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@ The v1 path is therefore:
 - optional Trusted Web Activity packaging later; and
 - no independent native implementation of OMP's collaboration protocol.
 
+## How this differs from `omp-deck`
+
+[OMP Session Gateway](https://github.com/alphastorm/omp-session-gateway) and
+[`omp-deck`](https://libraries.io/npm/omp-deck) address different workflows rather than competing
+for the same product boundary. The comparison below reflects `omp-deck` 0.6.0's published package
+description; check its current documentation before choosing.
+
+| | OMP Session Gateway | `omp-deck` 0.6.0 |
+|---|---|---|
+| Primary job | Private, zero-touch discovery and launch for already-running interactive terminal OMP processes | A browser cockpit that embeds the OMP SDK and owns the surrounding agent workflow |
+| Session experience | Opens OMP's existing encrypted `collab-web` client for View or Control | Provides its own multi-session chat surface |
+| Additional state | Keeps only live session metadata and capabilities in daemon memory; does not store transcripts | Adds persisted sessions plus kanban, inbox, knowledge-base, routines, marketplace, and messaging features |
+| Remote-access opinion | Loopback gateway behind Tailscale Serve with an exact identity allowlist; no public fallback | Loopback by default, with Tailscale, SSH tunnel, or an authenticated reverse proxy described by its package documentation |
+| Best fit | The terminal remains the source of truth and the phone needs the smallest possible session directory and capability broker | The browser should be a persistent work cockpit with project-management and automation features around the agent |
+
+Choose OMP Session Gateway when the desired change is narrowly: “make every current terminal OMP
+session safely reachable from my phone without copying links.” Choose `omp-deck` when the desired
+change is a broader browser-first operating environment for agent work. The gateway is intentionally
+not a chat rewrite, task system, routine engine, knowledge base, or messaging hub; reusing
+`collab-web` is the point.
+
 ## Security model
 
 OMP collaboration links are bearer capabilities. The implementation treats both view and control links as secrets.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -18,7 +18,7 @@
 - [x] Secret leak test harness.
 - [ ] Android and lifecycle E2E suite.
 - [x] Install, doctor, uninstall, token rotation.
-- [ ] Update the README with a neutral comparison to [`omp-deck`](https://libraries.io/npm/omp-deck): explain that OMP Session Gateway is a minimal tailnet session directory and capability broker for already-running terminal OMP processes that reuses OMP's existing `collab-web`, rather than a persistent full agent cockpit with its own chat, task board, routines, knowledge base, and messaging integrations; state when each approach is the better fit.
+- [x] Update the README with a neutral comparison to [`omp-deck`](https://libraries.io/npm/omp-deck): explain that OMP Session Gateway is a minimal tailnet session directory and capability broker for already-running terminal OMP processes that reuses OMP's existing `collab-web`, rather than a persistent full agent cockpit with its own chat, task board, routines, knowledge base, and messaging integrations; state when each approach is the better fit.
 
 ## v1.1 candidates
 


### PR DESCRIPTION
## Summary

- replace the tracked README TODO with a neutral product-boundary comparison to `omp-deck` 0.6.0
- explain that OMP Session Gateway discovers and brokers capabilities for already-running terminal OMP processes, then reuses OMP's encrypted `collab-web` client
- contrast that narrow path with `omp-deck`'s published browser-cockpit scope: embedded SDK, own chat, persisted sessions, kanban, inbox, knowledge base, routines, marketplace, and messaging
- state when each approach is the better fit without claiming affiliation, superiority, or interoperability

## Evidence

- source reviewed: https://libraries.io/npm/omp-deck/0.6.0
- `bun run validate:handoff` passed before commit
- clean-checkout `bun run check` passed: 80 tests/303 assertions across 15 files, four workspace typechecks, production build, handoff validation, capability-leak scan

## Threat-model impact

Documentation only. No capability flow, authentication boundary, persistence behavior, listener, or release artifact changes.
