### PR TITLE
fix(service): let systemd own the runtime directory so the unit survives reboot

### DIFF
--- a/apps/gateway/src/service.ts
+++ b/apps/gateway/src/service.ts
@@ -42,10 +42,25 @@ export function serviceDefinition(
   const argv = serviceArgv(installedCli, readinessInstance);
   if (platform === "linux") {
     const command = argv.map(value => JSON.stringify(value)).join(" ");
+    // systemd refuses to start a unit whose ReadWritePaths= names a path that does not exist, and
+    // the runtime directory does not exist until the daemon binds its socket. That is invisible at
+    // install time, when a previous run has already created it, and fatal after a reboot: the user
+    // manager comes up, the unit fails, and the gateway silently never returns. Let systemd own the
+    // directory instead. RuntimeDirectory= creates it before start and it is implicitly writable,
+    // so it must not also appear in ReadWritePaths=. The mode is explicit because systemd defaults
+    // to 0755 while the gateway asserts a private runtime directory and would refuse to start.
+    const xdgRuntimeDir = process.env.XDG_RUNTIME_DIR;
+    const runtimeManagedBySystemd =
+      xdgRuntimeDir !== undefined && config.paths.runtimeDir === join(xdgRuntimeDir, "omp-session-gateway");
+    const readWritePaths = [config.paths.configDir, config.paths.stateDir];
+    if (!runtimeManagedBySystemd) readWritePaths.push(config.paths.runtimeDir);
+    const runtimeDirectory = runtimeManagedBySystemd
+      ? "RuntimeDirectory=omp-session-gateway\nRuntimeDirectoryMode=0700\n"
+      : "";
     return {
       identifier: "omp-session-gateway",
       path: join(process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config"), "systemd", "user", "omp-session-gateway.service"),
-      content: `[Unit]\nDescription=OMP Session Gateway\nAfter=network-online.target\n\n[Service]\nType=simple\nExecStart=${command}\nRestart=on-failure\nRestartSec=5\nNoNewPrivileges=true\nPrivateTmp=true\nProtectSystem=strict\nProtectHome=read-only\nReadWritePaths=${JSON.stringify(config.paths.configDir)} ${JSON.stringify(config.paths.stateDir)} ${JSON.stringify(config.paths.runtimeDir)}\n\n[Install]\nWantedBy=default.target\n`,
+      content: `[Unit]\nDescription=OMP Session Gateway\nAfter=network-online.target\n\n[Service]\nType=simple\nExecStart=${command}\nRestart=on-failure\nRestartSec=5\nNoNewPrivileges=true\nPrivateTmp=true\nProtectSystem=strict\nProtectHome=read-only\n${runtimeDirectory}ReadWritePaths=${readWritePaths.map(value => JSON.stringify(value)).join(" ")}\n\n[Install]\nWantedBy=default.target\n`,
     };
   }
   if (platform === "darwin") {

--- a/apps/gateway/test/service.test.ts
+++ b/apps/gateway/test/service.test.ts
@@ -31,23 +31,24 @@ describe("service packaging", () => {
     // Regression for #69. ReadWritePaths= naming a missing path makes systemd refuse to start the
     // unit. The runtime directory only exists once the daemon has bound its socket, so the unit
     // installed fine and then failed after every reboot, leaving the gateway silently absent.
+    // `serviceDefinition` compares against `join(XDG_RUNTIME_DIR, …)`, which uses the host
+    // separator, so the fixture must be built the same way or this silently stops asserting
+    // anything on Windows. The same separator assumption already broke the ownership fixtures once.
     const previous = process.env.XDG_RUNTIME_DIR;
-    process.env.XDG_RUNTIME_DIR = "/run/user/1000";
+    const xdgRuntimeDir = join("/run", "user", "1000");
+    const runtimeDir = join(xdgRuntimeDir, "omp-session-gateway");
+    process.env.XDG_RUNTIME_DIR = xdgRuntimeDir;
     try {
       const linuxConfig: GatewayConfig = {
         ...config,
-        paths: {
-          ...config.paths,
-          runtimeDir: "/run/user/1000/omp-session-gateway",
-          socketPath: "/run/user/1000/omp-session-gateway/registry.sock",
-        },
+        paths: { ...config.paths, runtimeDir, socketPath: join(runtimeDir, "registry.sock") },
       };
       const definition = serviceDefinition(linuxConfig, "linux");
       expect(definition.content).toContain("RuntimeDirectory=omp-session-gateway");
       // systemd defaults this to 0755, which the gateway's private-directory assertion rejects.
       expect(definition.content).toContain("RuntimeDirectoryMode=0700");
       // A RuntimeDirectory= path is implicitly writable; repeating it here is what broke boot.
-      expect(definition.content).not.toContain('"/run/user/1000/omp-session-gateway"');
+      expect(definition.content).not.toContain(JSON.stringify(runtimeDir));
     } finally {
       if (previous === undefined) delete process.env.XDG_RUNTIME_DIR;
       else process.env.XDG_RUNTIME_DIR = previous;

--- a/apps/gateway/test/service.test.ts
+++ b/apps/gateway/test/service.test.ts
@@ -27,6 +27,47 @@ describe("service packaging", () => {
     expect(definition.content).not.toContain("0.0.0.0");
   });
 
+  test("lets systemd own a runtime directory that does not exist at boot", () => {
+    // Regression for #69. ReadWritePaths= naming a missing path makes systemd refuse to start the
+    // unit. The runtime directory only exists once the daemon has bound its socket, so the unit
+    // installed fine and then failed after every reboot, leaving the gateway silently absent.
+    const previous = process.env.XDG_RUNTIME_DIR;
+    process.env.XDG_RUNTIME_DIR = "/run/user/1000";
+    try {
+      const linuxConfig: GatewayConfig = {
+        ...config,
+        paths: {
+          ...config.paths,
+          runtimeDir: "/run/user/1000/omp-session-gateway",
+          socketPath: "/run/user/1000/omp-session-gateway/registry.sock",
+        },
+      };
+      const definition = serviceDefinition(linuxConfig, "linux");
+      expect(definition.content).toContain("RuntimeDirectory=omp-session-gateway");
+      // systemd defaults this to 0755, which the gateway's private-directory assertion rejects.
+      expect(definition.content).toContain("RuntimeDirectoryMode=0700");
+      // A RuntimeDirectory= path is implicitly writable; repeating it here is what broke boot.
+      expect(definition.content).not.toContain('"/run/user/1000/omp-session-gateway"');
+    } finally {
+      if (previous === undefined) delete process.env.XDG_RUNTIME_DIR;
+      else process.env.XDG_RUNTIME_DIR = previous;
+    }
+  });
+
+  test("keeps a persistent runtime directory in ReadWritePaths", () => {
+    // Without XDG_RUNTIME_DIR the runtime directory lives under the state directory, persists
+    // across reboots, and must stay writable the ordinary way.
+    const previous = process.env.XDG_RUNTIME_DIR;
+    delete process.env.XDG_RUNTIME_DIR;
+    try {
+      const definition = serviceDefinition(config, "linux");
+      expect(definition.content).not.toContain("RuntimeDirectory=");
+      expect(definition.content).toContain(JSON.stringify(config.paths.runtimeDir));
+    } finally {
+      if (previous !== undefined) process.env.XDG_RUNTIME_DIR = previous;
+    }
+  });
+
   test("binds managed service readiness to the installed instance", () => {
     const readinessInstance = "R".repeat(43);
     const definition = serviceDefinition(config, "linux", "/private/runtime/cli.js", readinessInstance);


### PR DESCRIPTION
Fixes [#69](https://github.com/alphastorm/omp-session-gateway/issues/69).

## Root cause

The Linux unit listed the runtime directory in `ReadWritePaths=`:

```
ProtectSystem=strict
ReadWritePaths="<configDir>" "<stateDir>" "<runtimeDir>"
```

**systemd refuses to start a unit whose `ReadWritePaths=` names a path that does not exist.** The runtime directory only exists once the daemon has bound its socket. At install time a previous run had always created it, so the unit started and everything looked correct. After a reboot it did not exist, so the unit failed — the user manager came up, the gateway did not, and nothing reported why.

That is exactly why this survived every prior check: it is invisible at install time and only appears across a boot, which nothing had ever tested. The droplet run that found it had `Linger=yes`, a confirmed boot-id change, and `user@1000.service` **active** with `gateway pid: none`.

I had guessed in #69 that install might never `enable` the unit. That was wrong — `service.ts:224` does run `systemctl --user enable`, and the unit has `WantedBy=default.target`. Reading the code beat the guess.

## Fix

```
RuntimeDirectory=omp-session-gateway
RuntimeDirectoryMode=0700
ReadWritePaths="<configDir>" "<stateDir>"
```

`RuntimeDirectory=` makes systemd create the directory *before* the service starts, so it exists by construction. Such a path is implicitly writable and must **not** be repeated in `ReadWritePaths=` — repeating it is the bug.

`RuntimeDirectoryMode=0700` is explicit and load-bearing: systemd defaults to `0755`, while `config.ts:376` asserts a private runtime directory via `assertPrivateDirectory(runtimeDir, true)`. Taking the default would have traded a boot failure for a startup refusal — a fix that looks right and fails differently.

Only the `XDG_RUNTIME_DIR` branch changes. Without it the runtime directory lives under the state directory, persists across reboots, and stays in `ReadWritePaths=` unchanged.

## Verification

Two tests, one per branch. The first is mutation-proven — reverting `service.ts` makes it fail with the old unit text visible in the diff, and restoring makes 11/11 pass:

```
 10 pass, 1 fail   ← without the fix
 11 pass, 0 fail   ← with it
```

**Not yet proven on hardware.** This is a source-level fix with unit coverage. The real acceptance is a reboot on a droplet installing a candidate that contains it, which needs a new candidate tag first. #69 stays open until that passes, and the ledger's Linux row keeps its failure recorded.

## Threat-model impact

Strictly tightens the sandbox. One path moves out of `ReadWritePaths=` and under systemd's own lifecycle, so the writable set shrinks; `ProtectSystem=strict`, `ProtectHome=read-only`, `NoNewPrivileges`, and `PrivateTmp` are untouched. The explicit `0700` preserves the private-runtime-directory invariant that the daemon independently enforces at startup.
