### PR TITLE
fix(web): give the offline state an exit and rebuild a frozen connection on resume

### DIFF
--- a/apps/web/src/app.ts
+++ b/apps/web/src/app.ts
@@ -494,7 +494,18 @@ function clearReconnectTimeout(): void {
   reconnectTimeout = undefined;
 }
 
-
+/**
+ * True only when the event stream has demonstrably been heard from inside the liveness window.
+ *
+ * Neither `events !== undefined` nor `eventStreamStale` survives a freeze. Chrome freezes the
+ * renderer while the display is off, so a page that resumes still holds an `EventSource` that
+ * reports open and a liveness timeout that never ran, however long the stream has been dead.
+ * Wall-clock freshness is the one signal a frozen page cannot have faked.
+ */
+function directoryStreamIsLive(): boolean {
+  if (events === undefined || eventStreamStale || lastFreshAt === undefined) return false;
+  return Date.now() - lastFreshAt < EVENT_LIVENESS_TIMEOUT_MS;
+}
 
 function scheduleReconnect(): void {
   if (authorizationDenied || reconnectTimeout !== undefined) return;
@@ -1443,6 +1454,25 @@ window.addEventListener("offline", () => {
   events = undefined;
   authorizationDenied = false;
   showTransportFailure("offline");
+  // `online` is not a dependable wake-up. Issue #65 measured `navigator.onLine` reporting true
+  // through a total outage on the device, so an offline state whose only exit is an `online` event
+  // is a state the page can never leave. Keep the bounded retry chain running instead.
+  scheduleReconnect();
+});
+
+/**
+ * Resume is a recovery signal Android actually delivers, so treat it as one.
+ *
+ * A page frozen across a network change has no way to notice the change: its timers did not run and
+ * its `EventSource` still reports open. `pageshow` does not cover this — it fires for a bfcache
+ * restore, not for freeze/resume of the foreground page. So on resume, unless the stream can be
+ * shown to be live, throw the whole connection away and build a new one now rather than waiting out
+ * a timer that was frozen with it.
+ */
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState !== "visible" || authorizationDenied) return;
+  if (directoryStreamIsLive()) return;
+  void refreshAndConnect();
 });
 
 const applicationWorkerRegistration = initializeApplicationWorker();

--- a/apps/web/test/app.test.ts
+++ b/apps/web/test/app.test.ts
@@ -19,6 +19,12 @@ const nativeGlobals = Object.fromEntries(
   GLOBAL_NAMES.map(name => [name, Object.getOwnPropertyDescriptor(globalThis, name)]),
 ) as Record<(typeof GLOBAL_NAMES)[number], PropertyDescriptor | undefined>;
 
+// A frozen renderer runs no timers while wall-clock time keeps moving, so the test clock has to
+// advance independently of the fake timers.
+const nativeNow = Date.now;
+let clockOffset = 0;
+Date.now = (): number => nativeNow() + clockOffset;
+
 class FakeElement extends EventTarget {
   readonly attributes = new Map<string, string>();
   readonly children: FakeElement[] = [];
@@ -120,7 +126,7 @@ class FakeMessageChannel {
 
 class FakeWindow extends EventTarget {
   readonly opened: string[] = [];
-  readonly timers = new Map<number, () => void>();
+  readonly timers = new Map<number, { readonly callback: () => void; readonly delay: number }>();
   scrollY = 0;
   #nextTimer = 1;
 
@@ -132,17 +138,22 @@ class FakeWindow extends EventTarget {
     this.timers.delete(handle);
   }
 
-  setTimeout(callback: () => void): number {
+  setTimeout(callback: () => void, delay = 0): number {
     const handle = this.#nextTimer;
     this.#nextTimer += 1;
-    this.timers.set(handle, callback);
+    this.timers.set(handle, { callback, delay });
     return handle;
   }
 
   runTimers(): void {
-    const callbacks = [...this.timers.values()];
+    const pending = [...this.timers.values()];
     this.timers.clear();
-    for (const callback of callbacks) callback();
+    for (const timer of pending) timer.callback();
+  }
+
+  /** Delays of every timer still waiting, so a test can bound a scheduled retry. */
+  pendingDelays(): number[] {
+    return [...this.timers.values()].map(timer => timer.delay);
   }
 
   scrollTo(_x: number, y: number): void {
@@ -152,6 +163,39 @@ class FakeWindow extends EventTarget {
   open(url?: string | URL): null {
     this.opened.push(String(url));
     return null;
+  }
+}
+
+class FakeDocument extends EventTarget {
+  readonly documentElement = {
+    dataset: {} as Record<string, string>,
+    style: {} as Record<string, string>,
+  };
+  visibilityState: "visible" | "hidden" = "visible";
+
+  constructor(
+    readonly bySelector: Record<string, FakeElement>,
+    readonly detailInputs: readonly FakeElement[],
+  ) {
+    super();
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    return this.bySelector[selector] ?? null;
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    return selector === 'input[name="notification-detail"]' ? [...this.detailInputs] : [];
+  }
+
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  }
+
+  /** Android freeze/resume delivers exactly this, and nothing else the page can observe. */
+  setVisibility(state: "visible" | "hidden"): void {
+    this.visibilityState = state;
+    this.dispatchEvent(new Event("visibilitychange"));
   }
 }
 
@@ -194,6 +238,9 @@ interface BrowserHarness {
   disconnectEvents(): void;
   expireEventLiveness(): void;
   runTimers(): void;
+  pendingDelays(): number[];
+  setVisibility(state: "visible" | "hidden"): void;
+  advanceClock(milliseconds: number): void;
   hangNextListRequest(): void;
   failNextListRequest(): void;
   setOnline(online: boolean): void;
@@ -257,6 +304,7 @@ async function bootApp(options: {
   readonly suffix: string;
 }): Promise<BrowserHarness> {
   FakeEventSource.instances.length = 0;
+  clockOffset = 0;
   const sessionList = new FakeElement("section");
   const emptyState = new FakeElement("section");
   const statusBanner = new FakeElement("div");
@@ -290,18 +338,7 @@ async function bootApp(options: {
     "#notification-settings-close": notificationSettingsClose,
     "#notification-disable": notificationDisable,
   };
-  const document = {
-    documentElement: { dataset: {} as Record<string, string>, style: {} as Record<string, string> },
-    querySelector(selector: string): FakeElement | null {
-      return bySelector[selector] ?? null;
-    },
-    querySelectorAll(selector: string): FakeElement[] {
-      return selector === 'input[name="notification-detail"]' ? notificationDetailInputs : [];
-    },
-    createElement(tagName: string): FakeElement {
-      return new FakeElement(tagName);
-    },
-  };
+  const document = new FakeDocument(bySelector, notificationDetailInputs);
   const window = new FakeWindow();
   const reloads = { count: 0 };
   const location = {
@@ -505,6 +542,15 @@ async function bootApp(options: {
     runTimers(): void {
       window.runTimers();
     },
+    pendingDelays(): number[] {
+      return window.pendingDelays();
+    },
+    setVisibility(state): void {
+      document.setVisibility(state);
+    },
+    advanceClock(milliseconds): void {
+      clockOffset += milliseconds;
+    },
     hangNextListRequest(): void {
       hangingListRequests += 1;
     },
@@ -532,6 +578,7 @@ afterAll(() => {
     if (descriptor === undefined) Reflect.deleteProperty(globalThis, name);
     else Object.defineProperty(globalThis, name, descriptor);
   }
+  Date.now = nativeNow;
 });
 
 describe("dashboard attention and notifications", () => {
@@ -832,5 +879,66 @@ describe("dashboard attention and notifications", () => {
     expect(unavailable.elements.notificationButton.textContent).toBe("Background alerts unavailable");
     expect(unavailable.elements.notificationButton.dataset.state).toBe("unavailable");
     expect(unavailable.elements.notificationButton.disabled).toBeTrue();
+  });
+
+  test("rebuilds a frozen directory connection on resume instead of trusting the old one", async () => {
+    const base = session("resume-session-00001");
+    const harness = await bootApp({
+      permission: "denied",
+      suffix: "frozen-resume",
+      initialSessions: [base],
+    });
+    const snapshots = (): number => harness.fetchPaths.filter(path => path === "/api/v1/sessions").length;
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(snapshots()).toBe(1);
+    const frozen = FakeEventSource.instances[0];
+
+    // #65's reproduction recipe: display off freezes the renderer, so no timer runs and the liveness
+    // watchdog never fires, while wall-clock time passes and the stream silently dies. The
+    // EventSource still reports open because nothing in the page ran to notice otherwise.
+    harness.setVisibility("hidden");
+    harness.advanceClock(45_000);
+    harness.setList(2, [base]);
+    harness.setVisibility("visible");
+
+    // No timer is flushed anywhere below: resume alone has to produce the fresh connection.
+    expect(frozen?.closed).toBeTrue();
+    await settleUntil(() => FakeEventSource.instances.length === 2);
+    await settleUntil(() => snapshots() === 2);
+    expect(FakeEventSource.instances[1]?.closed).toBeFalse();
+    expect(harness.elements.statusBanner.hidden).toBeTrue();
+    expect(harness.elements.sessionList.querySelectorAll(".working-row")).toHaveLength(1);
+  });
+
+  test("keeps a bounded retry pending when the phone reports offline and no online event follows", async () => {
+    const base = session("offline-retry-000001");
+    const harness = await bootApp({
+      permission: "denied",
+      suffix: "offline-retry",
+      initialSessions: [base],
+    });
+    const snapshots = (): number => harness.fetchPaths.filter(path => path === "/api/v1/sessions").length;
+
+    expect(snapshots()).toBe(1);
+    harness.setOnline(false);
+    harness.window.dispatchEvent(new Event("offline"));
+    expect(harness.elements.statusBanner.querySelector(".status-title")?.textContent).toBe(
+      "You're offline",
+    );
+
+    // The offline state must carry its own way out: #65 measured `navigator.onLine` reporting true
+    // through a total outage, so an `online` event is not a wake-up the page can count on. One
+    // retry is pending, and it is scheduled inside the backoff ceiling.
+    expect(harness.pendingDelays()).toHaveLength(1);
+    expect(harness.pendingDelays()[0]).toBeLessThanOrEqual(4_000);
+
+    harness.setOnline(true);
+    harness.setList(2, [base]);
+    harness.runTimers();
+    await settleUntil(() => snapshots() === 2);
+    await settleUntil(() => FakeEventSource.instances.length === 2);
+    expect(harness.elements.statusBanner.hidden).toBeTrue();
+    expect(harness.elements.sessionList.querySelectorAll(".working-row")).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Investigating [#65](https://github.com/alphastorm/omp-session-gateway/issues/65) found two provable application defects. **Neither is the 471-second stall the issue measures** — that remains unattributed, and #65 stays open.

## Defect 1 — the offline state had no exit

The `offline` handler cleared the reconnect timer, aborted the snapshot, closed the stream, and **scheduled nothing**. The only way out was an `online` event.

That is fine until `navigator.onLine` lies, and #65 proves it does on this device: it reported `true` through a total airplane-mode outage. A state whose only exit is an event that may never fire is unescapable and unbounded. The handler now ends with `scheduleReconnect()`, so the state carries its own exit.

## Defect 2 — a frozen renderer was trusted about its own liveness

Chrome freezes the renderer while the display is off, so a page's watchdog never runs. On resume, `events` and `eventStreamStale` describe the moment *before* the freeze, and the app believed them.

`directoryStreamIsLive()` now answers with wall-clock freshness against `lastFreshAt` instead, and on `visibilitychange` to visible a connection that is not demonstrably live is torn down — snapshot aborted, `EventSource` closed, timers cleared, backoff reset — and rebuilt.

## Three hypotheses refuted, not patched

| Hypothesis | Verdict |
|---|---|
| Unbounded/long backoff | **Refuted** — full jitter, `exponent = min(attempt, 2)`, 4 s ceiling (`app.ts:61-62,510-518`) |
| `EventSource` retried, not recreated | **Refuted** — new instance per attempt (`app.ts:1359`), old one closed |
| Requests reusing a wedged connection | **Refuted as an app defect** — snapshots already `cache: "no-store"`, and the service worker never intercepts `/api/` |

On the last one: no fetch option can force a fresh TCP connection, so the wedged-socket theory has **no application-level remedy**. I did not invent one. Backoff was deliberately left alone — widening it would slow the very recovery #65 measures.

## Verification

Both tests are mutation-proven: **2 fail** against the previous `app.ts`, **13/13 pass** with it.

The harness gained a virtual clock so wall-clock time can advance while no timer runs — the defining property of a frozen renderer, and not otherwise expressible in the existing fake-timer setup.

I cannot claim this resolves #65 on the device; that needs the phone and a reproduction, and the recipe is intermittent.

## Threat-model impact

No change to capability handling. Reviewed against `SECURITY.md` §7: session metadata stays in volatile memory, the stale marker and last-fresh timestamp are unchanged, no action is disabled, and authorization failure still clears state. The change only affects when a transport is rebuilt.
