### PR TITLE
fix(docs): restore ledger formatting lost to an over-broad substitution

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,97 +1,175 @@
-# Compatibility and support policy ## Current claim **No operating system, browser, or Android device is currently advertised as supported.**
+# Compatibility and support policy
+
+## Current claim
+
+**No operating system, browser, or Android device is currently advertised as supported.**
 The repository version is `0.1.0`, classified as an implemented **pre-alpha** rather than an alpha
 or a production-qualified release, and the alpha decision in
 [`RELEASE_STATUS.md`](RELEASE_STATUS.md) is **NO-GO**. Of that ledger's rows, 35 are **PASS** within
 their own narrow scope, 14 are **PARTIAL**, and one is **N/A**. A PASS row says nothing about a
-broader scope, and 14 PARTIAL rows are why nothing below carries a support claim. Signed pre-alpha candidates now exist, which changes what an artifact *is* without changing what it
+broader scope, and 14 PARTIAL rows are why nothing below carries a support claim.
+
+Signed pre-alpha candidates now exist, which changes what an artifact *is* without changing what it
 is *claimed* to be. `v0.1.0-prealpha.14`, `.15`, and `.16` are published and independently
 verifiable, and several rows below cite measurements taken against them rather than against a
 development checkout — an important distinction, because a development install can differ from the
 bytes a release workflow produced. A verified signature proves origin, not fitness: it establishes
 that the bytes are the ones the workflow built at that tag and says nothing about whether that build
 passes any behavioural gate. A locally built archive is weaker still — unsigned local preflight, an
-engineering artifact rather than a distribution. | Candidate | Bundled build recorded in the ledger | What it carries | Independent verification recorded |
+engineering artifact rather than a distribution.
+
+| Candidate | Bundled build recorded in the ledger | What it carries | Independent verification recorded |
 |---|---|---|---|
 | `v0.1.0-prealpha.14` | `0.1.0-8773d783ca96` | The baseline of the current candidate series. Its Linux unit named the runtime directory in `ReadWritePaths=`, which systemd refuses to start when the path does not yet exist, so it does not survive a reboot ([#69](https://github.com/alphastorm/omp-session-gateway/issues/69)). | `shasum -c` OK, `gh attestation verify` exit 0, and `cosign verify-blob` "Verified OK" for the archive, SBOM, and `SHA256SUMS` against certificate identity `https://github.com/alphastorm/omp-session-gateway/.github/workflows/release.yml@refs/tags/v0.1.0-prealpha.14` |
 | `v0.1.0-prealpha.15` | `0.1.0-4eddf19f2b71` | The systemd `RuntimeDirectory=` fix with `RuntimeDirectoryMode=0700` for [#69](https://github.com/alphastorm/omp-session-gateway/issues/69). The build identifier was observed on the droplet by the Linux `migration` lane, which recorded it as the active version restored by the rollback step. | Verified on the droplet by the Linux lane, which runs `sha256sum --check`, `cosign verify-blob` at the exact certificate identity, and `gh attestation verify` before extracting anything |
-| `v0.1.0-prealpha.16` | `0.1.0-2813d6b23306` | The directory-recovery fixes from [#72](https://github.com/alphastorm/omp-session-gateway/pull/72): the `offline` state gained its own exit instead of depending on an `online` event that may never fire — `navigator.onLine` reported `true` throughout a total airplane-mode outage on this device, and a connection that is not demonstrably live is torn down and rebuilt when a frozen renderer resumes. Carrying that fix is not evidence that [#65](https://github.com/alphastorm/omp-session-gateway/issues/65) is resolved; that issue is open. | `shasum -c`, `gh attestation verify`, and `cosign verify-blob` | [`RELEASE_STATUS.md`](RELEASE_STATUS.md) is the source of truth for evidence and for the release
+| `v0.1.0-prealpha.16` | `0.1.0-2813d6b23306` | The directory-recovery fixes from [#72](https://github.com/alphastorm/omp-session-gateway/pull/72): the `offline` state gained its own exit instead of depending on an `online` event that may never fire — `navigator.onLine` reported `true` throughout a total airplane-mode outage on this device, and a connection that is not demonstrably live is torn down and rebuilt when a frozen renderer resumes. Carrying that fix is not evidence that [#65](https://github.com/alphastorm/omp-session-gateway/issues/65) is resolved; that issue is open. | `shasum -c`, `gh attestation verify`, and `cosign verify-blob` |
+
+[`RELEASE_STATUS.md`](RELEASE_STATUS.md) is the source of truth for evidence and for the release
 decision. This document defines what the project is compatible with and how a compatibility claim
-becomes supportable. Where the two disagree, the ledger is right and this file is wrong. ## Status vocabulary Compatibility statements use these terms deliberately: | Term | Meaning |
+becomes supportable. Where the two disagree, the ledger is right and this file is wrong.
+
+## Status vocabulary
+
+Compatibility statements use these terms deliberately:
+
+| Term | Meaning |
 |---|---|
 | **Implemented** | The relevant code path exists and has repository-level automated coverage. |
 | **Smoke-tested** | A named scenario passed in one recorded environment. This is not a platform support claim. |
 | **Qualified** | The complete applicable release matrix passed on the named version, OS, browser, and deployment path. |
 | **Supported** | A published release advertises that qualified combination and accepts bug reports against it. |
 | **Deferred** | Intentionally outside the current release target. |
-| **Unsupported** | Must not be presented as a working deployment path. | An implemented or smoke-tested row remains unqualified until every applicable security,
-installation, lifecycle, and cleanup scenario passes. Blank version ranges never imply support. ## Exact OMP baseline The pre-alpha targets one immutable upstream source revision: | Gateway line | OMP source | Nearest release baseline | OMP package baselines | Collab client | Registry protocol | Claim |
+| **Unsupported** | Must not be presented as a working deployment path. |
+
+An implemented or smoke-tested row remains unqualified until every applicable security,
+installation, lifecycle, and cleanup scenario passes. Blank version ranges never imply support.
+
+## Exact OMP baseline
+
+The pre-alpha targets one immutable upstream source revision:
+
+| Gateway line | OMP source | Nearest release baseline | OMP package baselines | Collab client | Registry protocol | Claim |
 |---|---|---|---|---|---:|---|
-| `0.1.0` (pre-alpha candidates only; no alpha) | `can1357/oh-my-pi@858f7dd91fff9b84cf8a2c6a6bb85aa0e6d03a55` | `v17.3.8` | coding-agent `17.3.8`; wire `17.3.8` | collab-web `16.3.6` from the same source commit | 1 | Exact-commit pre-alpha qualification only | `v17.3.8` is the release tag and package baseline recorded on **2026-08-19**. It is
+| `0.1.0` (pre-alpha candidates only; no alpha) | `can1357/oh-my-pi@858f7dd91fff9b84cf8a2c6a6bb85aa0e6d03a55` | `v17.3.8` | coding-agent `17.3.8`; wire `17.3.8` | collab-web `16.3.6` from the same source commit | 1 | Exact-commit pre-alpha qualification only |
+
+`v17.3.8` is the release tag and package baseline recorded on **2026-08-19**. It is
 not a claim that every checkout or package combination labeled `v17.3.8` is compatible.
-No earlier or later OMP release, commit, fork, or loose semver range is supported. **Pin refreshed 2026-08-19, from `v17.0.6` / `89d6a8f6d14286f32f09ec9c8aa8af7b3451d2d6`.** The
+No earlier or later OMP release, commit, fork, or loose semver range is supported.
+
+**Pin refreshed 2026-08-19, from `v17.0.6` / `89d6a8f6d14286f32f09ec9c8aa8af7b3451d2d6`.** The
 previous mbox did not apply at this commit (`interactive-mode.ts`, `agent-session.ts`,
 `session-manager.ts`, and `builtin-registry.ts` all conflicted), so the shipped patch was
 regenerated against `v17.3.8`. The refresh itself carried source-level evidence only: it re-ran the
 documented patch suite and the repository suite, and it re-ran no native host, Tailscale, relay,
 Android, browser, or signed-artifact qualification. Any platform row whose evidence predates
 2026-08-19 is therefore **NOT RUN** for this pin until re-executed, and an unchanged row is never
-coverage of `v17.3.8`. Re-execution has since started; it has not finished. Measurements taken at this pin on 2026-08-20
+coverage of `v17.3.8`.
+
+Re-execution has since started; it has not finished. Measurements taken at this pin on 2026-08-20
 include the Linux droplet lanes against signed `.14`, `.15`, and `.16`; two in-place macOS upgrades
 ending at build `0.1.0-2813d6b23306` with `doctor` at 16/16; the Tailscale Serve identity matrix
 against `.16`; the macOS rollback lane across `.13` and `.14`; and the Android acceptance and
 capability-leak sweeps on the current device. Blocker 5 in the ledger still requires the complete
 re-run of the native, Tailscale, relay, Android, browser, and signed-artifact rows, so no row below
-is finished for `v17.3.8`. The immutable source paths, versions, observation date, and upstream findings live in
-[`UPSTREAM.lock.json`](../UPSTREAM.lock.json). The gateway integration currently requires: - the apply-ready OMP controller/auto-start/registry patch in [`patches/oh-my-pi`](../patches/oh-my-pi/README.md);
-- the pinned collab-web source integration described by [`packages/collab-client/upstream/UPSTREAM.json`](../packages/collab-client/upstream/UPSTREAM.json);
-- the reviewed in-memory client bootstrap, because unchanged upstream collab-web writes a capability to `location.hash`; and
-- Bun `1.3.14` for the recorded build and test baseline. The runtime archive declares Bun `>=1.3.14`, but versions newer than the pinned baseline are not release-qualified yet. ## Versioned interfaces Three compatibility surfaces change independently: | Surface | Current version | Current behavior |
+is finished for `v17.3.8`.
+
+The immutable source paths, versions, observation date, and upstream findings live in
+[`UPSTREAM.lock.json`](../UPSTREAM.lock.json). The gateway integration currently requires:
+
+- the apply-ready OMP controller/auto-start/registry patch in
+  [`patches/oh-my-pi`](../patches/oh-my-pi/README.md);
+- the pinned collab-web source integration described by
+  [`packages/collab-client/upstream/UPSTREAM.json`](../packages/collab-client/upstream/UPSTREAM.json);
+- the reviewed in-memory client bootstrap, because unchanged upstream collab-web writes a
+  capability to `location.hash`; and
+- Bun `1.3.14` for the recorded build and test baseline. The runtime archive declares
+  Bun `>=1.3.14`, but versions newer than the pinned baseline are not release-qualified yet.
+
+## Versioned interfaces
+
+Three compatibility surfaces change independently:
+
+| Surface | Current version | Current behavior |
 |---|---:|---|
 | OMP publisher to gateway registry | 1 | Strict runtime validation; unknown major versions are rejected. |
 | PWA to gateway HTTP API | `/api/v1` | One emitted API major; list/SSE remain metadata-only and launch remains generation-bound. |
-| Gateway patch to OMP internals | Exact commit above | Tested as a patch against the pinned checkout; no private-internals compatibility range is inferred. | Package version compatibility does not override a protocol major or exact OMP source pin.
+| Gateway patch to OMP internals | Exact commit above | Tested as a patch against the pinned checkout; no private-internals compatibility range is inferred. |
+
+Package version compatibility does not override a protocol major or exact OMP source pin.
 Rolling compatibility with an earlier publisher protocol may be added only after explicit
-cross-version tests exist. ## Host and client matrix The following describes code and evidence, not advertised support. Every support claim below is
+cross-version tests exist.
+
+## Host and client matrix
+
+The following describes code and evidence, not advertised support. Every support claim below is
 **None**, except desktop Chromium, which is smoke only. The qualification column is the honest
-remainder for each row, not a formality; read it before reading the evidence. | Platform | Implemented path | Recorded evidence | Qualification | Support claim |
+remainder for each row, not a formality; read it before reading the evidence.
+
+| Platform | Implemented path | Recorded evidence | Qualification | Support claim |
 |---|---|---|---|---|
 | Linux host | Unix-domain socket; systemd user service | Two environments. A **Debian 13 aarch64 container** with a real `systemd --user` manager passed the development-checkout lifecycle and repeated it from an unsigned extracted archive. On its 2026-08-20 re-run at the `v17.3.8` pin, from an archive built at merge commit `ac63641` on Bun 1.3.14, install reached ready with MainPID 159; the unit file, `config.json`, and the 44-byte publisher token were `0600` with `0700` config and state directories; `ss` showed a single listener bound to `127.0.0.1:4317`; active reinstall replaced PID 159 with 239; token rotation changed the token digest and replaced PID 239 with 292; the diagnostics bundle contained no token, allowlisted login, tailnet host, or home path; `uninstall --no-stop` refused with exit 1 while the service stayed active; and normal uninstall removed the unit and left zero listeners on 4317. A **real Debian 13 (trixie) x86_64 DigitalOcean droplet** — kernel `6.12.94+deb13-amd64`, systemd 257, `systemd-detect-virt` reporting `kvm` — then ran the sequence from the signed candidates. Install reported `{installed:true, active:true, ready:true, authMode:tailscale-serve}` with the listener bound to `127.0.0.1:4317` only and `doctor` at 12/16; the four false checks were `identityAllowed`, `pwa`, `securityHeaders`, and `publisherHealth`, all expected with no Serve mapping and no publishers. Reboot persistence **failed** on `.14` ([#69](https://github.com/alphastorm/omp-session-gateway/issues/69)): with lingering enabled, `loginctl Linger=yes`, and the boot id confirmed changed, `user@1000.service` came back `active` while the gateway daemon did not, leaving no pid and no listeners. It **passes** on `.15`: after a clean reboot with **no interactive login**, `loginctl` showed the uid-1000 session as class `manager`, the gateway ran as pid 766 with the listener on `127.0.0.1:4317`, and the process was 57 s old against 69 s of system uptime, so it started about 12 s after boot rather than on connection; the same procedure on `.14` left no pid and no listener. `.15` also reported `installed/active/ready`, `doctor` 12/16 with the same four expected false checks, socket mode 600 under the systemd-owned runtime directory, token rotation across pids 2208 to 2305, and a diagnostics bundle containing zero token bytes and zero home-path hits. On `.16`, with the service genuinely active, `uninstall --no-stop` **refused as required**, and a real uninstall then left no unit file, no gateway pid, and no listener. The `migration` lane passed 11/11 invariants from `.15` up to `.16` and back, including that `ExecStart` tracks the active version, that the unit stays `enabled` so an upgrade cannot silently reintroduce #69, that the main pid changes across the upgrade, and that the listener stays loopback-only after the rollback. | **PARTIAL** in the ledger. A KVM guest is a virtual machine, not bare metal: firmware, real disks, real NICs, and physical power loss remain untested, and "bare-metal" is the wrong word for this evidence. The architecture also moved from aarch64 to x86_64 while the distribution was held fixed, so architecture-sensitive behaviour is newly covered rather than re-confirmed. No OMP publisher, browser, or Android device took part on this host, so `publisherHealth` reflects an empty registry and no session discovery, View/Control, generation replacement, relay, or capability-leak evidence comes from it. `doctor` cannot reach 16/16 on a tagged node by construction, because its self-probe through Serve carries no user identity. Persistence is proven for systemd user lingering on this one distribution; no other init system, and no non-systemd path, has any claim. | None |
 | macOS host | User-only Unix-domain socket; LaunchAgent | macOS **26.5.2** arm64 passed live LaunchAgent install, private permissions, restart/reinstall, atomic token rotation, `doctor`/bundle, Serve access as the allowlisted node identity, loopback-backend identity rejection, loopback/LAN isolation, and uninstall — all from a **development checkout**. The independently verified `provenance-test-v0.1.0.10` archive passed an isolated `--no-start` install/runtime smoke, real Serve routing, gateway-restart recovery, one patched interactive OMP publication/removal, and three controlled publisher/gateway suspension orders beyond TTL. Signed candidate `.14` was then installed over the live service: the in-place upgrade replaced `0.1.0-61114587f124` with `0.1.0-8773d783ca96`, moved the daemon from PID 41501 to 51469, kept `doctor` at 16/16, left the tailnet origin answering `200` with loopback still `403`, reconnected all three live publishers within 40 seconds with the in-memory registry correctly restarting empty at revision 0 before repopulating, and preserved `config.json` and the publisher token unchanged (digest `f361650a4974`, mode 600). A second in-place upgrade moved `0.1.0-8773d783ca96` to `0.1.0-2813d6b23306` (`.16`) and the daemon from PID 51469 to 12327, with **`doctor` at 16/16** and the origin still answering `200`; that build is what the live daemon runs. Rollback was measured on **macOS 26.6.1** arm64 with Bun 1.3.14 by `scripts/qualify-rollback.sh`, in an isolated root against both signed artifacts: install `.13`, upgrade `.14`, roll back to `.13`, **20/20 invariants**, `current.json` tracking `0.1.0-1b654b660ec4` to `0.1.0-8773d783ca96` and back, the predecessor version directory surviving the upgrade, `config.json` byte-identical at `sha256:60d9c36e2766`, the publisher-token digest and mode 600 unchanged throughout, and `ProgramArguments` naming the active version at all three steps. | **PARTIAL** in the ledger. The rollback lane ran `--no-start` throughout, so it measured the installer's state machine and not a running-service transition: no bootout/bootstrap, no readiness handshake, no PID replacement, and no post-rollback `status`/`doctor`/health probe, which means a rollback that leaves correct files behind but never brings the predecessor back up would still have passed every invariant. launchd's label namespace is per-uid and cannot be scoped, so the lane shimmed the part of launchd it could not isolate and everything downstream of "the service definition on disk is correct" — RunAtLoad, KeepAlive, reboot and login persistence, `bootstrap` failure modes — is untested by construction; the rollback step itself was obtained with launchd reads scoped. Only one rollback shape was exercised: a pruned predecessor directory, a `config.json` schema change, and a readiness-protocol change are all untested, as is the non-atomic window between the service-definition rewrite and the `current.json` write. Actual sleep/wake, relay/browser recovery, reboot/login persistence, real OMP collaboration through a signed candidate, and candidate-artifact capability-leak acceptance remain unqualified. | None |
 | Windows host | Current-user named pipe and scheduled task; OMP publisher requires a nonce-bound mutual HMAC handshake before releasing capabilities | [GitHub Actions run 29791906104](https://github.com/alphastorm/omp-session-gateway/actions/runs/29791906104) applied the exact candidate OMP patch on `windows-latest`, passed all eleven publisher fixtures—including mutual authentication, fake-server withholding, restart recovery, post-restart token reread, and explicit-token-path publication preserving ambient XDG configuration—and the coding-agent typecheck, then passed gateway IPC/config/token ACL tests, current-user publisher access, cross-user publisher-write denial, UTF-16 task installation, active health, atomic token rotation with graceful PID replacement, idempotent active reinstall, and process-clean uninstall | Hosted source-checkout evidence is not signed-artifact qualification; reboot/login persistence, diagnostics, upgrade/rollback, and a release-candidate run remain unqualified. This row is also one of the native host rows the ledger marks **NOT RUN** for the `v17.3.8` pin: no Windows re-run at the refreshed pin is recorded. | None |
 | Android client | Installable HTTPS PWA through Tailscale Serve | **Current device baseline (2026-08-20):** Pixel 10 Pro (the paired device), Android 17 build `CP2A.260805.005` (SDK 37), Chrome `151.0.7922.139`, measured layout viewport 411×816 within a 412×919 screen at device pixel ratio 2.625. Measured at the `v17.3.8` pin on this combination: `scripts/android-leak-sweep.ts` against a **development install** returned launch `200` with `cache-control: no-store, max-age=0` and body keys `capability,generation,mode`, carrying the 66-character capability (`sha256:d107fb0d826278b5`) in JSON to same-origin JavaScript rather than in any URL component, and found it absent from Local Storage, Session Storage, cookies, Cache Storage keys and bodies (only `omp-sessions-shell-c304cf72b454` present), IndexedDB, `location`/fragment (0-character hash, so no fragment fallback was used), `history.state`, referrer, resource-timing entries, and serialized DOM — with the detector first proving itself by planting a synthetic secret in all seven sinks, requiring all seven to be found, then removing them with no residue. Re-run against the **signed candidate** serving the live tailnet origin, the sweep was clean across all seven sinks with the detector again proving itself (7 planted, 7 detected, no residue), launch `200` `no-store`, capability `sha256:39478ea244d0c1ef`, zero-character fragment. As a **distinct tailnet node** rather than the host, the phone received `200` for `GET /api/v1/sessions` and for a `POST …/launch` with identity headers supplied by Serve, and `403` with `{"code":"forbidden"}` and no `instanceId` or `cwdLabel` in the body from an isolated second gateway on Serve port `:9443` whose allowlist held only the placeholder `denied-identity@qual.invalid`. Recovery matrix via `scripts/android-acceptance.ts`, first from a **development install** and then against the **signed candidate**: lock and resume recovered in 3,465-3,674 ms after wake with a 64-106 ms fetch and no unreachable banner across three runs, and in 3,872 ms on the candidate; forced deep Doze reached `IDLE` and recovered in 8,484-9,348 ms, and in 9,335 ms on the candidate; airplane mode showed the unreachable banner during the outage in every run and recovered automatically without a reload in 14,873 ms and in 83 ms on two runs, but a third run stalled for 471,257 ms while `adb shell ping` proved the device had reached the host at 28,424 ms, recovering only after the Doze cycle, and that stall reproduced on the signed candidate with the device reachable at 28,354 ms. **Historical scenario evidence**, on the superseded Android 17 build `CP2A.260705.006` (SDK 37) with Chrome `150.0.7871.128`: corrected `v0.1.0-prealpha.4` passed installed-PWA View/Control/Back, exactly-once retained response, foreground and lock-screen attention notification, dashboard-only notification tap, lock/resume, automatic relay reconnect, generation replacement with stale `409`, and TTL removal/republication; the independently verified `v0.1.0-prealpha.5` artifact auto-discovered three real OMP processes, cleared all cards after a silent Airplane-mode partition, and restored exactly three from a fresh snapshot without Refresh; on signed `v0.1.0-prealpha.7` the user reported the instructed explicit-enable, closed-PWA background notification, and tap-to-current-Control flow working, without fresh version capture or a named evidence artifact. | **PARTIAL** in the ledger on every applicable row, and nothing here is a resilience claim. **Wi-Fi to cellular is untested.** With Wi-Fi disabled this device reports `Active default network: none` and `connect: Network is unreachable`, because its Google Fi SIM is present but `NOT_READY`. The historical Wi-Fi→cellular→Wi-Fi pass therefore cannot be reproduced on this hardware and must be read as **unverified** until a device with working cellular data is available. **Post-outage recovery is not qualified:** [#65](https://github.com/alphastorm/omp-session-gateway/issues/65) is open, the 471,257 ms stall is reproduced but unattributed between the application, Chrome's network stack, and the Tailscale interface, and the harness cannot evaluate the page while Chrome's renderer is frozen, so the hidden part of an outage window is unobserved rather than proven healthy. Chrome also freezes the renderer while the display is off, so lock-state observation is only possible after waking. Cold offline navigation is intentionally unavailable because navigation is never service-worker cached. The capability sweep still needs the collaboration client page itself after it connects, `control` mode, and release CI artifacts, recordings, and diagnostics scanned with canary capabilities from a signed candidate artifact. Physical interrupt, host-observed rejection of a View mutation attempt, switch/branch/saved-session resume, process crash, and the background-Push lock-screen, force-stop, and stale-generation matrix all remain incomplete, as does re-running every historical scenario on the current device and browser. Platform-capability observations on the real origin — `isSecureContext === true`, `navigator.serviceWorker` with a non-null controller, Cache Storage, `PushManager`, `Notification.permission === "granted"`, `navigator.setAppBadge`, `navigator.clearAppBadge`, and `PublicKeyCredential` — make [`TEST_PLAN.md`](TEST_PLAN.md) gate D.10's badge requirement achievable and the deferred WebAuthn control-gating path feasible on this device; neither is qualified. | None |
-| Desktop Chromium | Development/smoke client | Serve access as the current node's allowed identity, loopback-backend identity rejection, three real OMP cards, View/Control/interrupt, SSE, URL scrub, browser-store/cache checks, process removal, foreground/online reconnect, and live `/new` generation revocation (`409` for the stale generation) passed | Not a release target, and never a substitute for physical Android qualification: emulating a device's viewport and pixel ratio is not a result from that device. The denied-identity evidence in this document comes from a tagged droplet and the physical Pixel, not from desktop Chromium. | Smoke only | No other Linux init system, macOS deployment mode, Windows service mechanism, iOS browser,
-Firefox, Safari, or Chromium derivative has a compatibility claim. The v1 HTTP identity boundary assumes a user-controlled workstation. Any untrusted process or
+| Desktop Chromium | Development/smoke client | Serve access as the current node's allowed identity, loopback-backend identity rejection, three real OMP cards, View/Control/interrupt, SSE, URL scrub, browser-store/cache checks, process removal, foreground/online reconnect, and live `/new` generation revocation (`409` for the stale generation) passed | Not a release target, and never a substitute for physical Android qualification: emulating a device's viewport and pixel ratio is not a result from that device. The denied-identity evidence in this document comes from a tagged droplet and the physical Pixel, not from desktop Chromium. | Smoke only |
+
+No other Linux init system, macOS deployment mode, Windows service mechanism, iOS browser,
+Firefox, Safari, or Chromium derivative has a compatibility claim.
+
+The v1 HTTP identity boundary assumes a user-controlled workstation. Any untrusted process or
 different OS account that can connect to the desktop's loopback port can forge the non-cryptographic
 Serve identity headers and is therefore outside the support boundary. Shared shell hosts and
 mutually untrusted local accounts are unsupported even though IPC publication itself remains
-current-user/token protected. ## Deployment dependency matrix | Dependency or mode | Current state | Compatibility statement |
+current-user/token protected.
+
+## Deployment dependency matrix
+
+| Dependency or mode | Current state | Compatibility statement |
 |---|---|---|
 | Tailscale Serve over tailnet HTTPS | Required production architecture. All recorded evidence is macOS-hosted Serve: macOS 26.5.2 arm64 for the development-checkout lifecycle, macOS 26.6.1 arm64 for the rollback lane. The ledger records no Tailscale client version for any of this evidence; this workstation's client reported `1.102.2` on 2026-08-20, so no Tailscale version range is qualified. | The identity matrix is closed against signed candidate `v0.1.0-prealpha.16`. A **tagged** droplet carrying no user identity was refused `403` through Serve on both `/api/v1/sessions` and `/`, and a loopback request supplying no identity was refused `403`. From a distinct user-owned node, a real identity absent from the allowlist got `403`; a **forged** `Tailscale-User-Login` naming an allowlisted login got `403` while the caller's real identity was not allowlisted; the real allowlisted identity got `200`; and a forged header from an already-allowlisted caller was simply ignored, still `200`. That last pair is the proof that Serve owns the header rather than the caller, so remote identity-header spoofing cannot bypass the Serve path. Direct LAN and Tailscale-IP access failed and Funnel remained disabled. Direct loopback spoofing remains outside the explicitly single-user v1 trust boundary above, and the evidence must be repeated on each newly advertised host platform. |
 | User-owned Tailscale source identity | Designed identity-header mode | One exact user-owned login — the operator's own — was observed through Serve and allowlisted for qualification; no broader identity or device support is claimed. The login itself is deliberately not reproduced here: the only login written into this file is a placeholder in a reserved TLD, so nothing readable here is ever authenticable. A denial by a *different real person's* login has never been measured and cannot be produced by a single-account tailnet. |
-| Tagged Tailscale source device | Unsupported, and now measured | Serve populates user identity headers only for user-owned source devices, so a request proxied from a tagged source arrives with no user identity and the `tailscale-serve` auth mode must fail closed. Measured on droplet carrying `tag:omp-session-gateway`, confirmed by both `tailscale status` and `tailscale whois`, which reported no user profile and a tag list: `403` through Serve on `/api/v1/sessions` and on `/`. A tagged phone would need a separately designed app-capabilities or equivalent authentication mode; do not silently weaken authentication to accommodate one. |
+| Tagged Tailscale source device | Unsupported, and now measured | Serve populates user identity headers only for user-owned source devices, so a request proxied from a tagged source arrives with no user identity and the `tailscale-serve` auth mode must fail closed. Measured on droplet a node carrying `tag:omp-session-gateway`, confirmed by both `tailscale status` and `tailscale whois`, which reported no user profile and a tag list: `403` through Serve on `/api/v1/sessions` and on `/`. A tagged phone would need a separately designed app-capabilities or equivalent authentication mode; do not silently weaken authentication to accommodate one. |
 | Any other forwarder onto the gateway's loopback port | Unsupported; a complete authentication bypass | A tunnel, reverse proxy, port forward, container publish, or SSH `-L` that terminates remote traffic and relays it to `127.0.0.1:<port>` presents a loopback peer, satisfying the first authorization check, and then forwards whatever `Tailscale-User-Login` the remote caller chose. Tailscale Serve is safe here only because it overwrites caller-supplied identity headers; nothing else in this design does. See [`SECURITY.md`](SECURITY.md) §4 and [#74](https://github.com/alphastorm/omp-session-gateway/issues/74). |
 | Existing OMP encrypted relay | Required v1 relay path | Real desktop View/Control/interrupt passed. The signed `v0.1.0-prealpha.2` recovery soak remained live for 28,800 seconds through eight relay-room transitions with no restart, `finalPhase: "live"`, and gateway RSS moving from 45,776 KiB to 46,496 KiB (+720 KiB, approximately 1.6%). Physical Android qualification remains release-blocking; relay availability and traffic metadata are inherited dependencies. |
 | Self-hosted or proxied relay | Unsupported/deferred | Must pass the dedicated long-lived WebSocket soak and a separate security qualification before it can be documented as supported. |
 | `dev-localhost` HTTP mode | Development only | Never a remote, LAN, or production deployment path. |
-| Tailscale Funnel or public reverse tunnel | Unsupported | Must not be enabled or documented as a normal deployment path. | WebAuthn control gating, a Trusted Web Activity, native Android applications, and multi-host
+| Tailscale Funnel or public reverse tunnel | Unsupported | Must not be enabled or documented as a normal deployment path. |
+
+WebAuthn control gating, a Trusted Web Activity, native Android applications, and multi-host
 federation remain deferred. Background Web Push delivery is implemented with repository tests and
 a desktop Chromium closed-page smoke, and its core explicit-enable, closed-PWA notification, and
 tap-to-current-Control flow has one user-reported physical Android success on `v0.1.0-prealpha.7`.
 That report predates the current device baseline and every candidate in the table above. No
 compatibility promise exists until the exact-version physical lock-screen, stale-generation,
-force-stop, network-change, and forbidden-sink matrix passes with a named evidence artifact. ## Upstream refresh procedure For every proposed OMP update: 1. Inspect the new release/tag and collaboration-related source changes.
-2. Update `UPSTREAM.lock.json` with the exact tag, commit, package versions, Bun version, relevant paths, findings, and observation date.
+force-stop, network-change, and forbidden-sink matrix passes with a named evidence artifact.
+
+## Upstream refresh procedure
+
+For every proposed OMP update:
+
+1. Inspect the new release/tag and collaboration-related source changes.
+2. Update `UPSTREAM.lock.json` with the exact tag, commit, package versions, Bun version,
+   relevant paths, findings, and observation date.
 3. Rebase or regenerate the OMP patch series without unrelated changes.
 4. Rebuild the pinned collab-web integration and verify its provenance and license notices.
 5. Run controller, publisher, protocol, link parsing, View, and Control tests.
-6. Run start, stop, switch, branch, resume/tree-navigation, relay-replacement, fatal-failure, and shutdown lifecycle tests.
+6. Run start, stop, switch, branch, resume/tree-navigation, relay-replacement, fatal-failure,
+   and shutdown lifecycle tests.
 7. Run the complete capability-leak suite and real browser/Android acceptance.
 8. Qualify every advertised host installer and deployment path.
-9. Update this matrix, [`RELEASE_STATUS.md`](RELEASE_STATUS.md), and the changelog. Do not broaden the OMP range from one exact commit until CI and acceptance results prove
-each additional version independently. ## Protocol evolution - Reject unknown major protocol versions.
+9. Update this matrix, [`RELEASE_STATUS.md`](RELEASE_STATUS.md), and the changelog.
+
+Do not broaden the OMP range from one exact commit until CI and acceptance results prove
+each additional version independently.
+
+## Protocol evolution
+
+- Reject unknown major protocol versions.
 - Add optional fields within a major only when old peers safely ignore them.
 - Never reinterpret a field's security meaning in place.
 - Emit one browser API major at a time.
 - Record protocol versions in diagnostics without capability values.
-- Document upgrade order and rollback behavior before supporting mixed gateway/publisher versions. Every published release must identify the exact OMP and collab-web source, build command,
+- Document upgrade order and rollback behavior before supporting mixed gateway/publisher versions.
+
+Every published release must identify the exact OMP and collab-web source, build command,
 Bun version, dependency lockfile hash, local patches, license notices, and shipped asset hashes.

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -1,34 +1,56 @@
-# Release status **Updated:** 2026-08-20<br>
+# Release status
+
+**Updated:** 2026-08-20<br>
 **Repository version:** `0.1.0` (`v0.1.0-prealpha.14`; no alpha)<br>
 **Classification:** implemented pre-alpha<br>
 **Alpha decision:** **NO-GO**<br>
-**Advertised host/client platforms:** none The repository implements the intended v1 path and may publish deterministic Bun-runtime
+**Advertised host/client platforms:** none
+
+The repository implements the intended v1 path and may publish deterministic Bun-runtime
 pre-alpha archives for evaluation. It is not production-qualified, no alpha artifact is
 approved for publication, and no operating system, browser, or Android device is currently
 supported. Repository commits, pre-alpha archives, and provenance-test archives are engineering
-inputs for qualification only. **Pin refreshed to `v17.3.8` on 2026-08-19.** The OMP pin moved from `v17.0.6` /
+inputs for qualification only.
+
+**Pin refreshed to `v17.3.8` on 2026-08-19.** The OMP pin moved from `v17.0.6` /
 `89d6a8f6d14286f32f09ec9c8aa8af7b3451d2d6` to `v17.3.8` /
 `858f7dd91fff9b84cf8a2c6a6bb85aa0e6d03a55`. Every row below whose evidence predates that date was
 recorded against the previous pin. Source-level rows were re-run and are marked; native host,
 Tailscale, relay, Android, signed-artifact, and browser rows were **not** re-run and are **NOT RUN**
 for this pin regardless of the status they carry for the old one. Nothing here promotes `v17.3.8`
-to a qualified platform claim. **Physical Android baseline changed on 2026-08-20.** The Pixel 10 Pro is now on Android 17
+to a qualified platform claim.
+
+**Physical Android baseline changed on 2026-08-20.** The Pixel 10 Pro is now on Android 17
 build `CP2A.260805.005` (SDK 37) with Chrome `151.0.7922.139`. Every Android evidence row below
 predates this current device/browser combination and must be re-run before any result can be
 claimed for it. The older build and browser strings retained in those rows identify the trials
-actually run; they are historical evidence, not current-device values. This ledger is the source of truth for the current release decision. Compatibility claims live
+actually run; they are historical evidence, not current-device values.
+
+This ledger is the source of truth for the current release decision. Compatibility claims live
 in [`COMPATIBILITY.md`](COMPATIBILITY.md); required scenarios are defined in
 [`TEST_PLAN.md`](TEST_PLAN.md); the detailed implementation evidence is recorded in
-[`../HANDOFF_MANIFEST.md`](../HANDOFF_MANIFEST.md). ## Status rules | Status | Meaning |
+[`../HANDOFF_MANIFEST.md`](../HANDOFF_MANIFEST.md).
+
+## Status rules
+
+| Status | Meaning |
 |---|---|
 | **PASS** | The named scope has current, reproducible evidence. It says nothing about a broader scope. |
 | **PARTIAL** | Some automated or smoke evidence exists, but the complete release scenario has not passed. |
 | **NOT RUN** | No completed result is recorded for the required environment or scenario. |
 | **BLOCKED** | A known prerequisite prevents completion or publication. |
-| **N/A** | Deliberately excluded from this release and not advertised. | An alpha requires every applicable release-blocking row below to be **PASS**. Automated tests,
+| **N/A** | Deliberately excluded from this release and not advertised. |
+
+An alpha requires every applicable release-blocking row below to be **PASS**. Automated tests,
 mocks, a desktop mobile viewport, or generated service definitions do not substitute for native
-OS, real Tailscale, real relay, or Android qualification. ## Recorded implementation evidence These checks establish the implemented pre-alpha baseline; they do not resolve the acceptance
-gaps in the next section. | Scope | Status | Recorded evidence |
+OS, real Tailscale, real relay, or Android qualification.
+
+## Recorded implementation evidence
+
+These checks establish the implemented pre-alpha baseline; they do not resolve the acceptance
+gaps in the next section.
+
+| Scope | Status | Recorded evidence |
 |---|---|---|
 | Exact upstream pin | **PASS** | `UPSTREAM.lock.json` pins `can1357/oh-my-pi@858f7dd91fff9b84cf8a2c6a6bb85aa0e6d03a55`, tag `v17.3.8`, with package and Bun versions. The regenerated five-commit mbox applies cleanly to the pristine pin and reproduces tree `1320e3e7e7596dbe2f6a130d568072a9a38f2943`. Its first four commits are the reviewed handoff artifact `gateway-collaboration-v17.3.8.mbox` (sha256 `f63f74c90d72776ca1ebcb4b1a75b18130b3c65d1c6e0133c9bbb3a8e5b4af49`) applied verbatim with plain `git am`; the fifth restores the health-probe commit that the maintained series no longer carries. Recorded 2026-08-19. |
 | Repository check | **PASS** | Re-run at the `v17.3.8` pin on 2026-08-19, at doctor pin-contract commit `bb0a852b0c4c72181718033f261e0ff2901a08c8`. `bun run check` passed handoff validation, four workspace typechecks, production web/client builds, 133 tests with 767 assertions across 22 files, and capability-leak scanning. Twenty Android-sized Playwright cases passed at both `412 × 915` and `390 × 844`: installed-PWA View/Control handoff, the embedded active-ask 3d shell, direct client navigation returning to the directory, answer-feedback dismissal by keyboard/tap-out/swipe/timeout, transport-interruption reconnect, stale-session failure states, metadata-only attention and background-alert settings, and automatic plus collaboration-preserving PWA activation. |
@@ -56,9 +78,15 @@ gaps in the next section. | Scope | Status | Recorded evidence |
 | Signed candidate packaging/runtime smoke | **PASS** | The downloaded and independently verified `provenance-test-v0.1.0.10` archive installed with `--no-start` into an isolated macOS root, launched the installed runtime through the existing real Tailscale Serve mapping, and mutually authenticated three reconnect-capable patched OMP publisher fixtures. A real gateway restart restored all three cards in approximately 227 ms; a patched interactive OMP process auto-published a fourth card and revoked it immediately on shutdown. The controlled suspension experiment used this installed gateway and restored each expired session within eight seconds in all three resume orders. This is packaging/runtime and finite-suspension evidence, not complete LaunchAgent, distinct-device identity, actual sleep/wake, real collaboration, or Android qualification. |
 | Repository security controls | **PASS** | Private vulnerability reporting, dependency alerts and automated security updates, secret scanning and push protection, and immutable releases are enabled. `main` requires signed commits, pull requests, current implementation/Windows checks, resolved conversations, and blocks force-pushes and deletion. |
 | Production registry-socket rebind | **PASS** | On 2026-08-19 the installed macOS daemon (PID 9994, started 2026-08-16 23:13) was observed listening on a `registry.sock` whose inode was created 2026-08-17 09:31 — about ten hours after process start — so the watchdog re-bound the rendezvous point after macOS reaped the per-user `TMPDIR` entry, with no operator action and no daemon restart. `doctor` returned all sixteen checks true and four `omp-code-mode` publishers were connected to the re-bound socket. This is unsolicited production evidence for the fix merged in PR #47; it does not advance the macOS host lifecycle gate below. |
-| Live `doctor` at the refreshed pin | **PASS** | On 2026-08-19, after the `v17.3.8` refresh, `doctor` run from the updated checkout against the installed macOS daemon returned all sixteen checks true, including `compatibility`, `serveMapping`, `identityAllowed`, `funnelDisabled`, `listenerLoopbackOnly`, and `publisherHealth`. The first attempt returned `compatibility: false` because `doctor` hardcodes the expected upstream identity and the refresh had left it naming `v17.0.6`; that is fixed and now bound to `UPSTREAM.lock.json` by a pin-contract test. Four `omp-code-mode` publishers from the previous `17.3.5` release were connected throughout, so this is not evidence that a `17.3.8` OMP process publishes. | The evidence date and caveats above come from the implementation handoff and the current
+| Live `doctor` at the refreshed pin | **PASS** | On 2026-08-19, after the `v17.3.8` refresh, `doctor` run from the updated checkout against the installed macOS daemon returned all sixteen checks true, including `compatibility`, `serveMapping`, `identityAllowed`, `funnelDisabled`, `listenerLoopbackOnly`, and `publisherHealth`. The first attempt returned `compatibility: false` because `doctor` hardcodes the expected upstream identity and the refresh had left it naming `v17.0.6`; that is fixed and now bound to `UPSTREAM.lock.json` by a pin-contract test. Four `omp-code-mode` publishers from the previous `17.3.5` release were connected throughout, so this is not evidence that a `17.3.8` OMP process publishes. |
+
+The evidence date and caveats above come from the implementation handoff and the current
 provenance-test artifact. Every later candidate must rerun the applicable clean-checkout CI and
-native qualification and attach those records to its tag. ## Alpha gate ledger | Release gate | Status | Evidence or missing proof | Required to close |
+native qualification and attach those records to its tag.
+
+## Alpha gate ledger
+
+| Release gate | Status | Evidence or missing proof | Required to close |
 |---|---|---|---|
 | Exact OMP and collab-web provenance | **PASS** | Immutable source commit, package versions, relevant paths, local integration, and patch are recorded in `UPSTREAM.lock.json` and `packages/collab-client/upstream/UPSTREAM.json`. | Revalidate unchanged data at the candidate tag. |
 | Repository automated suite | **PASS** | Re-run at the `v17.3.8` pin on 2026-08-19: 133 tests with 767 assertions across 22 files and twenty Android-sized Playwright cases at both target viewports, plus a new pin-contract test binding `doctor`'s expected upstream identity to `UPSTREAM.lock.json`. The previous exact-3d candidate passed the complete clean-checkout release suite: handoff validation, all workspace typechecks, production assets, 118 unit/integration/release tests with 673 assertions across 21 files, and capability-leak scanning. Eighteen Android-sized Playwright cases also passed across both target viewports. Deterministic coverage exercises FIFO triage/all-clear home, embedded Ask selection and submission, single transcript/composer chrome, relay reconnect and clean-ended shell states, non-overlapping composer/triage geometry, request-bound Control, in-memory Back restoration, silent SSE recovery, and automatic PWA activation without persisting a capability. | Repeat the complete suite from clean CI for every subsequent candidate. |
@@ -66,7 +94,7 @@ native qualification and attach those records to its tag. ## Alpha gate ledger |
 | Fifty-publisher capacity | **PASS** | The signed `v0.1.0-prealpha.5` daemon held 50 authenticated publishers and sessions for a 642-second measured window at the normal 10-second heartbeat cadence. It consumed 0.80 CPU seconds over that interval (0.125% of one core average), stayed below 63,760 KiB observed RSS, retained 50 fresh records, logged no warnings/errors, and removed all 50 on clean publisher shutdown. The capacity files contained no synthetic capability marker. | Repeat on every later candidate and investigate any material regression from this baseline. |
 | Capability non-persistence | **PARTIAL** | Automated scans and desktop Chromium storage/history/cache checks passed. On 2026-08-20 a physical Pixel 10 Pro (the paired device, Android 17 `CP2A.260805.005`, Chrome `151.0.7922.139`) swept a real view capability minted by the live tailnet gateway at the `v17.3.8` pin via `scripts/android-leak-sweep.ts`. The launch returned `200` with `cache-control: no-store, max-age=0` and body keys `capability,generation,mode`, carrying the secret in JSON to same-origin JavaScript rather than any URL component; the 66-character capability (`sha256:d107fb0d826278b5`) and its long opaque segment were absent from Local Storage, Session Storage, cookies, Cache Storage keys and bodies (only `omp-sessions-shell-c304cf72b454` present), IndexedDB (no databases), `location`/fragment (0-character hash, so no fragment fallback was used), `history.state`, referrer, resource-timing entries, and serialized DOM. The same run first proved its own detector by planting a synthetic secret in all seven sinks and requiring all seven to be found, then removing them with no residue. Re-run on 2026-08-20 against the signed candidate serving the live tailnet origin: the sweep was clean across all seven sinks with the detector again proving itself (7 planted, 7 detected, no residue), launch `200` `no-store`, capability `sha256:39478ea244d0c1ef`, zero-character fragment.| Sweep the collaboration client page itself after it connects, cover `control` mode, and scan release CI artifacts, recordings, and diagnostics with canary capabilities from a signed candidate artifact rather than a development install. |
 | Loopback-only exposure | **PARTIAL** | macOS listener inspection and direct LAN/Tailscale-IP connection attempts proved the development checkout loopback-only. | Repeat with every signed candidate artifact and qualified host OS. |
-| Tailscale Serve identity and application allowlist | **PASS** | Real macOS Serve accepted requests as this node's exact allowlisted identity; the loopback backend rejected wrong and missing identities and accepted the allowed identity. Serve overwrites caller-supplied identity headers, so same-node requests cannot prove denied-device behavior. Direct LAN and Tailscale-IP access failed and Funnel was disabled. On 2026-08-20 a **distinct** tailnet device — the physical Pixel 10 Pro, not the host — reached the same origin over tailnet HTTPS and received `200` for `GET /api/v1/sessions` and for a `POST …/launch`, with identity headers supplied by Serve rather than by the caller. That closes the allowed-device half from a genuinely separate node; the same-node limitation had previously left it unproven. On 2026-08-20 the denial half was measured directly with an A/B against two allowlists. A second gateway was run on loopback `4320` in `tailscale-serve` auth mode with `allowedLogins` set to `denied-identity@qual.invalid`, exposed on a **third** Serve port `:9443` so the production `/` mapping was never touched. From the same tailnet device carrying the same real Serve-injected identity, `:443` returned `200` and `:9443` returned `403` with body `{"code":"forbidden","message":"Forbidden"}` and no session data. The temporary Serve port was removed and the isolated root deleted; `:443` still answers `200`, loopback still `403`, and `:9443` is unreachable. The same A/B was then repeated from the **physical Pixel** (the paired device), a distinct tailnet node rather than the host: `:443` returned `200` carrying session data and `:9443` returned `403` with `{"code":"forbidden"}` and no `instanceId` or `cwdLabel` anywhere in the body. Both halves were closed on 2026-08-20 against signed candidate `v0.1.0-prealpha.16` using a **tagged** DigitalOcean droplet, carrying `tag:omp-session-gateway`, confirmed by both `tailscale status` and `tailscale whois`. A tagged node has no user identity, which is the denial case a same-account device cannot produce. From that node through Serve, `/api/v1/sessions` and `/` both returned `403`, and a loopback request supplying no identity returned `403`. From this workstation, a distinct user-owned node, the full matrix was measured: a real identity absent from the allowlist got `403`; a **forged** `Tailscale-User-Login` naming an allowlisted login while the caller's real identity was not allowlisted also got `403`; the real allowlisted identity got `200`; and a forged header sent by an already-allowlisted caller was simply ignored, still `200`. That last pair is the proof that Serve owns the header rather than the caller, so remote identity-header spoofing cannot bypass the Serve path.| Repeat on each newly advertised host platform; the evidence is macOS-hosted Serve. |
+| Tailscale Serve identity and application allowlist | **PASS** | Real macOS Serve accepted requests as this node's exact allowlisted identity; the loopback backend rejected wrong and missing identities and accepted the allowed identity. Serve overwrites caller-supplied identity headers, so same-node requests cannot prove denied-device behavior. Direct LAN and Tailscale-IP access failed and Funnel was disabled. On 2026-08-20 a **distinct** tailnet device — the physical Pixel 10 Pro, not the host — reached the same origin over tailnet HTTPS and received `200` for `GET /api/v1/sessions` and for a `POST …/launch`, with identity headers supplied by Serve rather than by the caller. That closes the allowed-device half from a genuinely separate node; the same-node limitation had previously left it unproven. On 2026-08-20 the denial half was measured directly with an A/B against two allowlists. A second gateway was run on loopback `4320` in `tailscale-serve` auth mode with `allowedLogins` set to `denied-identity@qual.invalid`, exposed on a **third** Serve port `:9443` so the production `/` mapping was never touched. From the same tailnet device carrying the same real Serve-injected identity, `:443` returned `200` and `:9443` returned `403` with body `{"code":"forbidden","message":"Forbidden"}` and no session data. The temporary Serve port was removed and the isolated root deleted; `:443` still answers `200`, loopback still `403`, and `:9443` is unreachable. The same A/B was then repeated from the **physical Pixel** (the paired device), a distinct tailnet node rather than the host: `:443` returned `200` carrying session data and `:9443` returned `403` with `{"code":"forbidden"}` and no `instanceId` or `cwdLabel` anywhere in the body. Both halves were closed on 2026-08-20 against signed candidate `v0.1.0-prealpha.16` using a **tagged** DigitalOcean droplet, a node carrying `tag:omp-session-gateway`, confirmed by both `tailscale status` and `tailscale whois`. A tagged node has no user identity, which is the denial case a same-account device cannot produce. From that node through Serve, `/api/v1/sessions` and `/` both returned `403`, and a loopback request supplying no identity returned `403`. From this workstation, a distinct user-owned node, the full matrix was measured: a real identity absent from the allowlist got `403`; a **forged** `Tailscale-User-Login` naming an allowlisted login while the caller's real identity was not allowlisted also got `403`; the real allowlisted identity got `200`; and a forged header sent by an already-allowlisted caller was simply ignored, still `200`. That last pair is the proof that Serve owns the header rather than the caller, so remote identity-header spoofing cannot bypass the Serve path.| Repeat on each newly advertised host platform; the evidence is macOS-hosted Serve. |
 | Linux host lifecycle | **PARTIAL** | Debian 13 arm64 container runs with a real systemd user manager passed both development-checkout and unsigned extracted-archive install, readiness, permissions, loopback isolation, active reinstall/PID replacement, token rotation/restart, redacted diagnostics generation, active `--no-stop` refusal, uninstall, and process/listener cleanup. The full sequence was re-run at the `v17.3.8` pin on 2026-08-20 against a real systemd user manager from the extracted archive; see the evidence row above for the measured PIDs, permissions, and redaction results. On 2026-08-20 the lane moved off containers onto a real machine: a DigitalOcean droplet running Debian 13 (trixie), kernel `6.12.94+deb13-amd64`, systemd 257, virtualisation `kvm`, provisioned by `scripts/provision-linux-qual.sh` and qualified against the signed candidate `v0.1.0-prealpha.14`. Install from the verified artifact reported `{installed:true, active:true, ready:true, authMode:tailscale-serve}` with the listener bound to `127.0.0.1:4317` only and `doctor` at 12/16; the four false checks were `identityAllowed`, `pwa`, `securityHeaders`, and `publisherHealth`, all expected with no Serve mapping and no publishers. Publisher-token rotation succeeded with the service still `active` and `ready`. **Reboot persistence failed** ([#69](https://github.com/alphastorm/omp-session-gateway/issues/69)): with lingering enabled, `loginctl Linger=yes`, and the boot id confirmed changed, `user@1000.service` came back `active` while the gateway daemon did not, leaving no pid and no listeners. The droplet was destroyed after the run (0.19 h, about $0). **Reboot persistence now passes.** The cause was the unit naming the runtime directory in `ReadWritePaths=`, which systemd refuses to start when the path does not exist; the runtime directory only exists once the daemon has bound its socket. Fixed by `RuntimeDirectory=` with `RuntimeDirectoryMode=0700` and re-proved on a fresh droplet with signed candidate `v0.1.0-prealpha.15`: after a clean reboot with **no interactive login**, `loginctl` showed the uid-1000 session as class `manager` (the lingering-created user manager), the gateway ran as pid 766 with the listener bound to `127.0.0.1:4317`, and the process was 57s old against 69s of system uptime, so it started about 12s after boot rather than on connection. The same procedure on `v0.1.0-prealpha.14` left no pid and no listener. Install on `.15` also reported `installed/active/ready`, `doctor` 12/16 with the same four expected false checks, socket mode 600 under the systemd-owned runtime directory, token rotation across pids 2208 to 2305, and a diagnostics bundle containing zero token bytes and zero home-path hits. On signed candidate `v0.1.0-prealpha.16` the previously open `--no-stop` question was settled: with the service genuinely active (`installed/active/ready`, listener on `127.0.0.1:4317`, token rotation clean), `uninstall --no-stop` **refused, as required**, and a real uninstall then left no unit file, no gateway pid, and no listener. The earlier contrary observation was a false premise created by [#69](https://github.com/alphastorm/omp-session-gateway/issues/69) itself: the daemon had never started, so there was nothing for `--no-stop` to refuse.| Run the identity lane from a tagged node, and complete explicit upgrade and rollback on Linux; rollback is currently proven on macOS only. Note `kvm` is a virtual machine, so this is not literally bare metal. |
 | macOS host lifecycle | **PARTIAL** | macOS 26.5.2 arm64 passed live LaunchAgent install, private permissions, restart/reinstall, token rotation, diagnostics/bundle, Serve checks, and uninstall from a development checkout. The independently verified `provenance-test-v0.1.0.10` archive passed an isolated `--no-start` install/runtime smoke, real Serve routing, gateway-restart recovery, one patched interactive OMP publication/removal, and three controlled publisher/gateway suspension orders beyond TTL. On 2026-08-20 the signed candidate `v0.1.0-prealpha.14` was published, independently verified from a clean directory (`shasum -c` OK, `gh attestation verify` exit 0, and `cosign verify-blob` "Verified OK" for the archive, SBOM, and `SHA256SUMS` against certificate identity `https://github.com/alphastorm/omp-session-gateway/.github/workflows/release.yml@refs/tags/v0.1.0-prealpha.14`), and installed over the live macOS service. The in-place upgrade replaced version `0.1.0-61114587f124` with the candidate build `0.1.0-8773d783ca96`, moved the daemon from PID 41501 to 51469, kept `doctor` at 16/16, and left the tailnet origin answering `200` with loopback still `403`. All three live publishers reconnected within 40 seconds and the in-memory registry correctly restarted empty at revision 0 before repopulating. Configuration and the publisher token survived the upgrade unchanged (token digest `f361650a4974`, mode 600). A second in-place upgrade followed on 2026-08-20, from candidate build `0.1.0-8773d783ca96` to `0.1.0-2813d6b23306` (`v0.1.0-prealpha.16`, independently verified by `shasum -c`, `gh attestation verify`, and `cosign verify-blob`), moving the daemon from PID 51469 to 12327 with **`doctor` at 16/16** and the tailnet origin still answering `200`.| Complete the corrected signed candidate's LaunchAgent lifecycle, actual sleep/wake and relay/browser recovery, reboot/login persistence, explicit upgrade/rollback, distinct-device identity isolation, real OMP collaboration, and capability-leak acceptance. |
 | Windows host lifecycle | **PARTIAL** | Hosted run `29791906104` passed the exact candidate OMP publisher's current-user pipe derivation, strict token ACL inspection, eleven mutual-authentication/fake-server/restart/token-reread/explicit-path fixtures, and coding-agent typecheck together with the complete gateway lifecycle and cross-user denial workflow. | Repeat with a signed candidate artifact and qualify reboot/login persistence, diagnostics, upgrade, and rollback. |
@@ -82,20 +110,45 @@ native qualification and attach those records to its tag. ## Alpha gate ledger |
 | Private vulnerability reporting | **PASS** | GitHub private vulnerability reporting is enabled and repository security guidance identifies the private path. | Reverify before publication. |
 | Release signing, SBOM, and provenance | **PASS** | Corrected `provenance-test-v0.1.0.10` verified the protected tag workflow and sleep-recovery payload: archive `b446d405d97c2bec181b9d0f4be03c83ede7407d24d603a9d117be428b95576e`, SPDX inventory `4cb0b1b2c81fdcaf56044cd38259a9ad979bff88efd75ca9a7a2fe3f30d6e8f1`, and checksum manifest `08d28faa291f7b374dc8d6d88656c5e7e84cda93f65707acdc6a530415b39326`. The archive records exact source commit `1c33c90252643d7d0f572fe57a0e560f00b72afb` and its `bun.lock` digest, includes reviewed licenses and the distributed OMP patch, and its SBOM identifies that patch component. All six immutable release assets, three GitHub attestations, and three Cosign bundles verified; a clean exact-tag rebuild was byte-identical for all three payload files. | Repeat for every subsequent candidate; this PASS does not qualify a host or Android client. |
 | Known limitations and exact compatibility matrix | **PASS** | This ledger and `COMPATIBILITY.md` state the pre-alpha boundary, exact OMP pin, unqualified platforms, and unsupported modes. | Keep both synchronized with every candidate. |
-| Self-hosted/proxied relay | **N/A** | Explicitly unsupported and deferred. | Do not advertise; a future release needs the dedicated WebSocket soak and a separate security qualification. | > **Candidate artifacts `v0.1.0-prealpha.14`, `.15`, and `.16` have been deleted.** The build
-> identifiers and tag names cited in the evidence below therefore no longer resolve to a
-> downloadable artifact. Nothing depends on their presence: `main` carries all of the code and
-> evidence they were cut from, there were no consumers beyond this workstation and disposable
-> machines that have since been destroyed, and a measurement does not stop being true because
-> the artifact that produced it is gone. This is a traceability gap, not a correctness one. The
-> next candidate will be cut when an artifact is actually needed.
+| Self-hosted/proxied relay | **N/A** | Explicitly unsupported and deferred. | Do not advertise; a future release needs the dedicated WebSocket soak and a separate security qualification. |
 
-## Current release blockers The alpha decision remains **NO-GO** until, at minimum: 1. at least one proposed host platform passes its complete native lifecycle and security matrix from the signed candidate artifact, including reboot/login persistence, upgrade, rollback, diagnostics, token rotation, and uninstall;
-2. ~~real Tailscale Serve authorization and LAN/public isolation pass from distinct allowed and denied devices against that candidate host~~ — **closed 2026-08-20**. A tagged droplet (`tag:omp-session-gateway`) carries no user identity and was refused `403` through Serve on both `/api/v1/sessions` and `/`; this workstation, a distinct user-owned node, got `403` for a non-allowlisted real identity, `403` for a forged `Tailscale-User-Login` naming an allowlisted login, and `200` for the real allowlisted identity, with a forged header from an already-allowlisted caller simply ignored. Direct LAN and Tailscale-IP access already failed and Funnel is disabled. Measured against candidate `v0.1.0-prealpha.16`;
-3. a physical Android device passes install, automatic discovery, View, Control, interrupt, generation replacement, lock/resume, network-change, back-navigation, reconnect, and leak checks;
-4. the candidate OMP path passes branch, saved-session resume, and applicable default-relay connectivity scenarios without exposing a stale capability. Switch ordering, socket-close crash removal, and TTL-sweeper expiry were measured at the `v17.3.8` pin on 2026-08-19 and are recorded above; branch and resume still need a session carrying real conversation history;
-5. the native, Tailscale, relay, Android, browser, and signed-artifact rows are re-run at the current `v17.3.8` pin. The pin was refreshed on 2026-08-19 and only source-level evidence was regenerated with it, so every platform row still carries evidence gathered against `v17.0.6` / `89d6a8f6d14286f32f09ec9c8aa8af7b3451d2d6`; and
-6. every advertised host/client combination completes its candidate-artifact capability-leak acceptance across all forbidden sinks. Blocker 7, the silent publisher latch
+> **Candidate artifacts `v0.1.0-prealpha.14`, `.15`, and `.16` have been deleted.** The build
+> identifiers and tag names cited below therefore no longer resolve to a downloadable artifact.
+> Nothing depends on their presence: `main` carries all of the code and evidence they were cut
+> from, there were no consumers beyond machines that have since been destroyed, and a
+> measurement does not stop being true because the artifact that produced it is gone. This is a
+> traceability gap, not a correctness one. The next candidate will be cut when an artifact is
+> actually needed.
+
+## Current release blockers
+
+The alpha decision remains **NO-GO** until, at minimum:
+
+1. at least one proposed host platform passes its complete native lifecycle and security matrix
+   from the signed candidate artifact, including reboot/login persistence, upgrade, rollback,
+   diagnostics, token rotation, and uninstall;
+2. ~~real Tailscale Serve authorization and LAN/public isolation pass from distinct allowed and
+   denied devices against that candidate host~~ — **closed 2026-08-20**. A tagged droplet
+   (`tag:omp-session-gateway`) carries no user identity and was refused `403`
+   through Serve on both `/api/v1/sessions` and `/`; this workstation, a distinct user-owned node,
+   got `403` for a non-allowlisted real identity, `403` for a forged `Tailscale-User-Login` naming an
+   allowlisted login, and `200` for the real allowlisted identity, with a forged header from an
+   already-allowlisted caller simply ignored. Direct LAN and Tailscale-IP access already failed and
+   Funnel is disabled. Measured against candidate `v0.1.0-prealpha.16`;
+3. a physical Android device passes install, automatic discovery, View, Control, interrupt,
+   generation replacement, lock/resume, network-change, back-navigation, reconnect, and leak checks;
+4. the candidate OMP path passes branch, saved-session resume, and applicable default-relay
+   connectivity scenarios without exposing a stale capability. Switch ordering, socket-close crash
+   removal, and TTL-sweeper expiry were measured at the `v17.3.8` pin on 2026-08-19 and are recorded
+   above; branch and resume still need a session carrying real conversation history;
+5. the native, Tailscale, relay, Android, browser, and signed-artifact rows are re-run at the
+   current `v17.3.8` pin. The pin was refreshed on 2026-08-19 and only source-level evidence was
+   regenerated with it, so every platform row still carries evidence gathered against
+   `v17.0.6` / `89d6a8f6d14286f32f09ec9c8aa8af7b3451d2d6`; and
+6. every advertised host/client combination completes its candidate-artifact capability-leak
+   acceptance across all forbidden sinks.
+
+Blocker 7, the silent publisher latch
 ([#61](https://github.com/alphastorm/omp-session-gateway/issues/61)), is **closed**. The fix is
 mirrored here as the sixth handoff commit (`bfc555227`) and was clean-room verified on 2026-08-20:
 all six commits `git am` onto pristine `858f7dd9` from a fresh shallow clone,
@@ -108,14 +161,31 @@ isolated gateway to force a token reread; the card vanished (revision 0, listene
 returned about 20 seconds after the mode was restored (revision 1, same instance `aac1c980`, two
 socket descriptors). Production was untouched throughout: daemon `51469` stayed alive on the
 candidate, its publisher token digest `f361650a4974` is unchanged since Jul 19, and the tailnet
-origin kept answering `200`. Passing one platform permits advertising only that exact qualified platform/version combination.
-It does not promote untested rows or broaden the pinned OMP range. ## Known limitations - The gateway requires the exact pinned OMP source plus the repository patch; there is no upstream release/API compatibility promise yet.
-- A daemon restart intentionally starts with an empty in-memory registry until live publishers reconnect.
-- Browser reload intentionally returns to the session directory because collaboration capabilities are not persisted.
+origin kept answering `200`.
+
+Passing one platform permits advertising only that exact qualified platform/version combination.
+It does not promote untested rows or broaden the pinned OMP range.
+
+## Known limitations
+
+- The gateway requires the exact pinned OMP source plus the repository patch; there is no
+  upstream release/API compatibility promise yet.
+- A daemon restart intentionally starts with an empty in-memory registry until live publishers
+  reconnect.
+- Browser reload intentionally returns to the session directory because collaboration
+  capabilities are not persisted.
 - The existing OMP relay remains an availability and traffic-metadata dependency.
-- Same-desktop-user malware, a compromised browser/OS, and an unlocked authorized phone are outside or inherited trust boundaries described in `SECURITY.md`.
-- Tagged Tailscale source devices, Tailscale Funnel, public/LAN HTTP, self-hosted relays, WebAuthn gating, TWA/native clients, and multi-host federation are not supported by this release line. Background Web Push is implemented but remains unqualified until the physical Android closed-PWA, lock-screen, tap-to-Control, stale-generation, force-stop, and network matrix passes.
-- No production upgrade or rollback path has completed cross-platform qualification. ## Updating this ledger Change a row only with a reproducible command result or a named manual qualification record that
+- Same-desktop-user malware, a compromised browser/OS, and an unlocked authorized phone are
+  outside or inherited trust boundaries described in `SECURITY.md`.
+- Tagged Tailscale source devices, Tailscale Funnel, public/LAN HTTP, self-hosted relays,
+  WebAuthn gating, TWA/native clients, and multi-host federation are not supported by this release
+  line. Background Web Push is implemented but remains unqualified until the physical Android
+  closed-PWA, lock-screen, tap-to-Control, stale-generation, force-stop, and network matrix passes.
+- No production upgrade or rollback path has completed cross-platform qualification.
+
+## Updating this ledger
+
+Change a row only with a reproducible command result or a named manual qualification record that
 identifies the source commit, artifact checksum, OS/browser/device versions, deployment path, and
 date. Record failures as failures; do not turn a narrower automated pass into a broader platform
 claim. Update this file, `COMPATIBILITY.md`, `CHANGELOG.md`, and release notes together whenever a


### PR DESCRIPTION
The previous commit collapsed both ledger documents. A whitespace-normalising regex matched newlines, so it merged paragraphs across whole files: `COMPATIBILITY.md` fell from 176 lines to 98 with a **single surviving heading**, and `RELEASE_STATUS.md` lost all but two of its section headings.

## Why it reached main

Table rows survived intact, so the delimiter-count check I had been using to validate these files passed. I was verifying the wrong invariant — table shape says nothing about whether the surrounding document still exists.

The check now counts **headings** as well as table shape: 9 in `COMPATIBILITY.md`, 7 in `RELEASE_STATUS.md`, matching the originals.

## The fix

Both files restored from the commit before the damage, then reapplied surgically:

- the node identifier is removed **line by line**, only on lines containing it, rather than by whole-file substitution
- the candidate-availability note is inserted as **discrete lines** at the blockers section rather than by string replacement

Diff against the pre-damage state is 2 lines in `COMPATIBILITY.md` and 12 in `RELEASE_STATUS.md` — the node-id scrub and the note, nothing else.

## Verification

`bun run check` green from a clean tree. Heading counts and table shape both verified programmatically.