### PR TITLE
docs(release): record the silent publisher latch as an alpha blocker

### DIFF
--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -130,9 +130,18 @@ The alpha decision remains **NO-GO** until, at minimum:
 5. the native, Tailscale, relay, Android, browser, and signed-artifact rows are re-run at the
    current `v17.3.8` pin. The pin was refreshed on 2026-08-19 and only source-level evidence was
    regenerated with it, so every platform row still carries evidence gathered against
-   `v17.0.6` / `89d6a8f6d14286f32f09ec9c8aa8af7b3451d2d6`; and
+   `v17.0.6` / `89d6a8f6d14286f32f09ec9c8aa8af7b3451d2d6`;
 6. every advertised host/client combination completes its candidate-artifact capability-leak
-   acceptance across all forbidden sinks.
+   acceptance across all forbidden sinks; and
+7. the publisher stops latching itself off permanently and silently
+   ([#61](https://github.com/alphastorm/omp-session-gateway/issues/61)). On 2026-08-20 three live
+   OMP sessions disappeared from the directory and never returned while the daemon stayed healthy
+   (PID 41501, `ready`, doctor 16/16, socket listening, token unchanged since Jul 19); a freshly
+   started session published within 35s, proving the gateway side was sound. `#securityDisabled` is
+   a one-way latch that is never reset, the setup `catch` treats any non-`ENOENT`/`ECONNREFUSED`
+   error as a security event, and `this.#publisher ??=` means `/collab stop` plus `/collab` reuses
+   the latched instance. Only restarting the OMP process recovers, and nothing reports the state.
+   This defeats automatic discovery without appearing broken.
 
 Passing one platform permits advertising only that exact qualified platform/version combination.
 It does not promote untested rows or broaden the pinned OMP range.


### PR DESCRIPTION
Records [#61](https://github.com/alphastorm/omp-session-gateway/issues/61) as blocker 7.

Three live OMP sessions vanished from the directory tonight and never came back, while every health surface said the system was fine. That combination — working daemon, empty directory — is the specific failure this product exists to prevent, so it belongs in the ledger rather than only in an issue.

## Evidence

| Fact | Value |
| --- | --- |
| Directory | `revision 31`, **0 sessions**, identical from the Mac and from the phone over the tailnet |
| Live publisher processes | `85147`, `91389`, `11539` — all alive, up to 22h old |
| Daemon | PID `41501`, `ready: true`, doctor 16/16 |
| Socket | created 15:59 with the daemon, never rebound, **listener FD only** — no accepted connections |
| Token | unchanged since Jul 19 18:13 |
| Control run | a brand-new session published in 35s → `revision 32`, 1 session |

The control run is the load-bearing part: it rules out socket, token, permissions, Serve and daemon, and isolates the fault to the publisher inside already-running processes.

## Mechanism

`#securityDisabled` is assigned once and never reset, and both `#connect()` and `#scheduleReconnect()` bail while it is set. Three properties make it unrecoverable rather than strict:

- the setup `catch` wraps endpoint resolution, token read and the privacy assertion together, and treats anything that is not `ENOENT`/`ECONNREFUSED` as a security event — so a transient `EACCES`/`EAGAIN` reading the token file latches the process off for good;
- `this.#publisher ??=` means `/collab stop` then `/collab` reuses the **same** latched instance, so the obvious operator remedy does nothing;
- the warning fires once and `/collab status` never reports the state, so by the time anyone notices, the only evidence has scrolled away.

I cannot prove from outside the process which branch fired — a controller that dropped `#current` without republishing looks identical. That ambiguity is part of the defect.

## Threat-model impact

None to the capability boundary: no secret is exposed, no authorization is weakened, and the failure is fail-closed — sessions disappear rather than leak. The impact is availability and, more seriously, **trust in the directory as a complete view**. A user who sees three of four cards has no way to know the fourth is silently latched off rather than genuinely gone. Documentation only; no behavior change.

## Verification

`bun run check` green from a clean tree — 138 tests, 22 files, capability leak scan passed.
