### PR TITLE
test(android): make the harness prove the page was visible before measuring

### DIFF
--- a/scripts/android-acceptance.ts
+++ b/scripts/android-acceptance.ts
@@ -38,9 +38,53 @@ async function sleep(milliseconds: number): Promise<void> {
   await settle.promise;
 }
 
-async function wake(): Promise<void> {
-  await adb("shell", "input", "keyevent", WAKE);
-  await adb("shell", "input", "keyevent", MENU);
+/**
+ * Wakes the display and confirms it, rather than firing keyevents and hoping.
+ *
+ * A run where the display never came back produced `cdp-timeout` on nearly every probe, because
+ * Chrome freezes the renderer while the screen is off and `Runtime.evaluate` then never resolves.
+ * That is unmeasurable, not a product result, and it silently looked like a stall. Returning the
+ * observed wakefulness lets a caller record "the harness could not present a visible page" instead
+ * of attributing the timeout to the application.
+ */
+async function wake(): Promise<string> {
+  for (let attempt = 1; attempt <= 6; attempt++) {
+    await adb("shell", "input", "keyevent", WAKE);
+    await adb("shell", "input", "keyevent", MENU);
+    await sleep(1200);
+    const wakefulness = (await adb("shell", "dumpsys power | grep -m1 mWakefulness=")).split("=")[1]?.trim() ?? "";
+    if (wakefulness === "Awake") return wakefulness;
+  }
+  return (await adb("shell", "dumpsys power | grep -m1 mWakefulness=")).split("=")[1]?.trim() ?? "unknown";
+}
+
+/**
+ * Brings the owned tab to the foreground and confirms the page agrees it is visible.
+ *
+ * A woken display is not enough: the tab can still be backgrounded, and `document.visibilityState`
+ * is what actually governs whether the app's resume path runs. `Page.bringToFront` is the protocol
+ * way to do this; keyevents cannot.
+ */
+async function ensureVisible(driver: AndroidChromeDriver): Promise<string> {
+  for (let attempt = 1; attempt <= 4; attempt++) {
+    try {
+      await driver.send("Page.bringToFront");
+    } catch {
+      // Not fatal: a frozen renderer rejects it, and the retry after another wake may succeed.
+    }
+    try {
+      const evaluation = await driver.send("Runtime.evaluate", {
+        expression: "document.visibilityState",
+        returnByValue: true,
+      });
+      const { result } = evaluation;
+      if (result && typeof result === "object" && "value" in result && result.value === "visible") return "visible";
+    } catch {
+      // CDP timeout means the renderer is still frozen; wake again and retry.
+    }
+    await wake();
+  }
+  return "not-visible";
 }
 
 /** One reachability attempt plus the app's own rendered state, generously bounded. */
@@ -109,12 +153,15 @@ async function awaitRecovery(
   let deviceReachableFirstMs: number | null = null;
   for (let index = 1; index <= attempts; index++) {
     await sleep(8000);
-    await adb("shell", "input", "keyevent", WAKE);
+    // The app's resume path is driven by visibilityState, so a probe against a hidden or frozen page
+    // measures nothing. Record the presentation state alongside the result so an unmeasurable run is
+    // visibly unmeasurable rather than looking like an application stall.
+    const presentation = await ensureVisible(driver);
     const deviceReachable = await deviceReachesHost(host);
     const probe = await attempt(driver, `${label}-${index}`);
     const sinceMs = Math.round(performance.now() - since);
     if (deviceReachable && deviceReachableFirstMs === null) deviceReachableFirstMs = sinceMs;
-    record({ ...probe, deviceReachable, sinceMs });
+    record({ ...probe, presentation, deviceReachable, sinceMs });
     if (probe.status === 200) return { recoveredMs: sinceMs, deviceReachableFirstMs };
   }
   return { recoveredMs: null, deviceReachableFirstMs };
@@ -187,9 +234,10 @@ const summary = await withAndroidChrome(async driver => {
     await adb("shell", "input", "keyevent", POWER);
     await sleep(20000);
     const wokeAt = performance.now();
-    await wake();
+    const wakefulness = await wake();
+    const presentation = await ensureVisible(driver);
     await sleep(3000);
-    const unlocked = await attempt(driver, "after-unlock");
+    const unlocked: Record<string, unknown> = { ...(await attempt(driver, "after-unlock")), wakefulness, presentation };
     unlockMs = Math.round(performance.now() - wokeAt);
     record({ ...unlocked, sinceMs: unlockMs });
     if (unlocked.status !== 200) unlockMs = null;


### PR DESCRIPTION
Two device runs were **unmeasurable rather than failing**, and nothing in the output said so. `wake()` fired keyevents and hoped; when the display didn't come back, Chrome kept the renderer frozen, `Runtime.evaluate` never resolved, and every probe recorded `cdp-timeout` — indistinguishable from the application failing to recover.

That flaw produced a wrong conclusion I have since withdrawn: an earlier "recovered 1,286 ms after becoming visible" reading came from a run containing it.

## Fix

- `wake()` polls `dumpsys` until `mWakefulness=Awake` and **returns what it observed**, so a caller can record "the harness could not present a visible page".
- `ensureVisible()` issues `Page.bringToFront` and confirms the page agrees, retrying with another wake if the renderer is still frozen. A woken display is not a foregrounded tab, and `document.visibilityState` is what actually governs the app's resume path — keyevents cannot set it.
- Every recovery probe records `presentation` alongside the result.
- Restores the `unlockMs` assignment that an earlier edit of mine dropped, which made lock/resume report `null` despite the probe returning `200`.

## This is what made #65 diagnosable

With the page provably visible and the device provably reachable, the failure signature changed from timeouts to **`TypeError` in ~50 ms** — an immediate connection refusal, not a hang. That reframed everything, and led to the root cause:

```
magicdns-name  https://<gateway>/api/v1/sessions   TimeoutError  8,004ms
tailnet-ip     https://<tailnet-ip>/api/v1/...    TypeError        20ms
external-dns   https://www.google.com/generate_204 TypeError         1ms
```

`www.google.com` failing in **1 ms** while `adb shell ping www.google.com` returned `0% loss, 11.756ms` — Chrome's networking was wedged **browser-wide**. Force-stopping and relaunching Chrome restored the gateway to **200 in 66 ms**.

So [#65](https://github.com/alphastorm/omp-session-gateway/issues/65) is not the gateway, not the PWA, and not MagicDNS. Full evidence chain is on the issue.

## Threat-model impact

None. Test harness only; no product code, no capability handling. The harness continues to record capability material as length and digest only.

## Verification

Four workspaces typecheck clean. Executed on the physical Pixel across four runs; the last two produced the diagnostic dataset above with `presentation: visible` on every probe.

