### PR TITLE
fix(doctor): update the hardcoded upstream pin and guard it with a test

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
     id: omp-version
     attributes:
       label: OMP version or commit
-      placeholder: v17.0.6 or exact commit SHA
+      placeholder: v17.3.8 or exact commit SHA
     validations:
       required: true
   - type: dropdown

--- a/apps/gateway/src/doctor.ts
+++ b/apps/gateway/src/doctor.ts
@@ -17,6 +17,14 @@ const MAX_COMMAND_OUTPUT_BYTES = 1024 * 1024;
 const MAX_READINESS_BODY_BYTES = 512;
 const NETWORK_TIMEOUT_MS = 3_000;
 const DEFAULT_RELAY_HEALTH_URL = "https://my.omp.sh";
+/**
+ * Expected upstream identity of the shipped compatibility artifacts. These duplicate
+ * `UPSTREAM.lock.json` deliberately: the check exists to notice a tampered or mismatched lock, so
+ * reading the expectation out of the same file would make it tautological. `pin contract` in
+ * `apps/gateway/test/doctor.test.ts` fails whenever the two drift, so refresh both together.
+ */
+export const EXPECTED_UPSTREAM_COMMIT = "858f7dd91fff9b84cf8a2c6a6bb85aa0e6d03a55";
+export const EXPECTED_UPSTREAM_CODING_AGENT_VERSION = "17.3.8";
 
 function property(value: unknown, key: string): unknown {
   return typeof value === "object" && value !== null ? Reflect.get(value, key) : undefined;
@@ -261,8 +269,9 @@ async function compatibilityArtifactsPresent(): Promise<boolean> {
     const lock = JSON.parse(lockText) as unknown;
     return (
       property(lock, "repository") === "https://github.com/can1357/oh-my-pi" &&
-      property(lock, "commit") === "89d6a8f6d14286f32f09ec9c8aa8af7b3451d2d6" &&
-      property(property(lock, "packageVersions"), "@oh-my-pi/pi-coding-agent") === "17.0.6" &&
+      property(lock, "commit") === EXPECTED_UPSTREAM_COMMIT &&
+      property(property(lock, "packageVersions"), "@oh-my-pi/pi-coding-agent") ===
+        EXPECTED_UPSTREAM_CODING_AGENT_VERSION &&
       patch.includes("packages/coding-agent/src/collab/controller.ts") &&
       patch.includes("packages/coding-agent/src/collab/registry-publisher.ts")
     );

--- a/apps/gateway/test/doctor.test.ts
+++ b/apps/gateway/test/doctor.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { EXPECTED_UPSTREAM_CODING_AGENT_VERSION, EXPECTED_UPSTREAM_COMMIT } from "../src/doctor.ts";
+
+/**
+ * `compatibilityArtifactsPresent` deliberately hardcodes the upstream identity rather than reading
+ * it from the lock it is validating. That duplication is the point — it detects a tampered or
+ * mismatched lock — but it silently rots on an upstream refresh. On 2026-08-19 the pin moved to
+ * v17.3.8 while these constants still named v17.0.6, and `doctor` reported `compatibility: false`
+ * against a correct checkout. Nothing failed, because nothing compared the two.
+ */
+test("pin contract: doctor's expected upstream identity matches UPSTREAM.lock.json", async () => {
+  const lock = JSON.parse(
+    await readFile(fileURLToPath(new URL("../../../UPSTREAM.lock.json", import.meta.url)), "utf8"),
+  ) as { commit: string; packageVersions: Record<string, string> };
+
+  expect(EXPECTED_UPSTREAM_COMMIT).toBe(lock.commit);
+  expect(lock.packageVersions["@oh-my-pi/pi-coding-agent"]).toBe(EXPECTED_UPSTREAM_CODING_AGENT_VERSION);
+});
+
+test("pin contract: the shipped patch targets the locked upstream commit", async () => {
+  const patch = await readFile(
+    fileURLToPath(new URL("../../../patches/oh-my-pi/0001-collab-controller-autostart-registry.patch", import.meta.url)),
+    "utf8",
+  );
+
+  // The controller and publisher are the two files the compatibility check looks for; if a refresh
+  // ever regenerates the mbox without them, the gateway integration is not actually present.
+  expect(patch).toContain("packages/coding-agent/src/collab/controller.ts");
+  expect(patch).toContain("packages/coding-agent/src/collab/registry-publisher.ts");
+});


### PR DESCRIPTION
## Problem

Caught against the live daemon after #48: `doctor` reported `compatibility: false` on a correct checkout.

`compatibilityArtifactsPresent()` hardcodes the expected upstream commit and coding-agent version instead of reading them from the lock it validates. That duplication is deliberate and correct — it is precisely how a tampered or mismatched `UPSTREAM.lock.json` gets detected; reading the expectation out of the file under test would make the check tautological.

But nothing compared the two, so the v17.3.8 refresh moved the lock and left the constants naming `v17.0.6` / `89d6a8f6`. My sweep for stale pin references in #48 was truncated by `head -30` and these two lines fell past the cut.

This is a real operational failure, not cosmetic: `compatibility` is one of the sixteen `doctor` checks, and `doctor` gates install and qualification.

## Change

- Hoist the values into exported `EXPECTED_UPSTREAM_COMMIT` and `EXPECTED_UPSTREAM_CODING_AGENT_VERSION`, pointed at the current pin, with a comment explaining why the duplication exists and what enforces it.
- Add `apps/gateway/test/doctor.test.ts` with two pin-contract tests: the constants must equal `UPSTREAM.lock.json`, and the shipped mbox must still contain the controller and publisher sources the check looks for.
- Refresh the bug-report template placeholder.

## Verification

The guard fails on the exact drift it exists to catch — reverting `EXPECTED_UPSTREAM_COMMIT` to `89d6a8f6`:

```
(fail) pin contract: doctor's expected upstream identity matches UPSTREAM.lock.json
 1 pass, 1 fail
```

Restored, against the live installed daemon:

```
compatibility: True
all sixteen checks true
```

`bun run check` green from a clean tree — **133 tests / 767 assertions / 22 files** (up from 131/763; the two new tests are the delta).

## Threat-model impact

None. The check's semantics are unchanged — it still compares the shipped lock against an independently held expectation, so a swapped or edited lock is still detected. Only the expected value moved, and it is now pinned by a test rather than by memory.
