### PR TITLE
fix: rebind registry socket when its runtime path is reaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
   the file's first test — which pays two cold starts — exceeded the 5-second default and the
   2-second handshake budget while asserting security behavior that had not regressed. The patch is
   regenerated, so its five commit SHAs changed.
+- Drive a virtual clock in the collab-client fake-timer harness. `CollabSocket` schedules its idle
+  relay probe as `lastRelayActivityAt + RELAY_IDLE_PROBE_MS - Date.now()`, and `#commit()` runs
+  between the two reads, so faking `setTimeout` while leaving `Date.now()` on the wall clock let
+  real milliseconds shorten the delay to `9_99x`. The relay-probe test failed roughly one full-suite
+  run in six. The clock now advances only when a fake timer fires; injecting 3 ms of real work into
+  `#commit()` reproduced `9997` before the change and `10000` after.
 
 ## [0.1.0-prealpha.14] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
   endpoint. Readiness previously proved only that the HTTP listener answered, so a daemon that no
   publisher could reach still passed `status`, `doctor`, and install readiness checks.
 
+### Testing
+
+- Scale the OMP publisher fixtures' per-test and handshake budgets by platform. Every Windows
+  publisher-token fixture is secured, and the publisher's token ACL validated, by spawning
+  `powershell.exe`; hosted runner images made that spawn cost seconds rather than milliseconds, so
+  the file's first test — which pays two cold starts — exceeded the 5-second default and the
+  2-second handshake budget while asserting security behavior that had not regressed. The patch is
+  regenerated, so its five commit SHAs changed.
+
 ## [0.1.0-prealpha.14] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable project changes will be documented here.
 
 The format is based on Keep a Changelog, and the project intends to use Semantic Versioning once implementation releases begin.
 
+## [Unreleased]
+
+### Fixed
+
+- Re-bind the registry socket when its path disappears underneath the daemon. macOS reaps idle
+  per-user `TMPDIR` entries, which deleted `registry.sock` and its parent directory while Bun kept
+  listening on the unlinked inode, so every OMP publisher failed to connect with `ENOENT` and no
+  session could ever appear. The daemon now records the bound device/inode, re-checks the path every
+  15 seconds, and recreates the private runtime directory and listener when the path is gone. A path
+  owned by a different inode is reported as unhealthy instead of being clobbered.
+- Report `status: "degraded"` from `GET /api/v1/health` when publishers cannot reach the registry
+  endpoint. Readiness previously proved only that the HTTP listener answered, so a daemon that no
+  publisher could reach still passed `status`, `doctor`, and install readiness checks.
+
 ## [0.1.0-prealpha.14] - 2026-07-26
 
 ### Added

--- a/apps/gateway/src/cli.ts
+++ b/apps/gateway/src/cli.ts
@@ -39,6 +39,13 @@ interface ParsedArguments {
 
 const MISSING_OPTION_VALUE = "\0";
 
+/**
+ * Cadence for confirming the registry socket path still resolves to the live listener. The OS can
+ * remove it underneath a long-lived daemon (macOS reaps idle `TMPDIR` entries), which silently
+ * stops every publisher from connecting while HTTP keeps serving.
+ */
+const ENDPOINT_WATCHDOG_INTERVAL_MS = 15_000;
+
 function parseArguments(argv: readonly string[]): ParsedArguments {
   const command = argv[0] ?? "help";
   const values = new Map<string, string[]>();
@@ -137,6 +144,7 @@ async function runServe(arguments_: ParsedArguments): Promise<void> {
   };
   let http: ReturnType<typeof startHttpServer> | undefined;
   let sweeper: ReturnType<typeof setInterval> | undefined;
+  let endpointWatchdog: ReturnType<typeof setInterval> | undefined;
   process.once("SIGINT", stop);
   process.once("SIGTERM", stop);
   try {
@@ -148,16 +156,21 @@ async function runServe(arguments_: ParsedArguments): Promise<void> {
       pushService,
       readinessToken: token,
       ...(readinessInstance === undefined ? {} : { readinessInstance }),
+      endpointHealthy: () => ipc.endpointHealthy,
     });
     sweeper = setInterval(() => {
       const removed = registry.sweepExpired();
       if (removed > 0) logger.event("info", "registry.expired", { removed });
     }, Math.max(1_000, Math.floor((config.registry.ttlSeconds * 1_000) / 3)));
+    endpointWatchdog = setInterval(() => {
+      void ipc.verifyEndpoint();
+    }, ENDPOINT_WATCHDOG_INTERVAL_MS);
     await stopped;
   } finally {
     process.off("SIGINT", stop);
     process.off("SIGTERM", stop);
-    if (sweeper !== undefined) clearInterval(sweeper);
+    clearInterval(sweeper);
+    clearInterval(endpointWatchdog);
     try {
       http?.stop(true);
     } finally {

--- a/apps/gateway/src/http.ts
+++ b/apps/gateway/src/http.ts
@@ -199,6 +199,12 @@ export function createHttpHandler(options: {
   readonly readinessToken?: string;
   readonly readinessInstance?: string;
   readonly sseKeepaliveMs?: number;
+  /**
+   * Reports whether the registry rendezvous point is still reachable by publishers. A daemon whose
+   * socket path was removed underneath it keeps serving HTTP while no session can ever register, so
+   * readiness must reflect the IPC endpoint rather than process liveness alone.
+   */
+  readonly endpointHealthy?: () => boolean;
 }): (request: Request, peer?: RequestPeer) => Promise<Response> {
   const { config, registry, staticAssets } = options;
   const logger = options.logger ?? new SafeLogger();
@@ -223,8 +229,9 @@ export function createHttpHandler(options: {
       if (peer === undefined || !isLoopbackAddress(peer.address)) {
         return problem(403, "forbidden", "Forbidden");
       }
+      const status = options.endpointHealthy?.() === false ? "degraded" : "ready";
       const challenge = request.headers.get("X-OMP-Readiness-Challenge");
-      if (challenge === null) return withSecurityHeaders(Response.json({ status: "ready" }), true);
+      if (challenge === null) return withSecurityHeaders(Response.json({ status }), true);
       if (options.readinessToken === undefined || !/^[A-Za-z0-9_-]{43}$/u.test(challenge)) {
         return problem(400, "bad_request", "Invalid readiness challenge");
       }
@@ -235,7 +242,7 @@ export function createHttpHandler(options: {
         .update(instance)
         .digest("base64url");
       return withSecurityHeaders(
-        Response.json({ status: "ready", proof, ...(instance === "" ? {} : { instance }) }),
+        Response.json({ status, proof, ...(instance === "" ? {} : { instance }) }),
         true,
       );
     }
@@ -372,6 +379,7 @@ export function startHttpServer(options: {
   readonly logger?: SafeLogger;
   readonly readinessToken: string;
   readonly readinessInstance?: string;
+  readonly endpointHealthy?: () => boolean;
 }): Bun.Server<undefined> {
   const handler = createHttpHandler(options);
   const server = Bun.serve({

--- a/apps/gateway/src/ipc.ts
+++ b/apps/gateway/src/ipc.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { chmod } from "node:fs/promises";
+import type { Stats } from "node:fs";
+import { chmod, lstat } from "node:fs/promises";
 import {
   MAX_FRAME_BYTES,
   PROTOCOL_VERSION,
@@ -18,6 +19,7 @@ import {
 } from "@omp-session-gateway/protocol/ipc-auth";
 import {
   assertSocketPrivate,
+  ensureRuntimeDirectories,
   type GatewayConfig,
   removeRuntimeSocket,
 } from "./config.ts";
@@ -66,6 +68,14 @@ const runtimeDeadlineScheduler: RegistryIpcDeadlineScheduler = {
 export interface RegistryIpcServer {
   readonly endpoint: string;
   readonly publishers: number;
+  /** Last observed state of the filesystem rendezvous point. */
+  readonly endpointHealthy: boolean;
+  /**
+   * Confirms the bound socket path still resolves to this listener, re-binding when the path was
+   * removed underneath us (macOS reaps `TMPDIR` entries, so a long-lived daemon otherwise keeps an
+   * unlinked inode that no publisher can ever reach). Returns the resulting endpoint health.
+   */
+  verifyEndpoint(): Promise<boolean>;
   stop(): Promise<void>;
 }
 
@@ -254,75 +264,119 @@ export async function startRegistryIpcServer(options: {
     registry.remove(state.ownerId, message.instanceId, message.generation);
   };
 
-  const server = Bun.listen<ConnectionState>({
-    unix: config.paths.socketPath,
-    socket: {
-      open(socket) {
-        socket.data = {
-          ownerId: randomUUID(),
-          buffer: Buffer.alloc(MAX_HANDSHAKE_FRAME_BYTES),
-          bufferedBytes: 0,
-          authenticated: false,
-          closed: false,
-        };
-        if (publisherCount >= config.registry.maxPublishers) {
-          socket.data.closed = true;
-          socket.end('{"v":1,"op":"error","code":"capacity"}\n');
-          return;
-        }
-        publisherCount += 1;
-        connections.add(socket);
-        armDeadline(socket, HELLO_TIMEOUT_MILLISECONDS);
-      },
-      data(socket, chunk) {
-        const state = socket.data;
-        if (state.closed) return;
-        const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-        let offset = 0;
-        while (offset < bytes.byteLength && !state.closed) {
-          const newline = bytes.indexOf(0x0a, offset);
-          const end = newline < 0 ? bytes.byteLength : newline;
-          if (!appendFrameBytes(socket, bytes.subarray(offset, end))) return;
-          if (newline < 0) return;
-          if (state.bufferedBytes === 0) {
-            closeWithProtocolError(socket);
+  const bind = () =>
+    Bun.listen<ConnectionState>({
+      unix: config.paths.socketPath,
+      socket: {
+        open(socket) {
+          socket.data = {
+            ownerId: randomUUID(),
+            buffer: Buffer.alloc(MAX_HANDSHAKE_FRAME_BYTES),
+            bufferedBytes: 0,
+            authenticated: false,
+            closed: false,
+          };
+          if (publisherCount >= config.registry.maxPublishers) {
+            socket.data.closed = true;
+            socket.end('{"v":1,"op":"error","code":"capacity"}\n');
             return;
           }
+          publisherCount += 1;
+          connections.add(socket);
+          armDeadline(socket, HELLO_TIMEOUT_MILLISECONDS);
+        },
+        data(socket, chunk) {
+          const state = socket.data;
+          if (state.closed) return;
+          const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          let offset = 0;
+          while (offset < bytes.byteLength && !state.closed) {
+            const newline = bytes.indexOf(0x0a, offset);
+            const end = newline < 0 ? bytes.byteLength : newline;
+            if (!appendFrameBytes(socket, bytes.subarray(offset, end))) return;
+            if (newline < 0) return;
+            if (state.bufferedBytes === 0) {
+              closeWithProtocolError(socket);
+              return;
+            }
 
-          const frameLength = state.bufferedBytes;
-          try {
-            processFrame(socket, state.buffer.subarray(0, frameLength));
-            if (!state.closed && state.authenticated) armDeadline(socket, idleTimeoutMilliseconds);
-          } catch {
-            closeWithProtocolError(socket);
-          } finally {
-            state.buffer.fill(0, 0, frameLength);
-            state.bufferedBytes = 0;
+            const frameLength = state.bufferedBytes;
+            try {
+              processFrame(socket, state.buffer.subarray(0, frameLength));
+              if (!state.closed && state.authenticated) armDeadline(socket, idleTimeoutMilliseconds);
+            } catch {
+              closeWithProtocolError(socket);
+            } finally {
+              state.buffer.fill(0, 0, frameLength);
+              state.bufferedBytes = 0;
+            }
+            offset = newline + 1;
           }
-          offset = newline + 1;
-        }
+        },
+        close(socket) {
+          releaseConnection(socket);
+        },
+        error(socket) {
+          if (!socket.data.closed) logger.event("warn", "ipc.connection_error");
+        },
       },
-      close(socket) {
-        releaseConnection(socket);
-      },
-      error(socket) {
-        if (!socket.data.closed) logger.event("warn", "ipc.connection_error");
-      },
-    },
-  });
+    });
 
+  let boundDevice = -1;
+  let boundInode = -1;
+  let endpointHealthy = true;
 
-  if (process.platform !== "win32") {
+  const secureEndpoint = async (): Promise<void> => {
+    if (process.platform === "win32") return;
     await chmod(config.paths.socketPath, 0o600);
     await assertSocketPrivate(config);
-  }
+    const info = await lstat(config.paths.socketPath);
+    boundDevice = info.dev;
+    boundInode = info.ino;
+  };
+
+  let server = bind();
+  await secureEndpoint();
   logger.event("info", "ipc.listening");
+
+  const verifyEndpoint = async (): Promise<boolean> => {
+    if (process.platform === "win32") return true;
+    let info: Stats | undefined;
+    try {
+      info = await lstat(config.paths.socketPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    if (info !== undefined) {
+      const ours = info.isSocket() && info.dev === boundDevice && info.ino === boundInode;
+      if (!ours && endpointHealthy) logger.event("warn", "ipc.endpoint_replaced");
+      endpointHealthy = ours;
+      return ours;
+    }
+    try {
+      server.stop(false);
+      await ensureRuntimeDirectories(config);
+      server = bind();
+      await secureEndpoint();
+      endpointHealthy = true;
+      logger.event("warn", "ipc.endpoint_rebound");
+      return true;
+    } catch {
+      endpointHealthy = false;
+      logger.event("error", "ipc.endpoint_rebind_failed");
+      return false;
+    }
+  };
 
   return {
     endpoint: config.paths.socketPath,
     get publishers() {
       return publisherCount;
     },
+    get endpointHealthy() {
+      return endpointHealthy;
+    },
+    verifyEndpoint,
     async stop() {
       for (const socket of connections) {
         releaseConnection(socket);

--- a/apps/gateway/test/http.test.ts
+++ b/apps/gateway/test/http.test.ts
@@ -133,6 +133,31 @@ describe("HTTP boundary", () => {
     expect((await handler(healthRequest, { address: "192.168.1.20" })).status).toBe(403);
   });
 
+  test("reports degraded readiness when the registry endpoint is unreachable", async () => {
+    const readinessToken = "T".repeat(43);
+    const challenge = "C".repeat(43);
+    const handler = createHttpHandler({
+      config: config(),
+      registry: populatedRegistry(),
+      staticAssets: assets,
+      readinessToken,
+      endpointHealthy: () => false,
+    });
+
+    const proven = await handler(
+      new Request("http://127.0.0.1:4317/api/v1/health", { headers: { "X-OMP-Readiness-Challenge": challenge } }),
+      peer,
+    );
+    expect(proven.status).toBe(200);
+    expect(await proven.json()).toEqual({
+      status: "degraded",
+      proof: createHmac("sha256", readinessToken).update(challenge).update("\0").update("").digest("base64url"),
+    });
+
+    const plain = await handler(new Request("http://127.0.0.1:4317/api/v1/health"), peer);
+    expect(await plain.json()).toEqual({ status: "degraded" });
+  });
+
   test("fails closed for missing, disallowed, forged remote, and tagged-style identities", async () => {
     const handler = createHttpHandler({ config: config(), registry: populatedRegistry(), staticAssets: assets });
     expect((await handler(request("/api/v1/sessions", {}, ""), peer)).status).toBe(403);

--- a/apps/gateway/test/ipc.test.ts
+++ b/apps/gateway/test/ipc.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, rename, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -662,6 +662,85 @@ test("IPC closes authenticated publishers when heartbeat state is absent", async
     await waitFor(() => socket.data.closed && server.publishers === 0);
     expect(socket.data.text).not.toContain("protocol_error");
   } finally {
+    await server.stop();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("IPC rebinds the rendezvous point after the runtime directory is reaped", async () => {
+  if (process.platform === "win32") return;
+  const root = await mkdtemp(join(tmpdir(), "gateway-ipc-reaped-"));
+  const config = testConfig(root);
+  await mkdir(config.paths.runtimeDir, { recursive: true, mode: 0o700 });
+  const logs: string[] = [];
+  const logger = new SafeLogger({ write: line => logs.push(line) });
+  const registry = new SessionRegistry({ ttlSeconds: config.registry.ttlSeconds, maxSessions: 5 });
+  const token = "T".repeat(43);
+  const server = await startRegistryIpcServer({ config, token, registry, logger });
+
+  try {
+    expect(server.endpointHealthy).toBeTrue();
+    expect(await server.verifyEndpoint()).toBeTrue();
+
+    // Reproduce the macOS temp reaper: the socket and its parent directory disappear while the
+    // daemon keeps holding the now-unlinked listening inode.
+    await rm(config.paths.runtimeDir, { recursive: true, force: true });
+    await expect(connect(config.paths.socketPath)).rejects.toThrow();
+
+    expect(await server.verifyEndpoint()).toBeTrue();
+    expect(server.endpointHealthy).toBeTrue();
+    expect(logs.join("\n")).toContain("ipc.endpoint_rebound");
+
+    const socket = await connect(config.paths.socketPath);
+    const instanceId = "ipc-instance-rebound";
+    await authenticatePublisher(socket, token, instanceId, 700);
+    socket.write(
+      `${JSON.stringify({
+        v: 1,
+        op: "upsert",
+        session: {
+          instanceId,
+          generation: 1,
+          pid: 700,
+          sessionId: "ipc-session-rebound",
+          startedAt: "2026-07-21T00:00:00.000Z",
+          inputRequired: false,
+          viewLink: `REBOUND_VIEW_${"R".repeat(20)}`,
+        },
+      })}\n`,
+    );
+    await waitFor(() => registry.size === 1);
+    socket.end();
+  } finally {
+    await server.stop();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("IPC reports an unhealthy endpoint when another process replaces the socket", async () => {
+  if (process.platform === "win32") return;
+  const root = await mkdtemp(join(tmpdir(), "gateway-ipc-replaced-"));
+  const config = testConfig(root);
+  await mkdir(config.paths.runtimeDir, { recursive: true, mode: 0o700 });
+  const logs: string[] = [];
+  const logger = new SafeLogger({ write: line => logs.push(line) });
+  const registry = new SessionRegistry({ ttlSeconds: config.registry.ttlSeconds, maxSessions: 5 });
+  const server = await startRegistryIpcServer({ config, token: "T".repeat(43), registry, logger });
+  const usurper = Bun.listen({
+    unix: join(root, "usurper.sock"),
+    socket: { open() {}, data() {}, close() {}, error() {} },
+  });
+
+  try {
+    await rm(config.paths.socketPath);
+    await rename(join(root, "usurper.sock"), config.paths.socketPath);
+
+    expect(await server.verifyEndpoint()).toBeFalse();
+    expect(server.endpointHealthy).toBeFalse();
+    expect(logs.join("\n")).toContain("ipc.endpoint_replaced");
+    expect(logs.join("\n")).not.toContain("ipc.endpoint_rebound");
+  } finally {
+    usurper.stop(true);
     await server.stop();
     await rm(root, { recursive: true, force: true });
   }

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -338,3 +338,45 @@ needed to guarantee pending-action convergence across reconnect. The extension a
 timing traffic and no session data, capability, storage, URL, native surface, Workbox dependency,
 or Background Sync queue. ADR-016's fixed collaboration-client probe cadence and reconnect
 mechanics are superseded by this decision; its SSE heartbeat contract remains.
+
+---
+
+## ADR-021 — Treat the registry rendezvous path as failure-prone and make readiness prove it
+
+**Status:** Accepted
+
+**Context:** A production daemon ran continuously for a week yet published no sessions. It had not
+crashed: macOS reaps entries under the per-user `TMPDIR` after roughly three idle days, and it had
+deleted `omp-session-gateway-<uid>/registry.sock` together with its parent directory. Bun kept the
+listening socket alive on the now-unlinked inode, so `lsof` still showed the bound path while
+`stat` returned `ENOENT`. Publishers resolve that path by name, so every OMP `upsert` attempt failed
+with `ENOENT`. ADR-required behavior — a missing gateway never breaks OMP — then converted a total
+outage into silence: bounded retry, no UI noise, and nothing in the daemon log. `GET /api/v1/health`
+returned `{"status":"ready"}` throughout because it only proved that the HTTP listener answered, so
+`omp-gateway status`, `doctor`, and the install readiness probe all agreed the daemon was healthy.
+The runtime directory cannot simply move: OMP's publisher independently computes the same darwin
+`TMPDIR` path, so changing one side alone breaks the rendezvous until a patched OMP ships.
+
+**Decision:** Treat the filesystem rendezvous point as failure-prone rather than assuming the OS
+preserves it. The IPC server records the device and inode it bound, and `verifyEndpoint()`
+re-`lstat`s that path on a bounded 15-second cadence. A missing path means our own rendezvous point
+vanished, so the daemon stops the orphaned listener, recreates the `0700` runtime directory, re-binds,
+re-applies `0600`, and re-asserts private permissions. A path that exists but resolves to a different
+inode means another process owns it; the daemon reports an unhealthy endpoint and never clobbers it,
+because two daemons fighting over one socket is worse than one daemon reporting degraded. Readiness
+becomes state-faithful: `/api/v1/health` returns `degraded` whenever the endpoint is unreachable,
+keeping the HMAC challenge shape unchanged and still exposing no paths, counts, or publisher detail.
+`gatewayReady` already requires `status === "ready"`, so an unreachable endpoint now fails readiness
+instead of passing it.
+
+Moving the darwin runtime directory out of the reapable `TMPDIR` to
+`~/.local/state/omp-session-gateway/run/` remains the preferred way to remove the trigger, but it is
+a rendezvous-contract change that must ship in lockstep with a regenerated OMP publisher patch. It is
+deferred to that coordinated release; the watchdog is not a reason to skip it.
+
+**Consequences:** A reaped socket now self-heals within one watchdog interval instead of causing a
+silent multi-day outage, and the same control covers any other cause of socket loss. Detection costs
+one `lstat` per interval. Sessions published before a reap survive the re-bind because live publisher
+connections are not closed. The `degraded` status is a new observable value for health consumers, so
+monitoring that only checked HTTP reachability now distinguishes a serving daemon from a usable one.
+Until the lockstep path migration lands, the reap still happens; the daemon merely repairs it.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -379,6 +379,13 @@ Error behavior:
 
 A local unauthenticated health endpoint may return only generic process readiness. Session counts, identities, config, paths, and publisher health require authenticated diagnostics or local CLI access.
 
+Readiness must reflect the registry rendezvous point, not just the HTTP listener. `status` is `ready`
+only while publishers can still reach the IPC endpoint, and `degraded` once the daemon observes that
+its socket path no longer resolves to the live listener. This distinction is required because a
+long-lived daemon can keep serving HTTP on an unlinked socket inode that no publisher can connect to.
+The value carries no path, count, or publisher detail, and the optional HMAC challenge/response shape
+is identical for both values.
+
 ## 5. In-memory collab client bootstrap
 
 Preferred same-page API:

--- a/packages/collab-client/test/socket.test.ts
+++ b/packages/collab-client/test/socket.test.ts
@@ -71,8 +71,16 @@ function installFakeTimers(): FakeTimerHarness {
   const nativeSetTimeout = globalThis.setTimeout;
   const nativeClearTimeout = globalThis.clearTimeout;
   const nativeRandom = Math.random;
+  const nativeNow = Date.now;
   const timers = new Map<number, { handler: TimerHandler; delay: number }>();
   let nextTimer = 0;
+  // The client schedules its idle relay probe as `lastRelayActivityAt + RELAY_IDLE_PROBE_MS -
+  // Date.now()`. Faking setTimeout while leaving Date.now on the wall clock mixes the two, so any
+  // real milliseconds the test spends (WebCrypto decodes, machine load) shorten that delay to
+  // 9_99x and make exact-delay assertions fail under load. Drive a virtual clock instead: it only
+  // advances when a fake timer fires, which is exactly the elapsed time the client should observe.
+  let now = nativeNow();
+  Date.now = () => now;
   globalThis.setTimeout = ((handler: TimerHandler, delay?: number) => {
     nextTimer += 1;
     timers.set(nextTimer, { handler, delay: delay ?? 0 });
@@ -90,12 +98,14 @@ function installFakeTimers(): FakeTimerHarness {
       const [id, timer] = next;
       timers.delete(id);
       if (typeof timer.handler !== "function") throw new Error("string timer handlers are unsupported");
+      now += timer.delay;
       timer.handler();
     },
     restore() {
       globalThis.setTimeout = nativeSetTimeout;
       globalThis.clearTimeout = nativeClearTimeout;
       Math.random = nativeRandom;
+      Date.now = nativeNow;
       timers.clear();
     },
   };

--- a/patches/oh-my-pi/0001-collab-controller-autostart-registry.patch
+++ b/patches/oh-my-pi/0001-collab-controller-autostart-registry.patch
@@ -1,4 +1,4 @@
-From 7e8a69b557e7e69f9be54e491c17a69c4a20518e Mon Sep 17 00:00:00 2001
+From cf7a55308f292a53c5e69c4c8140e4b752c77dfc Mon Sep 17 00:00:00 2001
 From: Sunil Srivatsa <sunilsrivatsa@gmail.com>
 Date: Tue, 21 Jul 2026 10:22:26 -0400
 Subject: [PATCH 1/5] feat: add gateway collaboration controller
@@ -20,13 +20,13 @@ Subject: [PATCH 1/5] feat: add gateway collaboration controller
  .../test/collab/guest-ui-request.test.ts      |   8 +-
  .../test/collab/read-only.test.ts             |   1 -
  ...gistry-publisher-explicit-token.fixture.ts |  32 +
- .../test/collab/registry-publisher.test.ts    | 573 +++++++++++++++++
+ .../test/collab/registry-publisher.test.ts    | 582 +++++++++++++++++
  .../test/collab/replication-shrink.test.ts    |   1 -
  .../test/collab/steer-queue.test.ts           |   1 -
  .../test/config/collab-settings.test.ts       |   8 +
  .../test/session-manager-branch-order.test.ts |  14 +
  .../test/slash-commands/collab-qrcode.test.ts |  79 ++-
- 22 files changed, 1996 insertions(+), 78 deletions(-)
+ 22 files changed, 2005 insertions(+), 78 deletions(-)
  create mode 100644 packages/coding-agent/src/collab/controller.ts
  create mode 100644 packages/coding-agent/src/collab/registry-publisher.ts
  create mode 100644 packages/coding-agent/test/collab/controller.test.ts
@@ -1945,16 +1945,25 @@ index 000000000..32674dbd8
 +await new Promise(() => {});
 diff --git a/packages/coding-agent/test/collab/registry-publisher.test.ts b/packages/coding-agent/test/collab/registry-publisher.test.ts
 new file mode 100644
-index 000000000..b59e8bfd0
+index 000000000..83332b59f
 --- /dev/null
 +++ b/packages/coding-agent/test/collab/registry-publisher.test.ts
-@@ -0,0 +1,573 @@
+@@ -0,0 +1,582 @@
 +import { expect, test, vi } from "bun:test";
 +import { createHmac, randomBytes } from "node:crypto";
 +import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 +import { tmpdir } from "node:os";
 +import { join } from "node:path";
 +import { CollabRegistryPublisher, resolveCollabRegistryEndpoint } from "../../src/collab/registry-publisher";
++
++/**
++ * Windows secures every publisher-token fixture and re-validates its ACL through `powershell.exe`,
++ * and hosted runner images have made that spawn cost seconds rather than milliseconds. The first
++ * test in this file pays two cold starts. These budgets bound security assertions, not latency, so
++ * keep them wide enough on Windows that a slow spawn cannot masquerade as a protocol failure.
++ */
++const HANDSHAKE_TIMEOUT_MS = process.platform === "win32" ? 15_000 : 2_000;
++const PUBLISHER_TEST_TIMEOUT_MS = process.platform === "win32" ? 30_000 : 5_000;
 +
 +const record = {
 +	instanceId: "publisher-test-instance",
@@ -2043,7 +2052,7 @@ index 000000000..b59e8bfd0
 +	await rm(fixture.root, { recursive: true, force: true });
 +}
 +
-+async function beforeTimeout<T>(promise: Promise<T>, message: string, timeoutMilliseconds = 2_000): Promise<T> {
++async function beforeTimeout<T>(promise: Promise<T>, message: string, timeoutMilliseconds = HANDSHAKE_TIMEOUT_MS): Promise<T> {
 +	return await Promise.race([
 +		promise,
 +		Bun.sleep(timeoutMilliseconds).then(() => {
@@ -2199,7 +2208,7 @@ index 000000000..b59e8bfd0
 +		server.stop(true);
 +		await cleanupPublisherFixture(fixture);
 +	}
-+});
++}, PUBLISHER_TEST_TIMEOUT_MS);
 +
 +test("publisher authenticates the registry server before releasing capabilities", async () => {
 +	const fixture = await createPublisherFixture("mutual-auth");
@@ -2272,7 +2281,7 @@ index 000000000..b59e8bfd0
 +		server.stop(true);
 +		await cleanupPublisherFixture(fixture);
 +	}
-+});
++}, PUBLISHER_TEST_TIMEOUT_MS);
 +
 +test("publisher token path override preserves the ambient XDG configuration", async () => {
 +	const fixture = await createPublisherFixture("explicit-token-path");
@@ -2305,7 +2314,7 @@ index 000000000..b59e8bfd0
 +		server.server.stop(true);
 +		await cleanupPublisherFixture(fixture);
 +	}
-+});
++}, PUBLISHER_TEST_TIMEOUT_MS);
 +
 +test("publisher reconnects after registry restart and rereads the rotated token", async () => {
 +	const fixture = await createPublisherFixture("restart-token");
@@ -2376,7 +2385,7 @@ index 000000000..b59e8bfd0
 +		vi.restoreAllMocks();
 +		await cleanupPublisherFixture(fixture);
 +	}
-+});
++}, PUBLISHER_TEST_TIMEOUT_MS);
 +
 +test("invalid publisher configuration fails safely without exposing capabilities", async () => {
 +	const warning = Promise.withResolvers<string>();
@@ -2738,7 +2747,7 @@ index 8a63482d0..65c08959d 100644
 2.50.1 (Apple Git-155)
 
 
-From a000a13aae4f54792c36e823923f6c64d282e523 Mon Sep 17 00:00:00 2001
+From 6b2318b5f7f226ec71e1096686ec71ed2f5ea35b Mon Sep 17 00:00:00 2001
 From: Sunil Srivatsa <sunilsrivatsa@gmail.com>
 Date: Tue, 21 Jul 2026 11:25:56 -0400
 Subject: [PATCH 2/5] fix(collab): retain UI requests until a writer joins
@@ -2923,7 +2932,7 @@ index 0fa169eab..805d56bbb 100644
 2.50.1 (Apple Git-155)
 
 
-From ace9dbda1430d52f29e7cbfe2a4945580eb8300d Mon Sep 17 00:00:00 2001
+From 0ba85712195e7b76dcf726a546f5984cda55aee7 Mon Sep 17 00:00:00 2001
 From: Sunil Srivatsa <sunilsrivatsa@gmail.com>
 Date: Tue, 21 Jul 2026 11:31:08 -0400
 Subject: [PATCH 3/5] feat(collab): publish response-required state
@@ -3194,10 +3203,10 @@ index 32674dbd8..0f27bf06b 100644
  	controlLink: "CONTROL_CAPABILITY_FIXTURE",
  });
 diff --git a/packages/coding-agent/test/collab/registry-publisher.test.ts b/packages/coding-agent/test/collab/registry-publisher.test.ts
-index b59e8bfd0..a15e79666 100644
+index 83332b59f..5936e3792 100644
 --- a/packages/coding-agent/test/collab/registry-publisher.test.ts
 +++ b/packages/coding-agent/test/collab/registry-publisher.test.ts
-@@ -11,6 +11,7 @@ const record = {
+@@ -20,6 +20,7 @@ const record = {
  	pid: process.pid,
  	sessionId: "publisher-test-session",
  	startedAt: "2026-07-19T00:00:00.000Z",
@@ -3205,7 +3214,7 @@ index b59e8bfd0..a15e79666 100644
  	viewLink: "VIEW_CAPABILITY_FIXTURE",
  	controlLink: "CONTROL_CAPABILITY_FIXTURE",
  };
-@@ -27,6 +28,7 @@ interface AuthenticatedRegistryServer {
+@@ -36,6 +37,7 @@ interface AuthenticatedRegistryServer {
  	readonly frames: Array<Record<string, unknown>>;
  	readonly binding: () => AuthBinding | undefined;
  	readonly upsertReceived: Promise<void>;
@@ -3213,7 +3222,7 @@ index b59e8bfd0..a15e79666 100644
  }
  
  interface PublisherFixture {
-@@ -108,6 +110,15 @@ function startAuthenticatedRegistryServer(
+@@ -117,6 +119,15 @@ function startAuthenticatedRegistryServer(
  ): AuthenticatedRegistryServer {
  	const frames: Array<Record<string, unknown>> = [];
  	const upsertReceived = Promise.withResolvers<void>();
@@ -3229,7 +3238,7 @@ index b59e8bfd0..a15e79666 100644
  	let binding: AuthBinding | undefined;
  	let activeSocket: Bun.Socket<{ buffer: string }> | undefined;
  	const server = Bun.listen<{ buffer: string }>({
-@@ -144,6 +155,9 @@ function startAuthenticatedRegistryServer(
+@@ -153,6 +164,9 @@ function startAuthenticatedRegistryServer(
  						socket.write(`${JSON.stringify({ v: 1, op: "hello_ok", heartbeatSeconds: 10, ttlSeconds: 35 })}\n`);
  					} else if (frame.op === "upsert") {
  						upsertReceived.resolve();
@@ -3239,7 +3248,7 @@ index b59e8bfd0..a15e79666 100644
  					}
  				}
  			},
-@@ -158,6 +172,7 @@ function startAuthenticatedRegistryServer(
+@@ -167,6 +181,7 @@ function startAuthenticatedRegistryServer(
  		frames,
  		binding: () => binding,
  		upsertReceived: upsertReceived.promise,
@@ -3247,7 +3256,7 @@ index b59e8bfd0..a15e79666 100644
  	};
  }
  
-@@ -382,6 +397,9 @@ test("publisher reconnects after registry restart and rereads the rotated token"
+@@ -391,6 +406,9 @@ test("publisher reconnects after registry restart and rereads the rotated token"
  			authProof(initialToken, "omp-session-gateway.registry.client.v1", firstBinding as AuthBinding),
  		);
  		expect(first.frames[2]).toHaveProperty("session.viewLink", record.viewLink);
@@ -3257,7 +3266,7 @@ index b59e8bfd0..a15e79666 100644
  
  		const timeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
  			callback: (...callbackArguments: unknown[]) => void,
-@@ -414,6 +432,7 @@ test("publisher reconnects after registry restart and rereads the rotated token"
+@@ -423,6 +441,7 @@ test("publisher reconnects after registry restart and rereads the rotated token"
  			authProof(rotatedToken, "omp-session-gateway.registry.client.v1", secondBinding as AuthBinding),
  		);
  		expect(second.frames[2]).toHaveProperty("session.viewLink", record.viewLink);
@@ -3269,7 +3278,7 @@ index b59e8bfd0..a15e79666 100644
 2.50.1 (Apple Git-155)
 
 
-From 4a59450e8d854ac77755d66f796dff23a27ff52a Mon Sep 17 00:00:00 2001
+From dcb55ae7b59fda510cdf87c83d2c58f9435cd09f Mon Sep 17 00:00:00 2001
 From: Sunil Srivatsa <sunilsrivatsa@gmail.com>
 Date: Tue, 21 Jul 2026 11:45:28 -0400
 Subject: [PATCH 4/5] feat(collab): mirror response UI safely
@@ -4190,7 +4199,7 @@ index 308f58b79..6e51e0f82 100644
 2.50.1 (Apple Git-155)
 
 
-From 708d7a53e5017d5001f25352b7b84c7324efefca Mon Sep 17 00:00:00 2001
+From 5ccdaabeccfdcb896f5d029ecacbc74d43856e15 Mon Sep 17 00:00:00 2001
 From: Sunil Srivatsa <sunilsrivatsa@gmail.com>
 Date: Sun, 26 Jul 2026 22:48:20 -0400
 Subject: [PATCH 5/5] feat(collab): acknowledge web health and responses

--- a/patches/oh-my-pi/README.md
+++ b/patches/oh-my-pi/README.md
@@ -4,11 +4,11 @@
 `89d6a8f6d14286f32f09ec9c8aa8af7b3451d2d6` (nearest release: v17.0.6).
 The artifact is one mbox containing five reviewable commits:
 
-- `7e8a69b55` — shared collaboration controller, auto-start, lifecycle, and authenticated registry publisher;
-- `a000a13aa` — bounded, replayable host UI requests retained before a writable guest joins;
-- `ace9dbda1` — generation-scoped `inputRequired` publication;
-- `4a59450e8` — safe response-UI mirroring, race cleanup, and startup ordering; and
-- `708d7a53e` — optional encrypted health probes and idempotent response acknowledgement.
+- `cf7a55308` — shared collaboration controller, auto-start, lifecycle, and authenticated registry publisher;
+- `6b2318b5f` — bounded, replayable host UI requests retained before a writable guest joins;
+- `0ba857121` — generation-scoped `inputRequired` publication;
+- `dcb55ae7b` — safe response-UI mirroring, race cleanup, and startup ordering; and
+- `5ccdaabec` — optional encrypted health probes and idempotent response acknowledgement.
 
 It:
 
@@ -53,6 +53,15 @@ symmetric response-race cleanup, mutual authentication, reconnect/token reread,
 explicit-token-path isolation, collaboration-before-hooks ordering, optional read-only health
 probes, and duplicate response acknowledgement. Run every listed test, the coding-agent typecheck,
 and `bun run ci:check:full` against the exact pin before release qualification.
+
+On Windows every publisher-token fixture is secured, and the publisher's own token ACL is
+validated, by spawning `powershell.exe`. Hosted runner images have made that spawn cost seconds
+rather than milliseconds, and the first test in `registry-publisher.test.ts` pays two cold starts.
+`registry-publisher.test.ts` therefore scales its per-test and handshake budgets by platform
+(`PUBLISHER_TEST_TIMEOUT_MS`, `HANDSHAKE_TIMEOUT_MS`). Those budgets bound security assertions, not
+latency: they exist so a slow spawn cannot masquerade as a protocol failure. Treat a *sustained*
+rise in these tests' runtime as a signal to profile the Windows ACL path rather than to widen them
+again.
 
 Isolated launchers may set `OMP_GATEWAY_PUBLISHER_TOKEN_PATH` to an absolute publisher-token file so OMP can use a trial gateway without replacing `XDG_CONFIG_HOME` for OMP tools and child processes. The same regular-file, no-symlink, current-user ownership, mode, ACL, length, and alphabet checks apply; the environment variable carries only the path, never the token.
 


### PR DESCRIPTION
## Problem

A production daemon ran for a week without publishing a single session. macOS reaps idle entries under the per-user `TMPDIR` and had deleted `registry.sock` together with its parent directory, while Bun kept listening on the now-unlinked inode. Publishers resolve that path by name, so every OMP upsert failed with `ENOENT`.

The daemon reported itself healthy throughout. The "a missing gateway never breaks OMP" contract converted a total outage into silence: no card ever appeared on the phone, and nothing in health, status, or logs said why.

## Change

- **Rendezvous self-healing (`apps/gateway/src/ipc.ts`).** Record the device and inode the IPC server bound, and re-check the path on a bounded 15-second cadence. A missing path means our own rendezvous point vanished: stop the orphaned listener, recreate the `0700` runtime directory, re-bind, and re-assert `0600` private permissions. A path resolving to a *different* inode belongs to another process and is reported unhealthy rather than clobbered — we never unlink a peer's socket.
- **State-faithful readiness (`apps/gateway/src/http.ts`, `cli.ts`).** `/api/v1/health` returns `degraded` whenever the endpoint is unreachable, preserving the HMAC challenge shape and exposing no paths, counts, or publisher detail. `gatewayReady` already requires `status === "ready"`, so an unreachable endpoint now fails readiness instead of passing it.

## Threat-model impact

Reviewed against `docs/SECURITY.md`:

- **IPC surface.** Re-bind reuses the same creation path as first bind: `0700` directory, `0600` socket, current-user only. No widening. The inode-mismatch branch is deliberately fail-closed — it degrades health instead of unlinking a path another process owns, so this cannot be turned into a socket-hijack primitive by an attacker who wins a create race.
- **Information disclosure.** The degraded health response keeps the existing HMAC challenge shape and adds no path, count, publisher, or error detail. Capability-leak scanning passes.
- **Availability.** Bounded 15-second cadence, no unbounded retry. A reaped path is repaired without operator action; a contended path is surfaced rather than silently fought over.
- **No change** to capability handling, the registry's in-memory-only rule, generation semantics, or the HTTP identity boundary.

## Deferred

Moving the darwin runtime directory out of `TMPDIR` remains the preferred structural fix, but it changes the rendezvous contract on both sides. It is deferred to a release that ships a regenerated OMP publisher patch in lockstep. Recorded in `docs/DECISIONS.md`.

## Verification

`bun run check` green from a clean tree: handoff validation (244 files), four workspace typechecks, production web/client build, **131 tests / 763 assertions across 21 files**, capability-leak scan. Up from 118/673 on the previous candidate; new coverage is the reap/rebind and inode-mismatch paths in `apps/gateway/test/ipc.test.ts` plus degraded-health assertions in `apps/gateway/test/http.test.ts`.

This is a repository-suite pass. It does not advance any native, Tailscale, relay, or Android row in `docs/RELEASE_STATUS.md`.
