### PR TITLE
fix: show explicit Ask recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
 
 ## [Unreleased]
 
+### Fixed
+
+- Show an accent `Recommended` badge on the explicitly recommended option while an Ask request is awaiting a remote Control response, including late joins, without treating OMP's default selection index as a recommendation.
+
 
 ## [0.1.0-prealpha.8] - 2026-07-25
 

--- a/apps/web/e2e/fixture-server.ts
+++ b/apps/web/e2e/fixture-server.ts
@@ -17,6 +17,10 @@ const MIME_TYPES: Readonly<Record<string, string>> = {
 };
 const distRoot = resolve(fileURLToPath(new URL("../dist/", import.meta.url)));
 
+export interface DashboardFixtureOptions {
+  readonly roomKey?: Uint8Array;
+}
+
 export interface DashboardFixture {
   readonly origin: string;
   readonly requests: readonly string[];
@@ -30,6 +34,7 @@ export interface DashboardFixture {
 
 export async function startDashboardFixture(
   initialSessions: readonly SessionMetadata[],
+  options: DashboardFixtureOptions = {},
 ): Promise<DashboardFixture> {
   const sessions = new Map(initialSessions.map(session => [session.instanceId, session]));
   const streams = new Set<ServerResponse>();
@@ -37,7 +42,8 @@ export async function startDashboardFixture(
   let serviceWorkerVersion = 0;
   let revision = 1;
   const roomId = randomBytes(16).toString("base64url");
-  const roomKey = randomBytes(32);
+  const roomKey = options.roomKey === undefined ? randomBytes(32) : Buffer.from(options.roomKey);
+  if (roomKey.byteLength !== 32) throw new Error("dashboard fixture room key must be 32 bytes");
   const viewCapability = `${roomId}.${roomKey.toString("base64url")}`;
   const controlCapability = `${roomId}.${Buffer.concat([roomKey, randomBytes(16)]).toString("base64url")}`;
 

--- a/apps/web/e2e/launch.e2e.ts
+++ b/apps/web/e2e/launch.e2e.ts
@@ -115,3 +115,139 @@ test("installed-PWA View and Control mount in the current window without losing 
     await fixture.stop();
   }
 });
+
+test("active ask marks only the explicit recommended option", async ({ page }) => {
+  const roomKey = new Uint8Array(32).fill(37);
+  const fixture = await startDashboardFixture([session()], { roomKey });
+
+  try {
+    await page.addInitScript(({ keyBytes }) => {
+      const question = "How should ADR-0036 proceed?";
+      const options = [
+        { label: "Implement ADR-0036 locally", description: "Apply the compatibility fix in Alpha Founder." },
+        { label: "Wait for upstream", description: "Leave the current behavior unchanged." },
+      ];
+      const args = {
+        questions: [{ id: "adr-0036", question, options, multi: false, recommended: 0 }],
+      };
+      const key = crypto.subtle.importKey("raw", new Uint8Array(keyBytes), "AES-GCM", false, ["encrypt"]);
+      const encoder = new TextEncoder();
+
+      class AskWebSocket {
+        static readonly CONNECTING = 0;
+        static readonly OPEN = 1;
+        static readonly CLOSING = 2;
+        static readonly CLOSED = 3;
+        readonly url: string;
+        readyState = AskWebSocket.CONNECTING;
+        binaryType: BinaryType = "arraybuffer";
+        onopen: ((event: Event) => void) | null = null;
+        onmessage: ((event: MessageEvent) => void) | null = null;
+        onerror: ((event: Event) => void) | null = null;
+        onclose: ((event: CloseEvent) => void) | null = null;
+        sentWelcome = false;
+
+        constructor(url: string) {
+          this.url = url;
+          queueMicrotask(() => {
+            this.readyState = AskWebSocket.OPEN;
+            this.onopen?.(new Event("open"));
+          });
+        }
+
+        close(): void {
+          this.readyState = AskWebSocket.CLOSED;
+        }
+
+        send(): void {
+          if (this.sentWelcome) return;
+          this.sentWelcome = true;
+          void this.sendHostFrames();
+        }
+
+        async sendHostFrames(): Promise<void> {
+          const assistantEntry = {
+            id: "ask-entry",
+            parentId: null,
+            timestamp: "2026-07-25T00:00:00.000Z",
+            type: "message",
+            message: {
+              role: "assistant",
+              content: [{ type: "toolCall", id: "ask-active", name: "ask", arguments: args }],
+              model: "test/model",
+              usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { total: 0 } },
+              stopReason: "toolUse",
+              timestamp: 0,
+            },
+          };
+          const frames = [
+            {
+              t: "welcome",
+              proto: 3,
+              header: {
+                type: "session",
+                id: "ask-browser-smoke",
+                title: "Recommended ask browser smoke",
+                timestamp: "2026-07-25T00:00:00.000Z",
+                cwd: "/test",
+              },
+              state: {
+                isStreaming: true,
+                queuedMessageCount: 0,
+                cwd: "/test",
+                participants: [{ name: "host", role: "host" }],
+              },
+              agents: [],
+              entryCount: 1,
+              readOnly: false,
+            },
+            { t: "snapshot-chunk", entries: [assistantEntry], final: true },
+            {
+              t: "event",
+              event: { type: "tool_execution_start", toolCallId: "ask-active", toolName: "ask", args },
+            },
+            {
+              t: "ui-request",
+              request: {
+                reqId: 7,
+                kind: "select",
+                title: question,
+                options,
+                initialIndex: 0,
+                selectionMarker: "radio",
+              },
+            },
+          ];
+          for (const frame of frames) {
+            const iv = crypto.getRandomValues(new Uint8Array(12));
+            const ciphertext = new Uint8Array(
+              await crypto.subtle.encrypt({ name: "AES-GCM", iv }, await key, encoder.encode(JSON.stringify(frame))),
+            );
+            const envelope = new Uint8Array(4 + iv.byteLength + ciphertext.byteLength);
+            new DataView(envelope.buffer).setUint32(0, 1, false);
+            envelope.set(iv, 4);
+            envelope.set(ciphertext, 4 + iv.byteLength);
+            this.onmessage?.(new MessageEvent("message", { data: envelope.buffer }));
+          }
+        }
+      }
+
+      Object.defineProperty(globalThis, "WebSocket", { configurable: true, value: AskWebSocket });
+    }, { keyBytes: [...roomKey] });
+
+    await page.goto(fixture.origin);
+    await page.getByRole("button", { name: "Open request" }).click();
+
+    const recommended = page.locator(".sh-ask-option-recommended");
+    await expect(recommended).toHaveText("Recommended");
+    await expect(recommended).toHaveCount(1);
+    await expect(
+      page.locator(".sh-ask-option").filter({ hasText: "Implement ADR-0036 locally" }).locator(".sh-ask-option-recommended"),
+    ).toHaveText("Recommended");
+    await expect(
+      page.locator(".sh-ask-option").filter({ hasText: "Wait for upstream" }).locator(".sh-ask-option-recommended"),
+    ).toHaveCount(0);
+  } finally {
+    await fixture.stop();
+  }
+});

--- a/packages/collab-client/test/composer.test.ts
+++ b/packages/collab-client/test/composer.test.ts
@@ -1,0 +1,116 @@
+import type { AssistantMessage, SessionEntry } from "@oh-my-pi/pi-wire";
+import { describe, expect, test } from "bun:test";
+import { recommendedOptionIndex } from "../upstream/src/components/shell/ask-recommendation";
+import type { ActiveTool, GuestSnapshot } from "../upstream/src/lib/client";
+
+const QUESTION = "How should ADR-0036 proceed?";
+const OPTIONS = [
+  { label: "Implement ADR-0036 locally", description: "Apply the compatibility fix in Alpha Founder." },
+  { label: "Wait for upstream", description: "Leave the current behavior unchanged." },
+];
+
+function askArgs(recommended?: number): Record<string, unknown> {
+  return {
+    questions: [
+      {
+        id: "adr-0036",
+        question: QUESTION,
+        options: OPTIONS,
+        multi: false,
+        ...(recommended === undefined ? {} : { recommended }),
+      },
+    ],
+  };
+}
+
+function assistantEntry(toolCallId: string, args: Record<string, unknown>): SessionEntry {
+  const message: AssistantMessage = {
+    role: "assistant",
+    content: [{ type: "toolCall", id: toolCallId, name: "ask", arguments: args }],
+    model: "test/model",
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { total: 0 } },
+    stopReason: "toolUse",
+    timestamp: 0,
+  };
+  return {
+    id: `entry-${toolCallId}`,
+    parentId: null,
+    timestamp: "2026-07-25T00:00:00.000Z",
+    type: "message",
+    message,
+  };
+}
+
+function toolResultEntry(toolCallId: string): SessionEntry {
+  return {
+    id: `result-${toolCallId}`,
+    parentId: `entry-${toolCallId}`,
+    timestamp: "2026-07-25T00:00:01.000Z",
+    type: "message",
+    message: {
+      role: "toolResult",
+      toolCallId,
+      toolName: "ask",
+      content: [{ type: "text", text: "answered" }],
+      isError: false,
+      timestamp: 1,
+    },
+  };
+}
+
+function activeAsk(toolCallId: string, args: Record<string, unknown>): ActiveTool {
+  return { toolCallId, toolName: "ask", args, startedAt: 0 };
+}
+
+function snapshot(overrides: Partial<GuestSnapshot> = {}): GuestSnapshot {
+  return {
+    phase: "live",
+    endedReason: null,
+    header: null,
+    entries: [],
+    state: null,
+    agents: [],
+    progress: new Map(),
+    lifecycle: new Map(),
+    stream: null,
+    streamDone: false,
+    activeTools: new Map(),
+    working: true,
+    readOnly: false,
+    uiRequest: {
+      reqId: 7,
+      kind: "select",
+      title: QUESTION,
+      options: OPTIONS,
+      initialIndex: 0,
+      selectionMarker: "radio",
+    },
+    notices: [],
+    ...overrides,
+  };
+}
+
+describe("collaboration ask recommendations", () => {
+  test("finds an explicit recommendation on the matching active option", () => {
+    const current = snapshot({
+      activeTools: new Map([["ask-active", activeAsk("ask-active", askArgs(0))]]),
+    });
+
+    expect(recommendedOptionIndex(current)).toBe(0);
+  });
+
+  test("recovers recommendation metadata from an unresolved persisted tool call after late join", () => {
+    const current = snapshot({ entries: [assistantEntry("ask-persisted", askArgs(1))] });
+
+    expect(recommendedOptionIndex(current)).toBe(1);
+  });
+
+  test("does not mistake initialIndex or a resolved historical ask for a recommendation", () => {
+    const current = snapshot({
+      entries: [assistantEntry("ask-old", askArgs(0)), toolResultEntry("ask-old")],
+      activeTools: new Map([["ask-current", activeAsk("ask-current", askArgs())]]),
+    });
+
+    expect(recommendedOptionIndex(current)).toBeUndefined();
+  });
+});

--- a/packages/collab-client/upstream/UPSTREAM.json
+++ b/packages/collab-client/upstream/UPSTREAM.json
@@ -15,6 +15,7 @@
     "Force a fresh relay transport after mobile foreground and online transitions",
     "Recover established guests across bounded relay room replacement",
     "Preserve strict exact-optional typing for view links without a write token",
-    "Redact invalid capability input from collaboration-link errors"
+    "Redact invalid capability input from collaboration-link errors",
+    "Correlate active Ask requests with explicit tool-call recommendation metadata"
   ]
 }

--- a/packages/collab-client/upstream/src/components/shell/Composer.tsx
+++ b/packages/collab-client/upstream/src/components/shell/Composer.tsx
@@ -1,7 +1,8 @@
 import { SendHorizontal, Square } from "lucide-react";
 import type { KeyboardEvent, ReactNode } from "react";
-import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { GuestClient, GuestSnapshot } from "../../lib/client";
+import { recommendedOptionIndex } from "./ask-recommendation";
 
 export interface ComposerProps {
 	client: GuestClient;
@@ -83,6 +84,10 @@ export function Composer({ client, snapshot }: ComposerProps): ReactNode {
 	const busy = snapshot.working || (snapshot.state?.isStreaming ?? false);
 	const queued = snapshot.state?.queuedMessageCount ?? 0;
 	const canSend = canPrompt && text.trim().length > 0;
+	const recommendedIndex = useMemo(
+		() => recommendedOptionIndex(snapshot),
+		[uiRequest, snapshot.entries, snapshot.stream, snapshot.activeTools],
+	);
 
 	useLayoutEffect(() => {
 		autosize(taRef.current);
@@ -122,7 +127,10 @@ export function Composer({ client, snapshot }: ComposerProps): ReactNode {
 										{uiRequest.selectionMarker === "checkbox" ? (checked ? "☑" : "☐") : checked ? "◉" : "○"}
 									</span>
 									<span className="sh-ask-option-copy">
-										<span className="sh-ask-option-label">{label}</span>
+										<span className="sh-ask-option-heading">
+											<span className="sh-ask-option-label">{label}</span>
+											{index === recommendedIndex && <span className="sh-ask-option-recommended">Recommended</span>}
+										</span>
 										{typeof option !== "string" && option.description && (
 											<span className="sh-ask-option-description">{option.description}</span>
 										)}

--- a/packages/collab-client/upstream/src/components/shell/ask-recommendation.ts
+++ b/packages/collab-client/upstream/src/components/shell/ask-recommendation.ts
@@ -1,0 +1,124 @@
+import type { GuestSnapshot } from "../../lib/client";
+
+interface AskOptionSignature {
+	label: string;
+	description?: string;
+}
+
+interface AskQuestionRecommendation {
+	question: string;
+	options: AskOptionSignature[];
+	recommended: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionSignatures(raw: unknown): AskOptionSignature[] | null {
+	if (!Array.isArray(raw)) return null;
+	const options: AskOptionSignature[] = [];
+	for (const value of raw) {
+		if (typeof value === "string") {
+			options.push({ label: value });
+			continue;
+		}
+		if (!isRecord(value) || typeof value.label !== "string") return null;
+		if (value.description === undefined) options.push({ label: value.label });
+		else if (typeof value.description === "string") options.push({ label: value.label, description: value.description });
+		else return null;
+	}
+	return options;
+}
+
+function askQuestionRecommendations(rawArgs: unknown): AskQuestionRecommendation[] {
+	if (!isRecord(rawArgs)) return [];
+	let rawQuestions = rawArgs.questions;
+	if (typeof rawQuestions === "string") {
+		try {
+			rawQuestions = JSON.parse(rawQuestions);
+		} catch {
+			return [];
+		}
+	}
+	const candidates = Array.isArray(rawQuestions) ? rawQuestions : [rawArgs];
+	const recommendations: AskQuestionRecommendation[] = [];
+	for (const candidate of candidates) {
+		if (!isRecord(candidate)) continue;
+		const question = typeof candidate.question === "string" ? candidate.question : null;
+		const options = optionSignatures(candidate.options);
+		const recommended = candidate.recommended;
+		if (
+			question === null ||
+			options === null ||
+			typeof recommended !== "number" ||
+			!Number.isInteger(recommended) ||
+			recommended < 0 ||
+			recommended >= options.length
+		) {
+			continue;
+		}
+		recommendations.push({ question, options, recommended });
+	}
+	return recommendations;
+}
+
+function optionsEqual(left: readonly AskOptionSignature[], right: readonly AskOptionSignature[]): boolean {
+	return (
+		left.length === right.length &&
+		left.every((option, index) => {
+			const candidate = right[index];
+			return candidate !== undefined && option.label === candidate.label && option.description === candidate.description;
+		})
+	);
+}
+
+/**
+ * `initialIndex` is not recommendation metadata: OMP also defaults it to zero when no option is
+ * recommended. Correlate the pending select with the latest unresolved `ask` call instead.
+ */
+export function recommendedOptionIndex(snapshot: GuestSnapshot): number | undefined {
+	const request = snapshot.uiRequest;
+	if (request?.kind !== "select") return undefined;
+	const requestOptions = optionSignatures(request.options);
+	if (requestOptions === null) return undefined;
+
+	const resolvedToolCalls = new Set<string>();
+	for (const entry of snapshot.entries) {
+		if (entry.type === "message" && entry.message.role === "toolResult") {
+			resolvedToolCalls.add(entry.message.toolCallId);
+		}
+	}
+
+	const calls: Array<{ id: string; args: unknown }> = [];
+	const appendAskCalls = (message: GuestSnapshot["stream"]): void => {
+		if (message === null) return;
+		for (const block of message.content) {
+			if (block.type === "toolCall" && block.name === "ask") calls.push({ id: block.id, args: block.arguments });
+		}
+	};
+	for (const entry of snapshot.entries) {
+		if (entry.type === "message" && entry.message.role === "assistant") appendAskCalls(entry.message);
+	}
+	appendAskCalls(snapshot.stream);
+	for (const tool of snapshot.activeTools.values()) {
+		if (tool.toolName === "ask") calls.push({ id: tool.toolCallId, args: tool.args });
+	}
+
+	for (let callIndex = calls.length - 1; callIndex >= 0; callIndex -= 1) {
+		const call = calls[callIndex];
+		if (call === undefined || resolvedToolCalls.has(call.id)) continue;
+		const questions = askQuestionRecommendations(call.args);
+		for (let questionIndex = questions.length - 1; questionIndex >= 0; questionIndex -= 1) {
+			const question = questions[questionIndex];
+			if (
+				question !== undefined &&
+				question.question === request.title &&
+				optionsEqual(question.options, requestOptions)
+			) {
+				return question.recommended;
+			}
+		}
+	}
+	return undefined;
+}

--- a/packages/collab-client/upstream/src/components/shell/shell.css
+++ b/packages/collab-client/upstream/src/components/shell/shell.css
@@ -403,9 +403,26 @@
 	min-width: 0;
 }
 
+.sh-ask-option-heading {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	min-width: 0;
+}
+
 .sh-ask-option-label {
 	font-size: 13px;
 	font-weight: 500;
+}
+
+.sh-ask-option-recommended {
+	padding: 1px 6px;
+	font: 600 10px / 1.4 var(--font-mono);
+	color: var(--accent);
+	background: var(--accent-muted);
+	border: 1px solid var(--accent);
+	border-radius: var(--radius-sm);
+	white-space: nowrap;
 }
 
 .sh-ask-option-description {


### PR DESCRIPTION
## Summary
- correlate pending Ask UI requests with explicit `recommended` metadata
- show a compact Recommended badge only on the matching option
- cover active requests, late joins, resolved history, and Android browser rendering

## Validation
- `bun run check` — 113 tests passed; typecheck, build, handoff validation, and capability leak scan passed
- `bun run test:browser` — 12 Playwright tests passed across both Android viewports

## Threat model impact
No new capability handling, persistence, network surface, or authorization behavior. Recommendation metadata is derived from the existing in-memory collaboration snapshot.