### PR TITLE
docs: cross-link the upstream discussion and contribution

### DIFF
--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -35,6 +35,12 @@ These links informed the design snapshot. OMP and Tailscale are active projects;
 - WebAuthn: https://www.w3.org/TR/webauthn-3/
 - MessageChannel: https://developer.mozilla.org/docs/Web/API/MessageChannel
 
+## Upstream collaboration thread
+
+- Discussion #6460 (remote access to collab sessions): https://github.com/can1357/oh-my-pi/discussions/6460
+- Our contribution, bounded pending UI retention: https://github.com/can1357/oh-my-pi/pull/9031
+- Related enrollment work by others: https://github.com/can1357/oh-my-pi/pull/6354 and https://github.com/can1357/oh-my-pi/issues/6171
+
 ## Notes for the implementer
 
 - Verify that OMP has not added a supported collaboration automation API since this snapshot.

--- a/patches/oh-my-pi/README.md
+++ b/patches/oh-my-pi/README.md
@@ -77,6 +77,19 @@ again.
 
 Isolated launchers may set `OMP_GATEWAY_PUBLISHER_TOKEN_PATH` to an absolute publisher-token file so OMP can use a trial gateway without replacing `XDG_CONFIG_HOME` for OMP tools and child processes. The same regular-file, no-symlink, current-user ownership, mode, ACL, length, and alphabet checks apply; the environment variable carries only the path, never the token.
 
-No upstream PR or fork commit exists yet. Rebase by revalidating the paths in `UPSTREAM.lock.json`, applying
+## Upstream status
+
+Discussion: [can1357/oh-my-pi#6460 — Seamlessly connect all oh-my-pi collab session from anywhere](https://github.com/can1357/oh-my-pi/discussions/6460).
+
+| Piece | Upstream state |
+| --- | --- |
+| Bounded pending host UI retention (`0002` lineage) | Submitted as [PR #9031](https://github.com/can1357/oh-my-pi/pull/9031) from `alphastorm:contrib/collab-retain-pending-ui`. Isolated from the controller/registry stack: three files, no wire-protocol change. |
+| Controller, auto-start, and registry publisher | Not submitted. It is a new subsystem spanning several packages, which upstream `CONTRIBUTING.md` requires be discussed in Discord *before* implementation; it also overlaps [#6354](https://github.com/can1357/oh-my-pi/pull/6354) and [#6171](https://github.com/can1357/oh-my-pi/issues/6171). |
+| Optional encrypted `gateway-health` probes (commit five) | Not submitted; no upstream seam exists at `v17.3.8`. Flagged in the discussion because it fails inert rather than loudly. |
+| Gateway daemon, PWA, Tailscale identity, capability broker | Out of scope for upstream by design. |
+
+Do not open an upstream issue for work that is about to be submitted: upstream `CONTRIBUTING.md` treats actionable issues as work its bot may pick up in parallel. Link an existing issue from the pull request instead. Every pull request body must also contain at least one sentence written by the human contributor.
+
+Rebase by revalidating the paths in `UPSTREAM.lock.json`, applying
 with `git apply --3way`, resolving only narrow collaboration conflicts, then rerunning all listed and
 coding-agent tests. Keep generated assets, gateway code, and an optional future extension API out of this patch.


### PR DESCRIPTION
## Why

`patches/oh-my-pi/README.md` claimed "No upstream PR or fork commit exists yet." That is now false: [can1357/oh-my-pi#9031](https://github.com/can1357/oh-my-pi/pull/9031) is open from `alphastorm:contrib/collab-retain-pending-ui`, and the work is being tracked in [discussion #6460](https://github.com/can1357/oh-my-pi/discussions/6460).

## Change

- An **Upstream status** table in the patch README recording, per piece, what was submitted and what deliberately was not:
  - bounded pending host UI retention → PR #9031, isolated from the controller/registry stack;
  - controller / auto-start / registry publisher → **not** submitted; it is a new subsystem spanning several packages, which upstream `CONTRIBUTING.md` requires be discussed in Discord *before* implementation, and it overlaps #6354 and #6171;
  - optional `gateway-health` probes → not submitted, no upstream seam at v17.3.8;
  - daemon, PWA, Tailscale identity, capability broker → out of scope by design.
- Two upstream process rules written down so they are not rediscovered: **do not file an issue for work about to be submitted** (upstream's bot treats actionable issues as work to pick up in parallel), and **every PR body needs a sentence written by the human contributor** — an agent cannot satisfy that on their behalf.
- `docs/REFERENCES.md` gains the thread, our PR, and the related enrollment work.

## Verification

Documentation only; no runtime or protocol change. `bun run check` green from a clean tree — 131 tests / 763 assertions / 21 files, handoff validation, four typechecks, production build, capability-leak scan.

The upstream PR itself is verified separately in its own body: three new tests fail on unmodified upstream source and pass with the change, `tsgo` typecheck clean, Biome clean.
