### PR TITLE
fix: correct release install command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
 
           ### Install or upgrade
 
-          Extract \`omp-session-gateway-${PACKAGE_VERSION}-bun.tar\`, then run \`bun apps/gateway/src/cli.js install\` from the extracted directory. Active reinstall preserves the existing gateway configuration and publisher token. Reload or reopen the canonical PWA, then tap **Enable background alerts** and accept the browser permission prompt.
+          Extract \`omp-session-gateway-${PACKAGE_VERSION}-bun.tar\`, then run \`bun apps/gateway/src/cli.js install --origin https://host.tailnet.ts.net --allow user@example.com\` from the extracted directory, replacing both values with the existing canonical origin and allowed identity. Repeat \`--allow\` for additional identities. Active reinstall with the same values preserves the publisher token. Reload or reopen the canonical PWA, then tap **Enable background alerts** and accept the browser permission prompt.
 
           ### Compatibility and known issues
 
@@ -170,7 +170,7 @@ jobs:
 
           ### Rollback
 
-          Reinstall the signed \`v0.1.0-prealpha.5\` archive with the same command. The older gateway ignores the private Push state; existing configuration and publisher credentials remain valid.
+          To remove background Push, reinstall the signed \`v0.1.0-prealpha.5\` archive with \`bun apps/gateway/src/cli.js install --origin https://host.tailnet.ts.net --allow user@example.com\`, using the deployment's real values. The older gateway ignores the private Push state; existing publisher credentials remain valid.
 
           Verification instructions: [docs/RELEASE.md](https://github.com/$GITHUB_REPOSITORY/blob/$GITHUB_SHA/docs/RELEASE.md).
           EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
 
 ## [Unreleased]
 
+## [0.1.0-prealpha.7] - 2026-07-24
+
+### Fixed
+
+- Correct the release install/upgrade and rollback instructions to include the CLI's required `--origin` and `--allow` values. The signed `v0.1.0-prealpha.6` artifact remains valid, but its published install command was incomplete.
+
 ## [0.1.0-prealpha.6] - 2026-07-24
 
 ### Added

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -1,7 +1,7 @@
 # Release status
 
 **Updated:** 2026-07-24<br>
-**Repository version:** `0.1.0` (`v0.1.0-prealpha.6`; no alpha)<br>
+**Repository version:** `0.1.0` (`v0.1.0-prealpha.7`; no alpha)<br>
 **Classification:** implemented pre-alpha<br>
 **Alpha decision:** **NO-GO**<br>
 **Advertised host/client platforms:** none


### PR DESCRIPTION
## Problem

The immutable `v0.1.0-prealpha.6` release notes omitted the required `--origin` and `--allow` arguments from `omp-gateway install`. The signed artifact is valid, but copying that command fails before changing the installation.

## Fix

- publish corrected explicit install/upgrade and rollback commands
- record `v0.1.0-prealpha.7` as the correction release
- retain the same background Web Push implementation and security boundary

## Verification

- reproduced the incomplete command failure: `install requires --origin https://host.tailnet.ts.net`
- installed the signed prealpha.6 artifact successfully with the existing canonical origin and allowlisted identity
- `bun run check` — 105 tests, 561 assertions, capability-leak scan passed

Pre-alpha only; physical Android background-Push qualification remains open.