### PR TITLE
fix(test): refuse acceptance targets the harness does not own

### DIFF
--- a/.github/workflows/droplet-qualification.yml
+++ b/.github/workflows/droplet-qualification.yml
@@ -1,0 +1,442 @@
+# Scheduled Linux qualification on a throwaway DigitalOcean droplet.
+#
+# `scripts/provision-linux-qual.sh` already creates one droplet under a fixed name, joins it to the
+# tailnet as a tagged node, runs the qualification lanes, and deletes the droplet again. That makes it
+# the cheapest cross-platform automation this repository has: a full sequence is roughly twenty-five
+# minutes and one billed DigitalOcean hour, $0.01786. It has already produced two real findings, one
+# of which became #69 and its fix. This workflow runs that script unattended so the Linux evidence
+# stops depending on somebody remembering to run it by hand.
+#
+# Nothing here promotes a ledger row. The lanes print measurements; `docs/RELEASE_STATUS.md` is
+# changed by hand, by the lead, after reading them.
+#
+# The property that matters more than any lane result is that the droplet always goes away. A failed
+# lane costs nothing. A leaked droplet bills until somebody notices. Teardown is therefore its own
+# `if: always()` step, it runs after a failed, cancelled, or timed-out job, and it fails the job when
+# it cannot finish.
+#
+# SSH is the reason this needs more than a bare `run:` line. The script refuses to create a droplet it
+# could not then log into: preflight fetches the DigitalOcean key's fingerprint and requires a
+# matching local private key, because a droplet you cannot reach is pure cost. A hosted runner has
+# neither half. So this job mints an ephemeral keypair, registers the public half with DigitalOcean,
+# hands the script the resulting key id and identity path through the two variables it already reads
+# (`OMP_QUAL_SSH_KEY_ID`, `OMP_QUAL_SSH_IDENTITY`), and deletes the DigitalOcean key record in
+# teardown. The preflight itself is unchanged and still fails closed: if the fingerprint the API
+# returns ever stops matching the key we generated, this job stops before a droplet exists.
+
+name: Droplet Linux qualification
+
+on:
+  # Manual first. The candidate tag is an input with an explicit default rather than a lookup of "the
+  # newest release", because a scheduled run must qualify a decided candidate; silently following the
+  # newest tag would change what the evidence is about without anybody choosing that.
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Signed candidate tag to qualify
+        required: false
+        default: v0.1.0-prealpha.16
+      previous_tag:
+        description: Predecessor tag for the migration lane (must be v0.1.0-prealpha.15 or later)
+        required: false
+        default: v0.1.0-prealpha.15
+      lanes:
+        description: >-
+          Space-separated lane subset; empty runs the script's full default order. A subset must be
+          self-sufficient on a fresh droplet, so anything after `lifecycle` needs `artifact lifecycle`
+          in front of it.
+        required: false
+        default: ""
+  schedule:
+    # Weekly. Off the hour because GitHub's shared cron queue is congested at :00, and early Monday so
+    # a failure is visible at the start of a week rather than discovered during a release attempt.
+    # Weekly is also the cost decision: one billed droplet-hour per week is about $0.93 a year.
+    - cron: "17 11 * * 1"
+  # Deliberately no `pull_request` and no `push`. This job spends money and needs three long-lived
+  # secrets. A fork's pull request receives none of them, so it would fail for a confusing reason, and
+  # more importantly a pull request must never be able to run an arbitrary edit of this script against
+  # these DigitalOcean and Tailscale credentials.
+
+permissions: {}
+
+# One group with a constant name, not keyed on ref: the droplet name is global, so two runs on any two
+# refs would collide. This guard is load-bearing rather than hygiene — two runs of this lane have
+# already collided over that fixed name in practice. `provision` is idempotent by name, so the second
+# run would adopt the first run's droplet, install over the top of its lanes, reboot it underneath
+# them, and then destroy it while the first run was still measuring. `cancel-in-progress` stays false
+# because cancelling a run can end it before its teardown step, which is the one failure that leaks a
+# billing droplet.
+concurrency:
+  group: droplet-linux-qualification
+  cancel-in-progress: false
+
+jobs:
+  droplet-qualification:
+    runs-on: ubuntu-24.04
+    # Observed full sequence is about twenty-five minutes. The script's own bounded waits (five minutes
+    # for SSH, ten for cloud-init, about five per reboot) put a slow but legitimate run under forty.
+    # Fifty keeps the whole job, teardown included, inside a single billed DigitalOcean hour, so a hung
+    # step costs $0.018 instead of accruing hour after hour: DigitalOcean bills whole hours and refunds
+    # none of them, which is exactly why the bound sits just under sixty rather than at some round
+    # multiple of the expected duration.
+    timeout-minutes: 50
+    permissions:
+      # Checkout, plus `gh release download` and `gh attestation download` for the candidate assets.
+      contents: read
+    env:
+      # `inputs` is empty on a scheduled run, so each default is repeated here. Keep the two copies in
+      # step: the input default is what a human sees in the dispatch form, this is what cron uses.
+      OMP_QUAL_RELEASE_TAG: ${{ inputs.release_tag || 'v0.1.0-prealpha.16' }}
+      OMP_QUAL_PREVIOUS_TAG: ${{ inputs.previous_tag || 'v0.1.0-prealpha.15' }}
+      QUAL_LANES: ${{ inputs.lanes || '' }}
+      # Pinned here rather than left to the script's default so the droplet name this workflow checks
+      # for, refuses to adopt, and destroys is the same string in every step.
+      OMP_QUAL_NAME: omp-gateway-qual
+      # The script hardcodes this slug for asset downloads, so the preflight must check the same repo
+      # rather than `github.repository`; on a fork those two are not the same place.
+      REPO_SLUG: alphastorm/omp-session-gateway
+      TAILNET_TAG: tag:omp-session-gateway
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install pinned doctl and record runner tool versions
+        env:
+          # Version and digest are pinned together. 1.166.0 is the version this lane has actually been
+          # driven with from a workstation. The digest was read from that release's published
+          # `doctl-1.166.0-checksums.sha256` on 2026-08-20; it pins the bytes for that version, and it
+          # is not a signature check. Bump both lines or neither.
+          DOCTL_VERSION: 1.166.0
+          DOCTL_SHA256: 1596424b64091a7939bde561daf2402ca8a141966429928e688d20d17091ec89
+        run: |
+          cd "$RUNNER_TEMP"
+          curl -fsSL -o doctl.tar.gz \
+            "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz"
+          printf '%s  doctl.tar.gz\n' "$DOCTL_SHA256" | sha256sum --check --strict -
+          tar -xzf doctl.tar.gz
+          # No sudo and no /usr/local/bin: a private bin directory on PATH is enough and leaves the
+          # runner image alone.
+          mkdir -p "$RUNNER_TEMP/bin"
+          install -m 0755 doctl "$RUNNER_TEMP/bin/doctl"
+          printf '%s\n' "$RUNNER_TEMP/bin" >>"$GITHUB_PATH"
+          # `gh` and `jq` come from the runner image and are therefore floating. Printing their
+          # versions is what makes a run reproducible after the fact, since `gh attestation download`
+          # produces the bundles the droplet then verifies offline.
+          "$RUNNER_TEMP/bin/doctl" version
+          gh --version | head -1
+          jq --version
+          ssh -V
+
+      - name: Preflight the secrets, the candidate tags, and the lane list
+        env:
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
+          TS_API_KEY: ${{ secrets.TS_API_KEY }}
+          # `GITHUB_TOKEN`, not `GH_TOKEN`, and the difference is deliberate. `gh` accepts either, but
+          # the script forwards `GH_TOKEN` to the droplet so it can verify attestations online. Leaving
+          # `GH_TOKEN` unset selects the offline `--bundle` path instead: the bundles are downloaded
+          # here and verified there, and no token ever reaches a throwaway public-Internet box.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          fail() { printf '::error title=%s::%s\n' "$1" "$2"; exit 1; }
+
+          # Name the missing secret rather than letting a lane fail forty minutes later with an
+          # authentication error that reads like a gateway fault.
+          for name in DIGITALOCEAN_ACCESS_TOKEN TS_AUTHKEY TS_API_KEY; do
+            if [ -z "${!name:-}" ]; then
+              fail "Missing secret: $name" \
+                "$name is not configured for this repository. See docs/LINUX_QUALIFICATION.md section 9."
+            fi
+          done
+          printf 'all three secrets are present (values are never printed)\n'
+
+          # A DigitalOcean token can be created with an expiry. An expired one fails every later step
+          # in a way that looks like a droplet problem, so check it here where the message can be exact.
+          doctl account get --output json >/dev/null 2>&1 ||
+            fail "DigitalOcean token rejected" \
+              "doctl could not authenticate. DIGITALOCEAN_ACCESS_TOKEN is missing, revoked, or expired; regenerate it at DigitalOcean > API > Tokens with read and write scope."
+
+          # The second likely scheduled-run failure: a candidate tag that no longer exists, or whose
+          # assets were renamed. Both would otherwise surface as "release <tag> is missing asset ..."
+          # from inside the artifact lane, after a droplet had been created and paid for.
+          version="$(jq -r '.version' package.json)"
+          printf 'archive version from package.json: %s\n' "$version"
+          for tag in "$OMP_QUAL_RELEASE_TAG" "$OMP_QUAL_PREVIOUS_TAG"; do
+            if ! gh release view "$tag" --repo "$REPO_SLUG" --json assets \
+              --jq '.assets[].name' >"$RUNNER_TEMP/assets-$tag.txt" 2>/dev/null; then
+              fail "Candidate tag $tag not found" \
+                "$REPO_SLUG has no published release $tag. Dispatch this workflow with release_tag/previous_tag set to a published signed candidate, or publish that tag first. No droplet was created."
+            fi
+            for asset in \
+              "omp-session-gateway-${version}-bun.tar" \
+              "omp-session-gateway-${version}-bun.tar.sigstore.json" \
+              "omp-session-gateway-${version}.spdx.json" \
+              "omp-session-gateway-${version}.spdx.json.sigstore.json" \
+              SHA256SUMS \
+              SHA256SUMS.sigstore.json; do
+              grep -qxF -- "$asset" "$RUNNER_TEMP/assets-$tag.txt" ||
+                fail "Candidate $tag is missing $asset" \
+                  "Release $tag does not carry $asset. Either the release is incomplete or package.json's version no longer matches its asset names; set OMP_QUAL_VERSION in that case. No droplet was created."
+            done
+            printf 'release %s carries all six expected assets\n' "$tag"
+          done
+
+          # Lane names and lane ordering. The script validates names itself, but in CI that happens
+          # after `provision`, so a typo in the dispatch form would cost a droplet-hour. Ordering
+          # matters more here than on a workstation: every CI run starts on a fresh droplet, so a
+          # subset that skips `lifecycle` has nothing installed to measure.
+          if [ -n "$QUAL_LANES" ]; then
+            for lane in $QUAL_LANES; do
+              case "$lane" in
+                host | artifact | lifecycle | migration | identity | persistence | uninstall) ;;
+                *) fail "Unknown lane '$lane'" "Choose from: host artifact lifecycle migration identity persistence uninstall." ;;
+              esac
+            done
+            case " $QUAL_LANES " in
+              *" migration "* | *" identity "* | *" persistence "* | *" uninstall "*)
+                case " $QUAL_LANES " in
+                  *" lifecycle "*) ;;
+                  *) fail "Lane subset is not self-sufficient" \
+                    "migration, identity, persistence, and uninstall all measure an installed service, and every CI run starts on a fresh droplet. Include 'artifact lifecycle' before them." ;;
+                esac
+                ;;
+            esac
+            printf 'lane subset: %s\n' "$QUAL_LANES"
+          else
+            printf "lanes: the script's full default order\n"
+          fi
+
+      - name: Preflight the Tailscale auth key
+        env:
+          TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
+          TS_API_KEY: ${{ secrets.TS_API_KEY }}
+        run: |
+          fail() { printf '::error title=%s::%s\n' "$1" "$2"; exit 1; }
+          warn() { printf '::warning title=%s::%s\n' "$1" "$2"; }
+
+          # The first likely scheduled-run failure: the auth key expired since the last run. Tailscale
+          # caps auth keys at ninety days, so a weekly schedule outlives every key it is given. Without
+          # this check an expired key surfaces as `tailscale up` failing during provision, after a
+          # droplet exists, and reads like a network or policy fault.
+          #
+          # An auth key is `tskey-auth-<keyID>-<secret>`; the id is the third dash-separated field and
+          # is not itself a credential, but it is not printed either. Nothing below echoes any part of
+          # either key: the bearer token goes to curl through a stdin config file so it never appears
+          # in argv or in `ps`.
+          key_id="$(printf '%s' "$TS_AUTHKEY" | cut -d- -f3)"
+          case "$TS_AUTHKEY" in
+            tskey-auth-*) ;;
+            *) fail "TS_AUTHKEY is not an auth key" \
+              "The secret does not start with tskey-auth-. The identity lane needs a tagged auth key, not an OAuth client or API token." ;;
+          esac
+          if [ -z "$key_id" ]; then
+            warn "Auth key id could not be parsed" \
+              "TS_AUTHKEY has an unexpected shape, so its expiry could not be checked in advance. Provision will still validate it."
+            exit 0
+          fi
+
+          code="$(printf 'silent\nshow-error\nheader = "Authorization: Bearer %s"\n' "$TS_API_KEY" |
+            curl --config - -o "$RUNNER_TEMP/authkey.json" -w '%{http_code}' \
+              "https://api.tailscale.com/api/v2/tailnet/-/keys/${key_id}" || echo request-failed)"
+          case "$code" in
+            200) ;;
+            401 | 403)
+              fail "Tailscale API token rejected (HTTP $code)" \
+                "TS_API_KEY could not read the tailnet's keys. It is expired or lacks key read scope. Without it, teardown also cannot delete the tailnet machine record, so dead nodes accumulate." ;;
+            404)
+              fail "Tailscale auth key no longer exists (HTTP 404)" \
+                "The tailnet has no record of this auth key: it was deleted or has aged out. Generate a new tagged, pre-approved, non-ephemeral key and update the TS_AUTHKEY secret." ;;
+            *)
+              # A shape or availability change in the Tailscale API must not fail a run that would
+              # otherwise have worked. Losing the early warning is the correct degradation.
+              warn "Could not check the auth key (HTTP $code)" \
+                "The Tailscale API did not answer the key lookup, so expiry was not verified in advance. Provision will still fail loudly if the key is dead."
+              exit 0 ;;
+          esac
+
+          invalid="$(jq -r '.invalid // false' "$RUNNER_TEMP/authkey.json")"
+          expires="$(jq -r '.expires // ""' "$RUNNER_TEMP/authkey.json")"
+          tags="$(jq -r '(.capabilities.devices.create.tags // []) | join(",")' "$RUNNER_TEMP/authkey.json")"
+          ephemeral="$(jq -r '.capabilities.devices.create.ephemeral // false' "$RUNNER_TEMP/authkey.json")"
+          printf 'auth key expires: %s\n' "${expires:-<no expiry recorded>}"
+          printf 'auth key tags:    %s\n' "${tags:-<none>}"
+
+          if [ "$invalid" = "true" ]; then
+            fail "Tailscale auth key is expired or revoked" \
+              "The tailnet reports this key as invalid. Generate a replacement at Tailscale > Settings > Keys with tag ${TAILNET_TAG}, pre-approved, NOT ephemeral, and update the TS_AUTHKEY secret. No droplet was created."
+          fi
+          if [ -n "$expires" ]; then
+            remaining=$(( ( $(date -u -d "$expires" +%s) - $(date -u +%s) ) / 86400 ))
+            printf 'days until the auth key expires: %s\n' "$remaining"
+            if [ "$remaining" -le 0 ]; then
+              fail "Tailscale auth key expired on $expires" \
+                "Generate a replacement carrying ${TAILNET_TAG}, pre-approved and NOT ephemeral, and update the TS_AUTHKEY secret. No droplet was created."
+            fi
+            # Tailscale's maximum auth-key lifetime is ninety days, so this warning fires roughly once
+            # a quarter and is the only reminder the rotation gets.
+            if [ "$remaining" -le 14 ]; then
+              warn "Tailscale auth key expires in $remaining day(s)" \
+                "Rotate TS_AUTHKEY before it lapses, or the next scheduled runs fail at provision."
+            fi
+          fi
+          case ",$tags," in
+            *",${TAILNET_TAG},"*) ;;
+            *) warn "Auth key does not carry ${TAILNET_TAG}" \
+              "The droplet will join untagged, so it carries a user identity and the identity lane will skip instead of proving denial. Every other lane is unaffected." ;;
+          esac
+          if [ "$ephemeral" = "true" ]; then
+            warn "Auth key is ephemeral" \
+              "The persistence lane reboots the droplet twice; an ephemeral node can be removed while it is offline, taking the Serve mapping and node identity with it."
+          fi
+
+      - name: Refuse to adopt a droplet this run did not create
+        env:
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        run: |
+          # A successful run always destroys its droplet, so an existing one means either a previous
+          # run leaked it or the lead is driving the same fixed name by hand right now. Adopting it
+          # would be wrong both ways: the leftover has a deleted run's key in authorized_keys and this
+          # run could not log in, and stomping the lead's droplet mid-measurement is worse than not
+          # running. Refusing here also keeps the teardown step honest, because teardown only destroys
+          # a droplet when `provision` in this job ran.
+          if doctl compute droplet list --output json |
+            jq -e --arg name "$OMP_QUAL_NAME" 'any(.[]; .name == $name)' >/dev/null; then
+            doctl compute droplet list --output json |
+              jq -r --arg name "$OMP_QUAL_NAME" \
+                '.[] | select(.name == $name) | "existing droplet: id \(.id), created \(.created_at), region \(.region.slug)"'
+            printf '::error title=Droplet %s already exists::Refusing to adopt it. If a previous run leaked it, it is still billing at USD 0.01786 per hour: run ./scripts/provision-linux-qual.sh destroy from an authenticated workstation. If the lead is running this lane by hand, wait for that run to finish.\n' \
+              "$OMP_QUAL_NAME"
+            exit 1
+          fi
+          printf 'no droplet named %s exists; this run starts clean\n' "$OMP_QUAL_NAME"
+
+      - name: Create an ephemeral SSH key and register it with DigitalOcean
+        env:
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          SSH_IDENTITY: ${{ runner.temp }}/omp-qual-ci
+        run: |
+          # RSA, not ed25519. The script's preflight compares `ssh-keygen -l -E md5` against the
+          # fingerprint the DigitalOcean API returns, and the MD5 form is what this account is observed
+          # to return for an RSA key. The fingerprint format for other key types was not verified here,
+          # and the preflight comparison is the one thing that must not be the reason a scheduled run
+          # dies. The key exists for under an hour and is deleted in teardown.
+          ssh-keygen -q -t rsa -b 4096 -N '' -C "omp-qual-ci-${GITHUB_RUN_ID}" -f "$SSH_IDENTITY"
+          # Name carries the run id and attempt so teardown can find it without depending on state
+          # passed between steps, and so re-running a failed job cannot collide with its first attempt.
+          key_name="omp-qual-ci-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          created="$(doctl compute ssh-key create "$key_name" \
+            --public-key "$(cat "${SSH_IDENTITY}.pub")" --output json)"
+          # doctl has returned both a bare object and a single-element array from create in different
+          # versions; accept either rather than pinning on the shape.
+          key_id="$(printf '%s' "$created" | jq -r 'if type == "array" then .[0] else . end | .id')"
+          do_fingerprint="$(printf '%s' "$created" | jq -r 'if type == "array" then .[0] else . end | .fingerprint')"
+          # Exported before the assertion below, so teardown always has the id even if this step fails.
+          {
+            printf 'OMP_QUAL_SSH_KEY_ID=%s\n' "$key_id"
+            printf 'OMP_QUAL_SSH_IDENTITY=%s\n' "$SSH_IDENTITY"
+          } >>"$GITHUB_ENV"
+          printf 'registered DigitalOcean SSH key %s as id %s\n' "$key_name" "$key_id"
+
+          # The same comparison the script's preflight will make, made here where nothing has been
+          # created yet. If DigitalOcean ever stops returning an MD5 fingerprint, this fails with the
+          # reason instead of letting the preflight report "no local private key matches".
+          local_fingerprint="$(ssh-keygen -l -E md5 -f "${SSH_IDENTITY}.pub" | awk '{print $2}')"
+          if [ "$local_fingerprint" != "MD5:${do_fingerprint}" ]; then
+            printf '::error title=SSH key fingerprint mismatch::DigitalOcean returned %s for the key this job just generated, but ssh-keygen computes %s. The script preflight compares exactly these two values, so it would refuse to create a droplet. No droplet was created.\n' \
+              "MD5:${do_fingerprint}" "$local_fingerprint"
+            exit 1
+          fi
+          printf 'fingerprint round-trip matches: %s\n' "$local_fingerprint"
+
+      - name: Provision the droplet and join it to the tailnet
+        id: provision
+        env:
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          # Only this step needs the auth key: `qualify` never touches it and teardown must not.
+          TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
+        run: ./scripts/provision-linux-qual.sh provision
+
+      - name: Run the qualification lanes
+        env:
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          # See the preflight step: `GITHUB_TOKEN` authenticates `gh` here while leaving `GH_TOKEN`
+          # unset, which keeps attestation verification on the offline `--bundle` path and keeps the
+          # token off the droplet.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # If a future edit renames the variable above, fail rather than silently shipping a repo
+          # token to a throwaway public-Internet host through the remote `env` prefix.
+          if [ -n "${GH_TOKEN:-}" ]; then
+            printf '::error title=GH_TOKEN is set::The artifact lane forwards GH_TOKEN to the droplet for online attestation verification. Use GITHUB_TOKEN so the offline bundle path is selected instead.\n'
+            exit 1
+          fi
+          # The full default order runs on a schedule. The droplet-hour is the entire cost, the whole
+          # sequence fits inside it, and the lanes that justify the box only exist in the full set:
+          # `persistence` reboots twice and is what caught #69, `identity` is the only place a denied
+          # Tailscale identity is observable at all. A dispatch subset exists for re-observing one lane
+          # after a fix, not for saving money.
+          #
+          # Two lanes are weaker here than on a workstation, by construction rather than by accident.
+          # `identity` measures the tagged droplet's own denial in full, but its allowed half needs a
+          # user-owned tailnet node; a hosted runner is not one, `OMP_QUAL_ALLOWED_LOGIN` is left
+          # unset, and the script prints that the allowed half was not exercised. The public-IP probe
+          # in that same lane is genuinely better from here: the runner is a real public-Internet host.
+          read -r -a lanes <<<"$QUAL_LANES"
+          ./scripts/provision-linux-qual.sh qualify "${lanes[@]}"
+
+      - name: Destroy the droplet and the ephemeral SSH key
+        # `always()`, so a failed lane, a cancelled run, and an expired job timeout all still tear
+        # down. A teardown failure is more serious than any lane failure: a lane result is information
+        # the lead can go and re-measure for a cent, while a droplet that outlives its job bills every
+        # hour until a human notices. That is why this step is separate, why it runs unconditionally,
+        # and why it fails the job even when every lane passed.
+        if: always()
+        env:
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          # Only teardown needs the API token: without it `destroy` logs the node out but cannot delete
+          # the tailnet machine record, and logged-out records pile up until Tailscale starts appending
+          # -1, -2, -3 to the node name.
+          TS_API_KEY: ${{ secrets.TS_API_KEY }}
+          PROVISION_OUTCOME: ${{ steps.provision.outcome }}
+        run: |
+          status=0
+          # Destroy only when `provision` actually executed in this job. An unrecognised or empty
+          # outcome is treated as "did not run", because the refusal step above means a droplet that
+          # exists without this job having provisioned one belongs to somebody else — most likely the
+          # lead, mid-measurement, on the same fixed name. Deleting theirs is worse than the leak this
+          # would risk, and that leak needs an outcome value GitHub does not produce.
+          case "$PROVISION_OUTCOME" in
+            success | failure | cancelled)
+              if ./scripts/provision-linux-qual.sh destroy; then
+                printf 'teardown: droplet destroyed and tailnet record deleted\n' >>"$GITHUB_STEP_SUMMARY"
+              else
+                status=1
+                printf '::error title=Teardown failed::%s may still exist and may still be billing at USD 0.01786 per hour. Run ./scripts/provision-linux-qual.sh destroy from an authenticated workstation, and check the DigitalOcean console for a droplet tagged %s.\n' \
+                  "$OMP_QUAL_NAME" "$OMP_QUAL_NAME"
+                printf 'teardown: FAILED, %s may still be billing\n' "$OMP_QUAL_NAME" >>"$GITHUB_STEP_SUMMARY"
+              fi
+              ;;
+            *)
+              printf 'provision did not run (outcome: %s); not calling destroy\n' "${PROVISION_OUTCOME:-<none>}"
+              printf 'teardown: skipped, provision never ran\n' >>"$GITHUB_STEP_SUMMARY"
+              ;;
+          esac
+
+          # The DigitalOcean key record costs nothing but should not accumulate. Deleted by name so
+          # this works whether or not the creating step got as far as exporting the id, and skipped
+          # quietly if the job was cancelled before doctl was installed.
+          if command -v doctl >/dev/null 2>&1; then
+            doctl compute ssh-key list --output json |
+              jq -r --arg prefix "omp-qual-ci-${GITHUB_RUN_ID}" \
+                '.[] | select(.name | startswith($prefix)) | .id' |
+              while read -r stale_key; do
+                if doctl compute ssh-key delete "$stale_key" --force; then
+                  printf 'deleted ephemeral DigitalOcean SSH key %s\n' "$stale_key"
+                else
+                  # Not fatal: a leftover public key is inert and free, unlike a leftover droplet.
+                  printf '::warning title=Ephemeral SSH key %s was not deleted::Remove it under DigitalOcean > Settings > Security.\n' "$stale_key"
+                fi
+              done
+          fi
+          exit "$status"

--- a/docs/LINUX_QUALIFICATION.md
+++ b/docs/LINUX_QUALIFICATION.md
@@ -305,9 +305,11 @@ commit (relevant to the ledger's requirement that platform rows be re-run at the
 `doctor` true/false split with the false checks named, and a literal search of
 `doctor --bundle` output for the publisher token and the home path.
 
-**Not this lane.** `Configuration migration and rollback` needs an explicit forward upgrade and
-rollback; that is `docs/UPGRADE_ROLLBACK.md` and `scripts/qualify-upgrade-rollback.sh`. This lane does
-not upgrade anything, so its `qualify` can run before or after that one on the same droplet.
+**The sibling lane.** `Configuration migration and rollback` is also measured on macOS by
+[`UPGRADE_ROLLBACK.md`](UPGRADE_ROLLBACK.md) and `scripts/qualify-rollback.sh`. That harness has no
+user unit, no `enable` state, and no service manager owning the runtime directory, which is why lane
+`migration` above exists: the Linux half of the same claim. The two are independent, so this
+`qualify` can run before or after that one.
 
 ## 6. Teardown and cost
 
@@ -380,7 +382,162 @@ how tailnets accumulate dead nodes across runs.
   establish that the bytes are the ones the release workflow produced at that tag. They say nothing
   about whether that build passes any behavioural gate.
 
-## 9. Related documents
+## 9. Unattended runs in CI
+
+[`.github/workflows/droplet-qualification.yml`](../.github/workflows/droplet-qualification.yml) runs
+this same script on a hosted runner: `workflow_dispatch` at any time, plus a weekly `schedule` at
+11:17 UTC on Mondays. It runs nowhere else. In particular it never runs on `pull_request`, because the
+job spends money and a fork's pull request has no access to the secrets below — and because an
+arbitrary edit of this script must never execute against these credentials.
+
+Nothing about the workflow changes what the lanes measure. It exists so the Linux evidence stops
+depending on somebody remembering to run it, and so a regression like
+[#69](https://github.com/alphastorm/omp-session-gateway/issues/69) has a standing chance of being
+caught by the `persistence` lane rather than by a release attempt.
+
+**This has not been executed yet.** The workflow was validated statically and its shell steps were
+exercised against stubs; the first real run is the lead's to trigger.
+
+### 9.1 Secrets to configure first
+
+All three are repository secrets, set under **Settings → Secrets and variables → Actions**. Each is
+passed as `env` on only the steps that need it, never as a command-line argument, and none is ever
+echoed. A missing one fails the first preflight step by name instead of failing a lane twenty minutes
+into a paid droplet.
+
+| Secret | Created at | Used by | Notes |
+|---|---|---|---|
+| `DIGITALOCEAN_ACCESS_TOKEN` | DigitalOcean → API → Tokens → Generate New Token, read **and** write scope for droplets | every step that talks to DigitalOcean, including teardown | The preflight calls `doctl account get` so an expired token is named as such rather than surfacing as a droplet fault. |
+| `TS_AUTHKEY` | Tailscale admin console → Settings → Keys → Generate auth key | the `provision` step only | Must carry `tag:omp-session-gateway`, be pre-approved if your tailnet requires device approval, and **not** be ephemeral. See [section 3](#3-prerequisites); the reasoning there is unchanged. |
+| `TS_API_KEY` | the same Keys page, as an API access token | the teardown step only | Without it `destroy` logs the node out but cannot delete the tailnet machine record, and logged-out records accumulate until Tailscale starts appending `-1`, `-2`, `-3` to the node name. The auth-key preflight also uses it to read the key's expiry. |
+
+`GITHUB_TOKEN` is the automatic per-job token; there is nothing to configure. It is deliberately
+exported as `GITHUB_TOKEN` and not as `GH_TOKEN`: `gh` accepts either, but this script forwards
+`GH_TOKEN` to the droplet so it can verify attestations online. Leaving `GH_TOKEN` unset selects the
+offline `--bundle` path instead, so the bundles are downloaded on the runner and verified on the
+droplet and no token ever reaches a throwaway public-Internet box. The workflow fails the lane step if
+`GH_TOKEN` is ever set, so that property cannot be lost by a rename.
+
+### 9.2 Rotation
+
+Tailscale caps auth-key lifetime at ninety days, so a weekly schedule outlives every key it is given.
+`TS_AUTHKEY` therefore needs rotating at least quarterly, and that rotation has exactly one reminder:
+the auth-key preflight prints the expiry date and the days remaining on every run, and emits a
+workflow warning at fourteen days or fewer. Treat that warning as the task, not as noise. An expired
+key fails the run before a droplet is created.
+
+`TS_API_KEY` expires on the same schedule and is checked implicitly: a `401` or `403` from the key
+lookup is reported as an API-token failure, distinct from the auth key being dead.
+`DIGITALOCEAN_ACCESS_TOKEN` expires only if it was created with an expiry.
+
+### 9.3 How SSH works there, and why the preflight is untouched
+
+The script refuses to create a droplet it could not then log into: preflight fetches the DigitalOcean
+key's fingerprint and requires a matching local private key, because a droplet you cannot reach is
+pure cost. A hosted runner starts with neither half, so the workflow mints an RSA keypair in
+`$RUNNER_TEMP`, registers the public half with DigitalOcean, and hands the script the two variables it
+already reads: `OMP_QUAL_SSH_KEY_ID` and `OMP_QUAL_SSH_IDENTITY`. **The script is unchanged**, and the
+preflight still fails closed — a runner that cannot log into the droplet it created still stops before
+creating one.
+
+The keypair is RSA rather than ed25519 because the fingerprint DigitalOcean returns for an RSA key is
+the legacy MD5 form the preflight compares against, which is the shape this account is observed to
+return. The workflow makes that comparison itself, immediately after registering the key and before
+any droplet exists, so a change in DigitalOcean's fingerprint format fails with that reason rather
+than as "no local private key matches". The DigitalOcean key record is deleted in teardown; it is
+named `omp-qual-ci-<run id>-<attempt>` and deleting the record does not touch the droplet's
+`authorized_keys`.
+
+### 9.4 Teardown is the point
+
+Teardown is a separate `if: always()` step, so a failed lane, a cancelled run, and an expired
+`timeout-minutes` all still run `destroy`. It fails the job when it cannot finish, even if every lane
+passed, because the two outcomes are not comparable: a lane failure is information the lead can
+re-measure for a cent, while a droplet that outlives its job bills every hour until a human notices.
+
+Three related choices exist for the same reason:
+
+- `concurrency` uses one constant group with `cancel-in-progress: false`. This is load-bearing, not
+  hygiene: the droplet name is fixed and two runs have already collided over it in practice, and a
+  second run would adopt the first run's droplet, install over its lanes and reboot it underneath
+  them. Cancelling is worse than queueing, because a cancelled run may not reach teardown.
+- `timeout-minutes: 50`. A full sequence is about twenty-five minutes and the script's own bounded
+  waits keep a slow-but-legitimate run under forty. Fifty keeps the whole job inside a single billed
+  DigitalOcean hour, so a hung step costs one hour rather than accruing indefinitely.
+- The workflow **refuses to adopt** an existing `omp-gateway-qual` droplet, and teardown destroys a
+  droplet only when this job's `provision` step ran. A successful run always destroys its own droplet,
+  so a pre-existing one is either a leak from an earlier run or a run the lead is driving by hand, and
+  neither may be stomped by CI.
+
+Ways a droplet can still be leaked, none of which the workflow can eliminate:
+
+- the runner or GitHub itself dying mid-job, which skips every remaining step including teardown;
+- a cancellation whose grace period ends before `destroy` finishes;
+- `destroy` failing against a DigitalOcean API that is down, which fails the job loudly but leaves the
+  droplet;
+- the schedule silently stopping. GitHub disables scheduled workflows in repositories with sixty days
+  of no activity, so an unattended lane can stop running without any failure to notice.
+
+In every case the next run refuses to start and says why, and the recovery is the same:
+`./scripts/provision-linux-qual.sh destroy` from an authenticated workstation. A leaked droplet is
+also findable as `doctl compute droplet list --tag-name omp-gateway-qual`.
+
+One more property worth stating, because a scheduled job is exactly the shape that breaks it: this
+workflow only ever touches things it created. It installs the gateway on its own droplet and probes
+that droplet, and it never reads a session, relay room, or gateway from any published list. That
+matters because a run that picks up a live session label on a timer will eventually fire probes into
+something a human is using — which is how the relay soak was lost once already, to an acceptance run
+that reused a session it did not own. Nothing here has a path to the production daemon on
+`127.0.0.1:4317`, to the soak, or to any OMP process.
+
+### 9.5 Which lanes run, and what CI cannot measure
+
+A scheduled run uses the script's full default order. The droplet-hour is the entire cost and the whole
+sequence fits inside it, so running a subset saves nothing; and the lanes that justify provisioning a
+machine at all only exist in the full set — `persistence`, which reboots twice and is what caught #69,
+and `identity`, the only place a denied Tailscale identity is observable. The `lanes` dispatch input
+exists for re-observing one lane after a fix. Because every CI run starts on a fresh droplet, a subset
+must be self-sufficient: anything after `lifecycle` needs `artifact lifecycle` in front of it, and the
+preflight refuses a subset that does not, before a droplet is created.
+
+Two lanes are weaker on a runner than on a workstation, by construction:
+
+- **`identity` loses its allowed half.** Lane 4a is unaffected: the tagged droplet's self-probe still
+  measures the denial, with `tailscale whois` printed beside it. Lane 4b needs a *user-owned* tailnet
+  node, which a hosted runner is not, so `OMP_QUAL_ALLOWED_LOGIN` is left unset and the script prints
+  that the allowed half was not exercised. The `200`, the `no-store` check, and the forged-header pair
+  come only from a workstation run.
+- **The public-IP probe is better from CI, not worse.** A GitHub runner is a genuine public-Internet
+  host, so "connection refused to the droplet's public IP on `4317`" is measured from one.
+
+`migration` needs `OMP_QUAL_PREVIOUS_TAG` to name a published release that is `v0.1.0-prealpha.15` or
+later, for the reason in [section 4](#4-running-the-lane). Both tags are inputs with explicit
+defaults rather than a lookup of the newest release: a scheduled run must qualify a decided candidate,
+and silently following the newest tag would change what the evidence is about without anybody choosing
+that. The preflight checks that both tags exist and carry all six expected assets before provisioning.
+
+### 9.6 Reading a failure
+
+Failures are ordered so that the cheap ones happen first. Everything up to and including the SSH-key
+step runs before any droplet exists, and every message from those steps says so.
+
+| What you see | What it means |
+|---|---|
+| `::error title=Missing secret: …` | That repository secret is not configured. Nothing was created. |
+| `::error title=DigitalOcean token rejected` | `DIGITALOCEAN_ACCESS_TOKEN` is revoked, expired, or lacks write scope. |
+| `::error title=Tailscale auth key is expired or revoked` or `… expired on <date>` | The first of the two likely scheduled failures. Generate a replacement carrying `tag:omp-session-gateway`, pre-approved and not ephemeral, and update `TS_AUTHKEY`. |
+| `::error title=Tailscale API token rejected` | `TS_API_KEY`, not the auth key. Teardown would also be unable to delete the machine record. |
+| `::error title=Candidate tag <tag> not found` or `… is missing <asset>` | The second likely scheduled failure. The tag was deleted or its assets were renamed; `OMP_QUAL_VERSION` overrides the name derivation if `package.json` has moved on. |
+| `::warning title=Auth key does not carry tag:…` | The droplet will join untagged and the `identity` lane will skip. Every other lane is unaffected. |
+| `::error title=Droplet omp-gateway-qual already exists` | A leak from an earlier run or a live workstation run. CI will not touch it; destroy it by hand or wait. |
+| `::error title=SSH key fingerprint mismatch` | DigitalOcean returned a fingerprint the script's preflight would not match. No droplet was created. |
+| A lane failure with the droplet destroyed afterwards | Normal. Read the measurements in the log; the lanes print numbers, not verdicts. |
+| `::error title=Teardown failed` | The serious one. Treat it as an unclosed billing risk, not a test failure. |
+
+A lane failure and a teardown failure look identical in the run list, so check the job summary: it
+records one line saying whether the droplet was destroyed, skipped, or possibly still billing.
+
+## 10. Related documents
 
 - [`RELEASE_STATUS.md`](RELEASE_STATUS.md) — the ledger; the only place a row's status changes.
 - [`TEST_PLAN.md`](TEST_PLAN.md) — §4.E authorization and §4.F persistence scenarios this lane feeds.
@@ -388,3 +545,5 @@ how tailnets accumulate dead nodes across runs.
 - [`RELEASE.md`](RELEASE.md) — the canonical artifact verification commands this lane runs remotely.
 - [`OPERATIONS.md`](OPERATIONS.md) — install, Serve, paths, and `doctor` semantics.
 - [`UPGRADE_ROLLBACK.md`](UPGRADE_ROLLBACK.md) — the sibling lane for forward upgrade and rollback.
+- [`.github/workflows/droplet-qualification.yml`](../.github/workflows/droplet-qualification.yml) —
+  the scheduled unattended runner for this lane; see [section 9](#9-unattended-runs-in-ci).

--- a/scripts/acceptance-target.test.ts
+++ b/scripts/acceptance-target.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { targetEligibility } from "./acceptance-target.ts";
+
+const NOW = Date.parse("2026-08-20T16:00:00.000Z");
+const fresh = new Date(NOW - 60_000).toISOString();
+const old = new Date(NOW - 3 * 60 * 60 * 1000).toISOString();
+
+describe("acceptance target eligibility", () => {
+  test("refuses a protected label even when fresh and acknowledged", () => {
+    // The concrete incident: `omp-soak2` was an 8-hour relay soak's own host session, and three runs
+    // fired real launches into its relay room until its collab host faulted at 7h40m. A protected
+    // label must be unusable, not merely discouraged, so the acknowledgement must not rescue it.
+    for (const label of ["omp-soak2", "relay-endurance", "omp-monorepo", ".dotfiles-private", "alpha-founder"]) {
+      const verdict = targetEligibility(label, fresh, NOW, true);
+      expect(verdict.eligible).toBe(false);
+      expect(verdict.reason).toContain("protected pattern");
+    }
+  });
+
+  test("accepts a fresh disposable fixture", () => {
+    expect(targetEligibility("omp-accept-scratch", fresh, NOW, false)).toEqual({ eligible: true });
+  });
+
+  test("refuses a long-lived session unless explicitly acknowledged", () => {
+    const refused = targetEligibility("omp-accept-scratch", old, NOW, false);
+    expect(refused.eligible).toBe(false);
+    expect(refused.reason).toContain("--disposable-target");
+    expect(targetEligibility("omp-accept-scratch", old, NOW, true)).toEqual({ eligible: true });
+  });
+
+  test("treats a missing or unparseable start time as too old", () => {
+    // Fail closed. An absent timestamp previously would have read as age zero, which is exactly the
+    // wrong default for a destructive fixture.
+    for (const startedAt of [undefined, "not-a-date"]) {
+      const verdict = targetEligibility("omp-accept-scratch", startedAt, NOW, false);
+      expect(verdict.eligible).toBe(false);
+      expect(verdict.reason).toContain("unknown age");
+    }
+  });
+});

--- a/scripts/acceptance-target.ts
+++ b/scripts/acceptance-target.ts
@@ -1,0 +1,57 @@
+/**
+ * Decides whether a published session may be used as a destructive test fixture.
+ *
+ * This module exists because of a specific, avoidable loss. `scripts/android-acceptance.ts` fires
+ * real `view`, `control`, and stale-generation launches at whatever session it is pointed at. Three
+ * runs were pointed at `omp-soak2`, which was an 8-hour relay endurance soak's own host session,
+ * chosen only because it was the first published label that looked familiar. Its collaboration host
+ * faulted at 7h40m and the endurance result was lost.
+ *
+ * The rule "do not target a session you do not own" was known and still broken, so it is encoded
+ * here rather than left to memory. It lives in its own module so it can be tested without a device
+ * and without executing the harness's top-level argument parsing.
+ */
+
+/** Labels that can never be a target, at any age, with or without an override. */
+const PROTECTED_LABEL_PATTERN = /soak|relay|monorepo|dotfiles|alpha-founder/iu;
+
+/**
+ * Checked before any network lookup, so a protected label is refused whether or not it is currently
+ * published. The refusal must not depend on the state of the thing it is protecting.
+ */
+export function isProtectedLabel(label: string): boolean {
+  return PROTECTED_LABEL_PATTERN.test(label);
+}
+
+/** A session running longer than this is somebody's real work, not a disposable fixture. */
+export const DISPOSABLE_MAX_AGE_MS = 30 * 60 * 1000;
+
+export interface TargetEligibility {
+  readonly eligible: boolean;
+  readonly reason?: string;
+}
+
+/**
+ * Pure and deliberately fail-closed: an absent or unparseable start time is treated as too old
+ * rather than assumed fresh, because the wrong default here destroys someone's running work.
+ */
+export function targetEligibility(
+  label: string,
+  startedAt: string | undefined,
+  now: number,
+  acknowledgedDisposable: boolean,
+): TargetEligibility {
+  if (PROTECTED_LABEL_PATTERN.test(label)) {
+    return { eligible: false, reason: `"${label}" matches a protected pattern and can never be a target` };
+  }
+  const started = startedAt === undefined ? Number.NaN : Date.parse(startedAt);
+  const ageMs = Number.isFinite(started) ? now - started : Number.POSITIVE_INFINITY;
+  if (ageMs > DISPOSABLE_MAX_AGE_MS && !acknowledgedDisposable) {
+    const age = Number.isFinite(ageMs) ? `${Math.round(ageMs / 60000)} minutes old` : "of unknown age";
+    return {
+      eligible: false,
+      reason: `"${label}" is ${age}, so it is probably real work; pass --disposable-target to override`,
+    };
+  }
+  return { eligible: true };
+}

--- a/scripts/android-acceptance.ts
+++ b/scripts/android-acceptance.ts
@@ -18,6 +18,7 @@
  * Usage: `bun scripts/android-acceptance.ts <origin> <session-cwd-label>`
  */
 import { withAndroidChrome, type AndroidChromeDriver } from "./android-device.ts";
+import { isProtectedLabel, targetEligibility } from "./acceptance-target.ts";
 
 const WAKE = "224";
 const MENU = "82";
@@ -204,14 +205,50 @@ async function authorizationMatrix(driver: AndroidChromeDriver, label: string): 
   return value;
 }
 
-const origin = process.argv[2];
-const label = process.argv[3];
+const args = process.argv.slice(2);
+const acknowledgedDisposable = args.includes("--disposable-target");
+const [origin, label] = args.filter(value => !value.startsWith("--"));
 if (!origin || !label) {
-  console.error("usage: bun scripts/android-acceptance.ts <origin> <session-cwd-label>");
+  console.error("usage: bun scripts/android-acceptance.ts <origin> <session-cwd-label> [--disposable-target]");
+  process.exit(2);
+}
+
+// Refused before any network call, so the refusal cannot depend on whether the protected session
+// happens to be published at this instant.
+if (isProtectedLabel(label)) {
+  console.error(`REFUSED: "${label}" matches a protected pattern and can never be a target.`);
+  console.error("this harness fires real view, control, and stale-generation launches at the target.");
+  console.error("create a disposable session instead; a relay soak host lost 7h40m to exactly this.");
   process.exit(2);
 }
 
 const host = new URL(origin).hostname;
+
+// Refuse an ineligible target before touching the device or the session. This runs against the
+// gateway rather than the phone precisely so an ineligible target costs nothing and cannot be
+// discovered halfway through a run that has already fired launches at it.
+const listResponse = await fetch(new URL("/api/v1/sessions", origin), { headers: { accept: "application/json" } });
+if (!listResponse.ok) {
+  console.error(`could not read the session list to validate the target: HTTP ${listResponse.status}`);
+  process.exit(2);
+}
+const listed: unknown = await listResponse.json();
+const sessions =
+  listed && typeof listed === "object" && "sessions" in listed && Array.isArray(listed.sessions) ? listed.sessions : [];
+const match = sessions.find(
+  (session): session is { cwdLabel: string; startedAt?: string } =>
+    session !== null && typeof session === "object" && "cwdLabel" in session && session.cwdLabel === label,
+);
+if (!match) {
+  console.error(`target "${label}" is not published; nothing was touched`);
+  process.exit(2);
+}
+const eligibility = targetEligibility(label, match.startedAt, Date.now(), acknowledgedDisposable);
+if (!eligibility.eligible) {
+  console.error(`REFUSED: ${eligibility.reason}`);
+  console.error("this harness fires real view, control, and stale-generation launches at the target.");
+  process.exit(2);
+}
 
 const summary = await withAndroidChrome(async driver => {
   serial = driver.serial;


### PR DESCRIPTION
## The incident

I pointed three Android acceptance runs at `omp-soak2` — an 8-hour relay endurance soak's **own host session**. The harness fires real `view`, `control`, and stale-generation launches at whatever it is given, so the soak's collaboration host faulted at **7h40m** and the endurance result was lost.

Why: the scratch session I'd been using had been cleaned up, and I took a label off the published list without checking what it belonged to. `omp-soak2` was there and published. That's the whole reason.

The part worth fixing is that an hour later I told a subagent the exact rule I had just broken. **A rule I have to remember is not a control.**

## The control

`scripts/acceptance-target.ts`:

- A **protected label can never be a target** — any age, with or without an override — and that check runs **before any network call**, so the refusal can't depend on whether the protected session happens to be published at that instant. The refusal must not depend on the state of the thing it protects.
- A session older than **30 minutes** is refused as probably-real-work unless the caller passes `--disposable-target`.
- An absent or unparseable `startedAt` is treated as **too old**. Failing closed matters here: the wrong default destroys someone's running work.
- Target validation happens before the device is touched at all, so an ineligible target costs nothing rather than being discovered mid-run after launches have already fired.

Separate module so it's testable without a device and without executing the harness's argument parsing, which calls `process.exit`.

Proof it refuses the actual mistake, against a deliberately invalid origin to show no network is involved:

```
$ bun scripts/android-acceptance.ts https://invalid.invalid omp-soak2
REFUSED: "omp-soak2" matches a protected pattern and can never be a target.
this harness fires real view, control, and stale-generation launches at the target.
create a disposable session instead; a relay soak host lost 7h40m to exactly this.
$ echo $?
2
```

## Also lands the scheduled droplet workflow

Teardown is a separate `if: always()` step, so a failed, cancelled, or **timed-out** job still destroys the droplet — and it **fails the job when teardown fails**, because a leaked droplet bills indefinitely and matters more than a lane result. `timeout-minutes: 50` bounds a hung run.

The `concurrency` guard is load-bearing, not hygiene: the droplet name is fixed and two runs have already collided over it. `cancel-in-progress` stays **false**, because a cancelled run may skip teardown.

`GH_TOKEN` is deliberately **not** exported. `lane_artifact` forwards it into the droplet's remote env prefix, which would place a repository token in the droplet's argv; leaving it unset selects the offline attestation path the script already implements. The qualify step fails if it is ever set, so a rename can't silently lose that.

It also corrects a doc paragraph pointing at a `scripts/qualify-upgrade-rollback.sh` that does not exist.

## Threat-model impact

Reduces blast radius in two places. The harness can no longer be aimed at a session it does not own, and the workflow never reads a session, relay room, or gateway from any published list — it probes only the droplet it just created, so there is no path to `127.0.0.1:4317` or any OMP process.

## Verification

4 tests / 18 assertions on the predicate, including that acknowledgement does **not** rescue a protected label. `bun run check` green from a clean tree. Workflow YAML parses; `if: always()` teardown, `concurrency`, and `timeout-minutes` confirmed present.

**Before the first scheduled run** you must configure `DIGITALOCEAN_ACCESS_TOKEN`, `TS_AUTHKEY` (tagged), and `TS_API_KEY`. It has never been executed — the first run is a deliberate manual dispatch.
