### PR TITLE
docs(readme): add status, CI, and baseline badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,44 @@
+<div align="center">
+
 ![OMP Session Gateway](assets/banner.png)
 
 # OMP Session Gateway
 
 **Secure, zero-touch mobile access to every running Oh My Pi session.**
+
+[![CI][ci-badge]][ci]
+[![Windows lifecycle][windows-badge]][windows]
+[![Latest pre-alpha][release-badge]][releases]
+[![License][license-badge]][license]
+
+[![Project status][status-badge]][status]
+[![OMP baseline][omp-badge]][omp-lock]
+[![Runtime][bun-badge]][bun]
+[![Last commit][commit-badge]][commits]
+
+**[Quickstart](#build-and-run)** · **[Architecture](docs/ARCHITECTURE.md)** ·
+**[Security model](docs/SECURITY.md)** · **[Protocol](docs/PROTOCOL.md)** ·
+**[Operations](docs/OPERATIONS.md)** · **[Release status](docs/RELEASE_STATUS.md)** ·
+**[Compatibility](docs/COMPATIBILITY.md)** · **[Roadmap](ROADMAP.md)**
+
+[ci]: https://github.com/alphastorm/omp-session-gateway/actions/workflows/ci.yml
+[ci-badge]: https://img.shields.io/github/actions/workflow/status/alphastorm/omp-session-gateway/ci.yml?branch=main&label=CI&labelColor=0B0E11
+[windows]: https://github.com/alphastorm/omp-session-gateway/actions/workflows/platform-qualification.yml
+[windows-badge]: https://img.shields.io/github/actions/workflow/status/alphastorm/omp-session-gateway/platform-qualification.yml?event=pull_request&label=windows%20lifecycle&labelColor=0B0E11
+[releases]: https://github.com/alphastorm/omp-session-gateway/releases
+[release-badge]: https://img.shields.io/github/v/release/alphastorm/omp-session-gateway?include_prereleases&filter=v*-prealpha.*&label=pre-alpha&color=C99B45&labelColor=0B0E11
+[license]: LICENSE
+[license-badge]: https://img.shields.io/github/license/alphastorm/omp-session-gateway?color=1C232B&labelColor=0B0E11
+[status]: docs/RELEASE_STATUS.md
+[status-badge]: https://img.shields.io/badge/status-pre--alpha%2C%20unqualified-C99B45?labelColor=0B0E11
+[omp-lock]: UPSTREAM.lock.json
+[omp-badge]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falphastorm%2Fomp-session-gateway%2Fmain%2FUPSTREAM.lock.json&query=%24.tag&label=OMP%20baseline&color=1C232B&labelColor=0B0E11
+[bun]: https://bun.sh
+[bun-badge]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falphastorm%2Fomp-session-gateway%2Fmain%2Fpackage.json&query=%24.packageManager&label=runtime&color=1C232B&labelColor=0B0E11
+[commits]: https://github.com/alphastorm/omp-session-gateway/commits/main
+[commit-badge]: https://img.shields.io/github/last-commit/alphastorm/omp-session-gateway/main?label=last%20commit&color=1C232B&labelColor=0B0E11
+
+</div>
 
 > **Project status: implemented pre-alpha, not production-qualified.** The daemon, authenticated IPC registry, PWA, pinned collaboration client, management CLI, service definitions, release builder, tests, and OMP patch are present. Real Android, Tailscale, relay, and cross-OS acceptance gates remain unqualified. See the [release gate ledger](docs/RELEASE_STATUS.md) and [compatibility matrix](docs/COMPATIBILITY.md).
 


### PR DESCRIPTION
Adds two badge rows and a section navigation row to the README header, in the
layout used by `gakonst/nanocodex`.

## What the badges report

| Badge | Source | Current value |
|---|---|---|
| CI | `ci.yml` on `main` | passing |
| windows lifecycle | `platform-qualification.yml`, latest `pull_request` run | passing |
| pre-alpha | newest release matching `v*-prealpha.*` | `v0.1.0-prealpha.13` |
| license | GitHub license detection | MIT |
| status | static | `pre-alpha, unqualified` |
| OMP baseline | `$.tag` of `UPSTREAM.lock.json` on `main` | `v17.3.8` |
| runtime | `$.packageManager` of `package.json` on `main` | `bun@1.3.14` |
| last commit | `main` | live |

Six of the eight are dynamic, so a pin refresh, Bun bump, release, or CI
regression updates the README without an edit. The two hand-written ones are
`status` and the badge labels.

The `windows lifecycle` badge is scoped to `event=pull_request` because that
workflow only triggers on `pull_request` and `workflow_dispatch`; the unscoped
badge reports a stale `workflow_dispatch` failure from 2026-07-20 rather than
the current gate.

No platform-support badge is included: `docs/COMPATIBILITY.md` advertises no
supported OS, browser, or device, and a `platforms` badge would contradict that.
The static `status` badge repeats the pre-alpha claim so maturity is visible
above the install commands.

## Other changes

- Navigation row: Quickstart, Architecture, Security model, Protocol,
  Operations, Release status, Compatibility, Roadmap. All targets verified to
  exist; `#build-and-run` matches the existing `## Build and run` heading.
- Header wrapped in `<div align="center">`; the markdown `# OMP Session Gateway`
  heading is preserved, so `scripts/validate-handoff.ts`'s canonical string
  check still passes.
- Badge colors come from `docs/BRANDING.md`: labels ink-dark `#0B0E11`, neutral
  values border `#1C232B`, caution values control `#C99B45`. No upstream orange,
  per the kinship rule.

## Threat-model impact

None. No change to auth, IPC, browser storage, launch, logging, or OMP
lifecycle. The badges are third-party images on the GitHub README page only;
GitHub proxies them through camo, so reader IPs are not exposed to shields.io,
and no third-party asset enters the PWA runtime closure.

## Verification

- Rendered the exact file through GitHub's markdown API and confirmed all eight
  reference-style badges resolve (no literal `[![…]]` text), the centered div
  survives sanitization, and the mermaid block still renders.
- Screenshotted the rendered header in a browser: all eight badge images load
  with real values, both rows and the nav row fit one line at 1012px.
- `bun run validate:handoff` — passed (246 files scanned).
- `bun run check:capability-leaks` — passed.
