### PR TITLE
fix: implement native 3d collaboration shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable project changes will be documented here.
 
 The format is based on Keep a Changelog, and the project intends to use Semantic Versioning once implementation releases begin.
 
+## [0.1.0-prealpha.12] - 2026-07-26
+
+### Fixed
+
+- Implement the approved Couch Flow 3d shell as one fixed frame: gateway top bar, the untouched
+  pinned collaboration client, and an answer-only bottom triage bar below the composer.
+- Remove the embedded client's connecting window and ended-session popup; connection lifecycle is
+  represented only by the shell's Connected, Reconnecting, or Offline chip.
+- Show triage feedback only after the exact opened request resolves, then dismiss it after eight
+  seconds, tap-out, or swipe without covering the composer or its safe-area inset.
+- Route direct and historical `/client/` navigation back through the PWA directory and stop
+  shipping the obsolete popup/MessageChannel bootstrap.
+
+### Security
+
+- Continue passing the launch capability directly into the pinned client mount in memory without
+  adding it to shell state, DOM, URL, history, browser storage, or service-worker caches.
+
+### Testing
+
+- Exercise the exact three-child shell frame, single transcript/composer/interrupt controls,
+  lifecycle-popup suppression, answer-only triage, composer geometry, Back restoration, and direct
+  `/client/` recovery at both Android viewport sizes.
+
 ## [0.1.0-prealpha.11] - 2026-07-26
 
 ### Fixed

--- a/apps/gateway/src/http.ts
+++ b/apps/gateway/src/http.ts
@@ -210,7 +210,8 @@ export function createHttpHandler(options: {
     } catch {
       return problem(400, "bad_request", "Invalid request");
     }
-    const clientBootstrap = isValidClientBootstrap(url);
+    const clientRoute = request.method === "GET" && url.pathname === "/client/";
+    const clientBootstrap = clientRoute && isValidClientBootstrap(url);
     const requestBootstrap = request.method === "GET" && isValidRequestBootstrap(url);
     const updateBootstrap = request.method === "GET" && url.pathname === "/update/";
     if (url.search !== "" && !clientBootstrap && !requestBootstrap) {
@@ -353,10 +354,12 @@ export function createHttpHandler(options: {
     }
 
     if (url.pathname.startsWith("/api/")) return problem(404, "not_found", "Not found");
-    const staticResponse = staticAssets.response(requestBootstrap || updateBootstrap ? "/" : url.pathname);
+    const staticResponse = staticAssets.response(
+      clientRoute || requestBootstrap || updateBootstrap ? "/" : url.pathname,
+    );
     return withSecurityHeaders(
       staticResponse ?? new Response("Not found", { status: 404 }),
-      clientBootstrap || requestBootstrap || updateBootstrap,
+      clientRoute || requestBootstrap || updateBootstrap,
     );
   };
 }

--- a/apps/gateway/test/http.test.ts
+++ b/apps/gateway/test/http.test.ts
@@ -395,15 +395,21 @@ describe("HTTP boundary", () => {
     }
   });
 
-  test("rejects query-bearing assets and no-stores the validated client bootstrap", async () => {
+  test("rejects query-bearing assets and maps every client route to the PWA shell", async () => {
     const handler = createHttpHandler({ config: config(), registry: populatedRegistry(), staticAssets: assets });
     const rejected = await handler(request(`/assets/app.0123456789ab.js?token=${viewCapability}`), peer);
     expect(rejected.status).toBe(400);
     expect(rejected.headers.get("Cache-Control")).toContain("no-store");
 
-    const bootstrap = await handler(request("/client/?handoff=7a2cadc8-c634-4a4e-9045-bc7001a034a7"), peer);
-    expect(bootstrap.status).toBe(200);
-    expect(bootstrap.headers.get("Cache-Control")).toContain("no-store");
+    for (const clientPath of [
+      "/client/",
+      "/client/?handoff=7a2cadc8-c634-4a4e-9045-bc7001a034a7",
+    ]) {
+      const client = await handler(request(clientPath), peer);
+      expect(client.status).toBe(200);
+      expect(client.headers.get("Cache-Control")).toContain("no-store");
+      expect(await client.text()).toContain("OMP Sessions");
+    }
     expect((await handler(request("/client/?handoff=not-a-uuid"), peer)).status).toBe(400);
     const update = await handler(request("/update/"), peer);
     expect(update.status).toBe(200);

--- a/apps/web/e2e/fixture-server.ts
+++ b/apps/web/e2e/fixture-server.ts
@@ -197,7 +197,7 @@ export async function startDashboardFixture(
       }
       const requestBootstrap = /^\/collab\/[A-Za-z0-9._:-]{16,128}$/u.test(pathname) &&
         url.searchParams.has("request");
-      const relative = pathname === "/" || pathname === "/update/" || requestBootstrap
+      const relative = pathname === "/" || pathname === "/client/" || pathname === "/update/" || requestBootstrap
         ? "index.html"
         : pathname.endsWith("/")
           ? `${pathname.slice(1)}index.html`

--- a/apps/web/e2e/launch.e2e.ts
+++ b/apps/web/e2e/launch.e2e.ts
@@ -133,10 +133,13 @@ test("installed-PWA View and Control mount in the current window without losing 
     await expect(page.locator("#root[role='application']")).toHaveCount(1);
     await expect(page.locator(".shell-title")).toHaveText("Android standalone launch");
     await expect(page.locator(".shell-control")).toBeVisible();
-    await expect(page.locator(".conn-chip")).toHaveAttribute("data-state", /^(connected|reconnecting)$/u);
-    await expect(page.locator(".triage-bar")).toHaveAttribute("data-kind", "reconnecting");
-    await expect(page.locator(".triage-copy")).toHaveText("Reconnecting to relay… composer paused");
-    await expect(page.locator(".triage-action")).toHaveCount(0);
+    await expect(page.locator(".conn-chip")).toHaveAttribute("data-state", "reconnecting");
+    await expect(page.locator(".triage-bar")).toBeHidden();
+    await expect(page.locator("#root > .sh-app")).toHaveCount(1);
+    await expect(page.locator(".co-connect, .sh-banner, .sh-ended")).toHaveCount(0);
+    expect(await page.locator(".gateway-shell").evaluate(element =>
+      [...element.children].map(child => child.id || child.className),
+    )).toEqual(["shell-bar", "root", "triage-bar"]);
     const shellTargets = await page.locator(".shell-back, .shell-control").evaluateAll(elements =>
       elements.filter(element => !(element as HTMLElement).hidden).map(element => element.getBoundingClientRect().height),
     );
@@ -373,6 +376,9 @@ test("active ask marks only the explicit recommended option", async ({ page }) =
     await expect(page.locator(".sh-ask-option").first()).toBeFocused();
     await expect(page.locator(".sh-composer")).toHaveCount(1);
     await expect(page.locator(".gateway-shell > .sh-composer")).toHaveCount(0);
+    await expect(page.locator(".sh-header")).toHaveCount(1);
+    await expect(page.locator(".sh-transcript")).toHaveCount(1);
+    await expect(page.locator(".sh-btn-stop")).toHaveCount(1);
     await expect(
       page.locator(".sh-ask-option").filter({ hasText: "Implement ADR-0036 locally" }).locator(".sh-ask-option-recommended"),
     ).toHaveText("Recommended");
@@ -388,17 +394,21 @@ test("active ask marks only the explicit recommended option", async ({ page }) =
     });
     await expect(page.locator(".conn-chip")).toHaveAttribute("data-state", "offline");
     await expect(page.locator(".conn-chip")).toHaveText("Offline");
-    await expect(page.locator(".triage-bar")).toHaveAttribute("data-kind", "ended");
-    await expect(page.locator(".triage-copy")).toHaveText("Session ended · exit 0");
-    await expect(page.locator(".triage-action")).toHaveText("Back to Sessions");
-    const inset = await page.evaluate(() => {
-      const composer = document.querySelector(".sh-composer")?.getBoundingClientRect();
-      const triage = document.querySelector(".triage-bar")?.getBoundingClientRect();
-      if (composer === undefined || triage === undefined) return undefined;
-      return { composerBottom: composer.bottom, triageTop: triage.top };
-    });
-    expect(inset).toBeDefined();
-    expect(inset?.composerBottom).toBeLessThanOrEqual(inset?.triageTop ?? 0);
+    await expect(page.locator(".triage-bar")).toBeHidden();
+    await expect(page.locator(".sh-ended")).toHaveCount(0);
+  } finally {
+    await fixture.stop();
+  }
+});
+
+test("direct client navigation returns to the session directory without legacy bootstrap UI", async ({ page }) => {
+  const fixture = await startDashboardFixture([session()]);
+
+  try {
+    await page.goto(`${fixture.origin}/client/`);
+    await expect(page).toHaveURL(`${fixture.origin}/`);
+    await expect(page.locator("#session-list")).toBeVisible();
+    await expect(page.locator(".co-connect, .gateway-shell, .sh-ended")).toHaveCount(0);
   } finally {
     await fixture.stop();
   }
@@ -415,6 +425,14 @@ test("answer feedback dismisses by tap-out, swipe, and the eight-second timeout"
     await expect(page).toHaveURL(`${fixture.origin}/client/`);
     fixture.upsert(answeredSession(initial));
     await expect(page.locator(".triage-bar")).toHaveAttribute("data-kind", "clear");
+    const inset = await page.evaluate(() => {
+      const composer = document.querySelector(".sh-composer")?.getBoundingClientRect();
+      const triage = document.querySelector(".triage-bar")?.getBoundingClientRect();
+      if (composer === undefined || triage === undefined) return undefined;
+      return { composerBottom: composer.bottom, triageTop: triage.top };
+    });
+    expect(inset).toBeDefined();
+    expect(inset?.composerBottom).toBeLessThanOrEqual(inset?.triageTop ?? 0);
     await page.locator(".shell-bar").dispatchEvent("pointerdown", { pointerId: 1, clientY: 20 });
     await expect(page.locator(".triage-bar")).toBeHidden();
 

--- a/apps/web/src/app.ts
+++ b/apps/web/src/app.ts
@@ -19,6 +19,7 @@ interface CollabEmbedState {
 
 interface CollabEmbedOptions {
   readonly focusPendingRequest?: boolean;
+  readonly shellOwnsLifecycle?: boolean;
   readonly onStateChange?: (state: CollabEmbedState) => void;
 }
 
@@ -117,10 +118,10 @@ interface ActiveCollabShell {
   readonly instanceId: string;
   readonly generation: number;
   readonly openedRequestId?: string;
+  readonly connectionChip: HTMLElement;
   readonly triageBar: HTMLElement;
   readonly shell: HTMLElement;
   answerShown: boolean;
-  reconnectingShown: boolean;
   triageTimeout?: number;
 }
 
@@ -758,7 +759,7 @@ function hideTriageBar(shell: ActiveCollabShell): void {
 
 function showTriageBar(
   shell: ActiveCollabShell,
-  kind: "next" | "clear" | "reconnecting" | "ended",
+  kind: "next" | "clear",
   copy: string,
   actionLabel?: string,
   action?: () => void,
@@ -778,10 +779,8 @@ function showTriageBar(
   }
   shell.triageBar.hidden = false;
   shell.shell.dataset.triageVisible = "true";
-  if (kind === "next" || kind === "clear") shell.triageBar.dataset.dismissible = "true";
-  if (kind === "next" || kind === "clear") {
-    shell.triageTimeout = window.setTimeout(() => hideTriageBar(shell), 8_000);
-  }
+  shell.triageBar.dataset.dismissible = "true";
+  shell.triageTimeout = window.setTimeout(() => hideTriageBar(shell), 8_000);
 }
 
 function returnToDirectory(historyValue?: unknown): void {
@@ -810,7 +809,8 @@ function reconcileActiveCollabShell(): void {
   const current = sessions.get(shell.instanceId);
   if (current === undefined || current.generation !== shell.generation) {
     shell.answerShown = true;
-    showTriageBar(shell, "ended", "Session ended", "Back to Sessions", returnToDirectory);
+    setConnectionState(shell.connectionChip, "offline");
+    hideTriageBar(shell);
     return;
   }
   if (shell.openedRequestId === undefined || current.ask?.requestId === shell.openedRequestId) return;
@@ -951,42 +951,19 @@ function enterCollabClient(
     instanceId: session.instanceId,
     generation: session.generation,
     ...(requestId === undefined ? {} : { openedRequestId: requestId }),
+    connectionChip: connection,
     triageBar,
     shell,
     answerShown: false,
-    reconnectingShown: false,
   };
   activeCollabShell = shellState;
 
   const updateConnection = (state: CollabEmbedState): void => {
     if (state.phase === "ended") {
       setConnectionState(connection, "offline");
-      if (!shellState.answerShown) {
-        shellState.answerShown = true;
-        const exitCode = /\bexit(?:ed)?(?:\s+with)?(?:\s+code)?\s*[:=]?\s*(-?\d{1,3})\b/iu.exec(
-          state.endedReason ?? "",
-        )?.[1];
-        showTriageBar(
-          shellState,
-          "ended",
-          exitCode === undefined ? "Session ended" : `Session ended · exit ${exitCode}`,
-          "Back to Sessions",
-          returnToDirectory,
-        );
-      }
       return;
     }
-    const reconnecting = state.phase !== "live";
-    setConnectionState(connection, reconnecting ? "reconnecting" : "connected");
-    if (reconnecting && !shellState.answerShown) {
-      if (!shellState.reconnectingShown) {
-        shellState.reconnectingShown = true;
-        showTriageBar(shellState, "reconnecting", "Reconnecting to relay… composer paused");
-      }
-    } else if (shellState.reconnectingShown) {
-      shellState.reconnectingShown = false;
-      if (!shellState.answerShown) hideTriageBar(shellState);
-    }
+    setConnectionState(connection, state.phase === "live" ? "connected" : "reconnecting");
   };
 
   let disposeClient = (): void => undefined;
@@ -1019,6 +996,7 @@ function enterCollabClient(
       },
       {
         focusPendingRequest: requestId !== undefined,
+        shellOwnsLifecycle: true,
         onStateChange: updateConnection,
       },
     );

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -752,11 +752,14 @@ body.collab-shell-active {
 }
 
 .gateway-shell {
+  position: fixed;
+  inset: 0;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   width: 100%;
   height: 100dvh;
   min-width: 0;
+  overflow: hidden;
   background: var(--ground);
 }
 
@@ -868,13 +871,6 @@ body.collab-shell-active {
   line-height: 1.35;
 }
 
-.triage-bar[data-kind="reconnecting"] {
-  border-color: var(--control-border);
-}
-
-.triage-bar[data-kind="reconnecting"] .triage-copy {
-  color: var(--control);
-}
 
 .triage-action {
   flex: none;

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -1,7 +1,7 @@
 # Release status
 
 **Updated:** 2026-07-26<br>
-**Repository version:** `0.1.0` (`v0.1.0-prealpha.11`; no alpha)<br>
+**Repository version:** `0.1.0` (`v0.1.0-prealpha.12`; no alpha)<br>
 **Classification:** implemented pre-alpha<br>
 **Alpha decision:** **NO-GO**<br>
 **Advertised host/client platforms:** none

--- a/packages/collab-client/upstream/src/app.tsx
+++ b/packages/collab-client/upstream/src/app.tsx
@@ -37,6 +37,7 @@ export interface CollabEmbedState {
 
 export interface CollabEmbedOptions {
 	focusPendingRequest?: boolean;
+	shellOwnsLifecycle?: boolean;
 	onStateChange?(state: CollabEmbedState): void;
 }
 
@@ -47,9 +48,27 @@ export interface AppProps {
 }
 
 export function App({ capability, onDispose, embedOptions }: AppProps): ReactNode {
-	const [client, setClient] = useState<GuestClient | null>(null);
-	const [connectError, setConnectError] = useState<string | null>(null);
-	const credsRef = useRef<Creds | null>(null);
+	const shellOwnsLifecycle = embedOptions?.shellOwnsLifecycle === true;
+	const [initialConnection] = useState(() => {
+		if (!shellOwnsLifecycle) return undefined;
+		const name = storedName();
+		try {
+			return {
+				client: new GuestClient(capability, name),
+				creds: { link: capability, name } satisfies Creds,
+				error: null,
+			};
+		} catch {
+			return {
+				client: null,
+				creds: null,
+				error: "Unable to open this collaboration session.",
+			};
+		}
+	});
+	const [client, setClient] = useState<GuestClient | null>(initialConnection?.client ?? null);
+	const [connectError, setConnectError] = useState<string | null>(initialConnection?.error ?? null);
+	const credsRef = useRef<Creds | null>(initialConnection?.creds ?? null);
 
 	const connect = useCallback((link: string, name: string): void => {
 		let next: GuestClient;
@@ -109,7 +128,16 @@ export function App({ capability, onDispose, embedOptions }: AppProps): ReactNod
 	}, []);
 
 	useEffect(() => {
-		connect(capability, storedName());
+		if (initialConnection === undefined) {
+			connect(capability, storedName());
+		} else if (initialConnection.client !== null) {
+			initialConnection.client.connect();
+			try {
+				localStorage.setItem(NAME_KEY, initialConnection.creds.name);
+			} catch {
+				// storage unavailable (private mode) — non-fatal
+			}
+		}
 		return () => {
 			credsRef.current = null;
 			setClient(current => {
@@ -117,7 +145,7 @@ export function App({ capability, onDispose, embedOptions }: AppProps): ReactNod
 				return null;
 			});
 		};
-	}, [capability, connect]);
+	}, [capability, connect, initialConnection]);
 
 	useEffect(() => {
 		if (!client) return;
@@ -138,6 +166,7 @@ export function App({ capability, onDispose, embedOptions }: AppProps): ReactNod
 	}, [client, connectError, embedOptions]);
 
 	if (!client) {
+		if (shellOwnsLifecycle) return null;
 		return (
 			<main className="co-connect">
 				<h1>{connectError ? "Session unavailable" : "Connecting…"}</h1>
@@ -269,7 +298,9 @@ function Session({ client, onLeave, onRejoin, embedOptions }: SessionProps): Rea
 					/>
 				</>
 			)}
-			<Banners phase={snap.phase} endedReason={snap.endedReason} onRejoin={onRejoin} onNewLink={onLeave} />
+			{embedOptions?.shellOwnsLifecycle !== true && (
+				<Banners phase={snap.phase} endedReason={snap.endedReason} onRejoin={onRejoin} onNewLink={onLeave} />
+			)}
 			<Toasts notices={snap.notices} />
 		</div>
 	);

--- a/scripts/build-web.ts
+++ b/scripts/build-web.ts
@@ -57,14 +57,6 @@ if (clientModule === undefined || clientStylesheet === undefined) {
   throw new Error("collab client build did not emit JavaScript and CSS");
 }
 
-const clientBuild = await buildEntrypoint(
-  join(clientSource, "upstream", "src", "main.tsx"),
-  join(temporaryRoot, "client"),
-  { __COLLAB_CLIENT_MODULE__: JSON.stringify(clientModule) },
-);
-const clientScriptSource = clientBuild.find(path => extname(path) === ".js");
-if (clientScriptSource === undefined) throw new Error("client bootstrap build did not emit JavaScript");
-const clientScript = await moveHashedAsset(clientScriptSource, "collab-bootstrap");
 
 const webBuild = await buildEntrypoint(join(webSource, "app.ts"), join(temporaryRoot, "web"), {
   __COLLAB_CLIENT_MODULE__: JSON.stringify(clientModule),
@@ -83,12 +75,6 @@ const indexHtml = indexTemplate
   .replace("<!--ASSET_SCRIPT-->", `<script type="module" src="${webScript}"></script>`);
 await writeFile(join(outputRoot, "index.html"), indexHtml);
 
-const clientTemplate = await readFile(join(clientSource, "src", "index.html"), "utf8");
-const clientHtml = clientTemplate
-  .replace("</head>", `    <link rel="stylesheet" href="${clientStylesheet}" />\n  </head>`)
-  .replace("<!--CLIENT_SCRIPT-->", `<script type="module" src="${clientScript}"></script>`);
-await mkdir(join(outputRoot, "client"), { recursive: true });
-await writeFile(join(outputRoot, "client", "index.html"), clientHtml);
 
 await copyFile(join(webSource, "manifest.webmanifest"), join(outputRoot, "manifest.webmanifest"));
 await copyFile(join(webSource, "icon.svg"), join(outputRoot, "icon.svg"));


### PR DESCRIPTION
## Summary
- make the gateway collaboration view exactly three layers: top shell bar, untouched pinned client root, answer-only bottom triage
- create the embedded client before first paint and suppress its legacy connection/ended lifecycle overlays
- remove the shipped popup bootstrap and route direct or historical `/client/` loads through the PWA directory
- preserve exact-request triage gating, eight-second/tap/swipe dismissal, safe-area composer inset, and Back order/scroll restoration

## Security impact
Capabilities remain direct in-memory arguments to the pinned client mount. No capability is added to shell state, DOM, URL/history, storage, caches, logs, or diagnostics. The obsolete MessageChannel bootstrap is no longer shipped.

## Verification
- `bun run check` — 118 tests, 673 assertions, capability leak scan passed
- `bun run test:browser` — 18 tests passed across 412×915 and 390×844
