### PR TITLE
chore(deps-dev): bump @playwright/test from 1.61.1 to 1.62.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "omp-session-gateway",
       "devDependencies": {
-        "@playwright/test": "1.61.1",
+        "@playwright/test": "1.62.1",
         "@types/bun": "1.3.14",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
@@ -57,7 +57,7 @@
 
     "@omp-session-gateway/web": ["@omp-session-gateway/web@workspace:apps/web"],
 
-    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -147,9 +147,9 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
 
-    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:browser": "bun run build && bun scripts/test-browser.ts"
   },
   "devDependencies": {
-    "@playwright/test": "1.61.1",
+    "@playwright/test": "1.62.1",
     "@types/bun": "1.3.14",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",


### PR DESCRIPTION
Last item in the dependabot backlog. Supersedes #45, which was red only because it was raised against pre-refresh `main`.

Dev-only and outside the bundled runtime closure, so unlike #53 there is no license, notices, or SBOM movement.

## One thing worth knowing before you pull this

1.62.1 requires a newer Chromium than 1.61.1 pinned — `chromium-headless-shell v1234`, Chrome `151.0.7922.34`. CI installs the browser fresh on every run, so it picks that up with no change. A **local** checkout does not: every E2E test fails at browser launch with

```
browserType.launch: Executable doesn't exist at .../chromium_headless_shell-1234/...
```

until you run `bunx playwright install chromium` once. I hit exactly that, which is the only reason it is called out here rather than discovered later.

## Verification

`bun run check` green from a clean tree — 133 tests / 767 assertions / 22 files.

**20 Playwright cases pass at both `412 × 915` and `390 × 844`** on the new browser build. Running the suite was the point of the exercise: a test-runner bump that silently stopped executing the suite would look identical to a passing one in `bun run check`, since `check` does not invoke Playwright.

## Backlog now clear

| PR | Disposition |
|---|---|
| #46 lucide-react → 1.31.0 | Taken in #53 — matches upstream v17.3.8's resolved version |
| #43 marked → 18.0.9 | Taken in #53 with license/SBOM updates |
| #18 actions/checkout → 7.0.1 | Taken in #53 |
| #45 @playwright/test → 1.62.1 | This PR |
| #49 react-dom → 19.2.8 | Closed — diverges from upstream's exact 19.2.7 pin |
| #19 attest-build-provenance → 4.2.2 | Held open — two-major jump on release provenance, unexercised by PR checks, wants a `provenance-test-*` tag run |
