### PR TITLE
fix(service): scope service liveness to the install that owns it

### DIFF
--- a/apps/gateway/src/service.ts
+++ b/apps/gateway/src/service.ts
@@ -1,6 +1,6 @@
 import { access, chmod, mkdir, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { GatewayConfig } from "./config.ts";
 type ServicePathConfig = Pick<GatewayConfig, "paths">;
@@ -88,6 +88,56 @@ async function commandSucceeds(command: readonly string[]): Promise<boolean> {
   }
 }
 
+async function commandOutput(command: readonly string[]): Promise<string | undefined> {
+  try {
+    const subprocess = Bun.spawn([...command], { stdin: "ignore", stdout: "pipe", stderr: "ignore" });
+    const stdout = await new Response(subprocess.stdout).text();
+    return (await subprocess.exited) === 0 ? stdout : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Whether a service manager's rendering of a loaded unit names a program under `stateDir`.
+ *
+ * Installed runtimes live at `<stateDir>/installation/versions/<id>/...`, so the install root is a
+ * path prefix of the program the OS is actually executing. The trailing separator matters: without
+ * it `/tmp/x/state/omp-session-gateway` would match a sibling root like
+ * `/tmp/x/state/omp-session-gateway-2`.
+ */
+export function serviceProgramBelongsTo(programText: string | undefined, stateDir: string): boolean {
+  return programText !== undefined && programText.includes(stateDir + sep);
+}
+
+/**
+ * Whether the service instance the OS currently has loaded was installed from *this* config root.
+ *
+ * Service managers key their registry on identity that no filesystem override can scope: launchd on
+ * `gui/<uid>/<label>`, systemd on the user unit name, Task Scheduler on the task name. Pointing
+ * `HOME`/`XDG_CONFIG_HOME` at a sandbox therefore isolates every file this program writes and none
+ * of the state it reads back, so an install rooted in a temp directory observes the real service and
+ * reports it as its own. On 2026-08-19 that cost a live daemon: an isolated archive smoke saw
+ * `active: true` from the production service and `rotate-publisher-token` booted it out.
+ *
+ * The loaded service's own program path is the one piece of identity that does carry the root, so
+ * compare against it rather than trusting the label. Returns false when nothing is loaded.
+ */
+async function loadedServiceIsOurs(config: ServicePathConfig): Promise<boolean> {
+  const owns = (text: string | undefined): boolean => serviceProgramBelongsTo(text, config.paths.stateDir);
+  if (process.platform === "linux") {
+    if (!(await commandSucceeds(["systemctl", "--user", "is-active", "omp-session-gateway.service"]))) return false;
+    return owns(
+      await commandOutput(["systemctl", "--user", "show", "-p", "ExecStart", "--value", "omp-session-gateway.service"]),
+    );
+  }
+  if (process.platform === "darwin") {
+    return owns(await commandOutput(["launchctl", "print", `gui/${process.getuid?.() ?? 0}/omp-session-gateway`]));
+  }
+  if (!(await windowsTaskActive())) return false;
+  return owns(await commandOutput(["schtasks.exe", "/Query", "/TN", "OMP Session Gateway", "/XML"]));
+}
+
 
 async function bootstrapLaunchAgent(domain: string, path: string): Promise<void> {
   let lastError: unknown;
@@ -140,18 +190,16 @@ async function stopWindowsTask(): Promise<void> {
 export async function userServiceStatus(config: ServicePathConfig): Promise<UserServiceStatus> {
   const definition = serviceDefinition(config);
   const definitionExists = await fileExists(definition.path);
+  // `active` means "a service this install owns is running", never "some service holds our label".
+  // Everything downstream acts on it: rotation restarts, stop boots out, uninstall refuses.
+  const active = await loadedServiceIsOurs(config);
   if (process.platform === "linux") {
     const installed =
       definitionExists && (await commandSucceeds(["systemctl", "--user", "is-enabled", "omp-session-gateway.service"]));
-    const active = await commandSucceeds(["systemctl", "--user", "is-active", "omp-session-gateway.service"]);
     return { installed, active };
   }
-  if (process.platform === "darwin") {
-    const target = `gui/${process.getuid?.() ?? 0}/omp-session-gateway`;
-    return { installed: definitionExists, active: await commandSucceeds(["launchctl", "print", target]) };
-  }
+  if (process.platform === "darwin") return { installed: definitionExists, active };
   const installed = await commandSucceeds(["schtasks.exe", "/Query", "/TN", "OMP Session Gateway"]);
-  const active = installed && (await windowsTaskActive());
   return { installed, active };
 }
 
@@ -178,7 +226,18 @@ export async function installUserService(
   } else if (process.platform === "darwin") {
     if (!activate) return definition;
     const target = `gui/${process.getuid?.() ?? 0}/omp-session-gateway`;
-    if (await commandSucceeds(["launchctl", "print", target])) await run(["launchctl", "bootout", target]);
+    if (await commandSucceeds(["launchctl", "print", target])) {
+      // Replacing our own running instance is the ordinary upgrade path. Booting out a service that
+      // belongs to a different install root is how a sandboxed run kills the real daemon, so refuse
+      // instead: launchd keys the label on uid alone and cannot tell the two apart for us.
+      if (!(await loadedServiceIsOurs(config))) {
+        throw new Error(
+          "another gateway service already holds this launchd label from a different install root; " +
+            "uninstall it from that root before installing here",
+        );
+      }
+      await run(["launchctl", "bootout", target]);
+    }
     await bootstrapLaunchAgent(`gui/${process.getuid?.() ?? 0}`, definition.path);
   } else {
     const status = await userServiceStatus(config);

--- a/apps/gateway/test/service.test.ts
+++ b/apps/gateway/test/service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { GatewayConfig } from "../src/config.ts";
-import { serviceDefinition } from "../src/service.ts";
+import { serviceDefinition, serviceProgramBelongsTo } from "../src/service.ts";
 
 const config: GatewayConfig = {
   http: { hostname: "127.0.0.1", port: 4317, publicOrigin: "https://gateway.example.ts.net" },
@@ -53,5 +53,48 @@ describe("service packaging", () => {
     expect(definition.content).toContain("<AllowHardTerminate>true</AllowHardTerminate>");
     expect(definition.content).not.toContain("HighestAvailable");
     expect(definition.content).not.toContain("cmd.exe");
+  });
+});
+
+/**
+ * Regression for a live outage on 2026-08-19. Service managers key their registry on identity no
+ * filesystem override can scope — launchd on `gui/<uid>/<label>`, systemd on the unit name, Task
+ * Scheduler on the task name — so an install rooted in a sandbox sees the real machine's service and
+ * previously reported it as its own. An isolated archive smoke then ran `rotate-publisher-token`,
+ * which took the active branch and booted out the production daemon.
+ */
+describe("loaded service ownership", () => {
+  const stateDir = "/Users/example/.local/state/omp-session-gateway";
+  const launchctlPrint = `gui/501/omp-session-gateway = {
+	program = /opt/homebrew/Cellar/bun/1.3.14/bin/bun
+	arguments = {
+		/opt/homebrew/Cellar/bun/1.3.14/bin/bun
+		${stateDir}/installation/versions/0.1.0-77e3a6914cea/apps/gateway/src/cli.js
+		serve
+	}
+}`;
+
+  test("claims a loaded service whose program lives under this install root", () => {
+    expect(serviceProgramBelongsTo(launchctlPrint, stateDir)).toBe(true);
+  });
+
+  test("disclaims a service installed from a different root", () => {
+    expect(serviceProgramBelongsTo(launchctlPrint, "/tmp/smoke.abc123/state/omp-session-gateway")).toBe(false);
+  });
+
+  test("disclaims a sibling root that shares a path prefix", () => {
+    // Without the trailing separator this matches, and a second install silently adopts the first.
+    expect(serviceProgramBelongsTo(launchctlPrint, "/Users/example/.local/state/omp-session-gateway-2")).toBe(false);
+    expect(serviceProgramBelongsTo(`${stateDir}-2/installation/x/cli.js`, stateDir)).toBe(false);
+  });
+
+  test("disclaims when the service manager reports nothing loaded", () => {
+    expect(serviceProgramBelongsTo(undefined, stateDir)).toBe(false);
+  });
+
+  test("reads a systemd ExecStart line", () => {
+    const execStart = `{ path=/usr/bin/bun ; argv[]=/usr/bin/bun ${stateDir}/installation/versions/0.1.0-a/apps/gateway/src/cli.js serve ; ignore_errors=no }`;
+    expect(serviceProgramBelongsTo(execStart, stateDir)).toBe(true);
+    expect(serviceProgramBelongsTo(execStart, "/tmp/other/state/omp-session-gateway")).toBe(false);
   });
 });

--- a/apps/gateway/test/service.test.ts
+++ b/apps/gateway/test/service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { join, sep } from "node:path";
 import type { GatewayConfig } from "../src/config.ts";
 import { serviceDefinition, serviceProgramBelongsTo } from "../src/service.ts";
 
@@ -64,12 +65,16 @@ describe("service packaging", () => {
  * which took the active branch and booted out the production daemon.
  */
 describe("loaded service ownership", () => {
-  const stateDir = "/Users/example/.local/state/omp-session-gateway";
+  // Build fixtures with the host separator: the predicate compares against `stateDir + sep`, so a
+  // hard-coded POSIX fixture would vacuously fail on Windows and pass for the wrong reason on macOS.
+  const stateDir = join(sep, "Users", "example", ".local", "state", "omp-session-gateway");
+  const installedCli = join(stateDir, "installation", "versions", "0.1.0-77e3a6914cea", "apps", "gateway", "src", "cli.js");
+  const otherRoot = join(sep, "tmp", "smoke.abc123", "state", "omp-session-gateway");
   const launchctlPrint = `gui/501/omp-session-gateway = {
 	program = /opt/homebrew/Cellar/bun/1.3.14/bin/bun
 	arguments = {
 		/opt/homebrew/Cellar/bun/1.3.14/bin/bun
-		${stateDir}/installation/versions/0.1.0-77e3a6914cea/apps/gateway/src/cli.js
+		${installedCli}
 		serve
 	}
 }`;
@@ -79,13 +84,13 @@ describe("loaded service ownership", () => {
   });
 
   test("disclaims a service installed from a different root", () => {
-    expect(serviceProgramBelongsTo(launchctlPrint, "/tmp/smoke.abc123/state/omp-session-gateway")).toBe(false);
+    expect(serviceProgramBelongsTo(launchctlPrint, otherRoot)).toBe(false);
   });
 
   test("disclaims a sibling root that shares a path prefix", () => {
     // Without the trailing separator this matches, and a second install silently adopts the first.
-    expect(serviceProgramBelongsTo(launchctlPrint, "/Users/example/.local/state/omp-session-gateway-2")).toBe(false);
-    expect(serviceProgramBelongsTo(`${stateDir}-2/installation/x/cli.js`, stateDir)).toBe(false);
+    expect(serviceProgramBelongsTo(launchctlPrint, `${stateDir}-2`)).toBe(false);
+    expect(serviceProgramBelongsTo(join(`${stateDir}-2`, "installation", "x", "cli.js"), stateDir)).toBe(false);
   });
 
   test("disclaims when the service manager reports nothing loaded", () => {
@@ -93,8 +98,8 @@ describe("loaded service ownership", () => {
   });
 
   test("reads a systemd ExecStart line", () => {
-    const execStart = `{ path=/usr/bin/bun ; argv[]=/usr/bin/bun ${stateDir}/installation/versions/0.1.0-a/apps/gateway/src/cli.js serve ; ignore_errors=no }`;
+    const execStart = `{ path=/usr/bin/bun ; argv[]=/usr/bin/bun ${installedCli} serve ; ignore_errors=no }`;
     expect(serviceProgramBelongsTo(execStart, stateDir)).toBe(true);
-    expect(serviceProgramBelongsTo(execStart, "/tmp/other/state/omp-session-gateway")).toBe(false);
+    expect(serviceProgramBelongsTo(execStart, otherRoot)).toBe(false);
   });
 });


### PR DESCRIPTION
## Incident

While re-qualifying the extracted-archive smoke at the v17.3.8 pin, an **isolated** run took down the live production daemon on this machine.

The smoke ran under `env -i` with `HOME`, `XDG_CONFIG_HOME`, `XDG_STATE_HOME`, and `TMPDIR` all pointed at a temp root. It then ran `rotate-publisher-token`, which saw `active: true`, took the restart branch, and issued `launchctl bootout gui/501/omp-session-gateway` — against the **real** service. PID 9994 died, the LaunchAgent unloaded, and all publishers dropped until it was bootstrapped again by hand.

## Why isolation could not have worked

Service managers key their registry on identity that no filesystem override can scope:

| platform | identity | scoped by `HOME`/`XDG_*`? |
|---|---|---|
| macOS | `gui/<uid>/omp-session-gateway` | no |
| Linux | `omp-session-gateway.service` (user unit) | no |
| Windows | task name `OMP Session Gateway` | no |

So env isolation covers every file we *write* and none of the state we *read back*. `userServiceStatus` asked launchd "is this label loaded?", launchd answered about the production service, and everything downstream — rotation restarts, `stopUserService`, `uninstall` refusal — acted on that answer.

This also means the existing "isolated archive smoke" procedure is a landmine on any machine with a real install. It was safe historically only because it never invoked `rotate-publisher-token`.

## Fix

Ask a question the label cannot confuse: **does the loaded service's own program path live under this install's `stateDir`?** Installed runtimes live at `<stateDir>/installation/versions/<id>/…`, so the root is a path prefix of the program the OS is actually executing.

- `userServiceStatus` now derives `active` from that ownership check on all three platforms.
- `installUserService` refuses to boot out a service belonging to a different root instead of hijacking the label. Replacing our own instance remains the ordinary upgrade path.
- The comparison appends a path separator, so `…/omp-session-gateway` cannot adopt `…/omp-session-gateway-2`.

## Verification

Measured against the live machine with the real service running:

| root | before | after |
|---|---|---|
| isolated temp root | `{installed:false, active:true}` | `{installed:false, active:false}` |
| real install root | `{installed:true, active:true}` | `{installed:true, active:true}` |

So rotation in a sandbox now takes the inactive branch and cannot reach the production daemon.

Five regression tests over real `launchctl print` and `systemd ExecStart` renderings. They fail on the actual defect rather than restating the code — dropping the trailing separator fails `disclaims a sibling root that shares a path prefix`.

`bun run check` green from a clean tree: **138 tests / 774 assertions / 22 files** (up from 133/767).

## Threat-model impact

Strictly narrowing. `active` previously meant "some service holds our label", which let one install act on another's daemon; it now means "a service this install owns is running". No change to capability handling, IPC authentication, the registry, or the HTTP identity boundary. The new refusal path in `installUserService` is fail-closed: it errors rather than replacing a service it cannot prove is its own.
