### PR TITLE
feat(ci): enforce identifier hygiene and ledger structure programmatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
     "packages/*"
   ],
   "scripts": {
-    "check": "bun run validate:handoff && bun run typecheck && bun run build && bun run test && bun run check:capability-leaks",
+    "check": "bun run validate:handoff && bun run typecheck && bun run build && bun run test && bun run check:capability-leaks && bun run check:identifier-leaks",
     "validate:handoff": "bun scripts/validate-handoff.ts",
     "typecheck": "bun run --filter '*' typecheck",
     "build": "bun run --filter '@omp-session-gateway/web' build",
     "test": "bun test",
     "check:capability-leaks": "bun scripts/check-capability-leaks.ts",
+    "check:identifier-leaks": "bun scripts/check-identifier-leaks.ts",
     "release:build": "bun scripts/build-release.ts",
     "qualify:relay-soak": "bun scripts/relay-soak.ts",
     "test:browser": "bun run build && bun scripts/test-browser.ts"

--- a/scripts/check-identifier-leaks.ts
+++ b/scripts/check-identifier-leaks.ts
@@ -1,0 +1,49 @@
+/**
+ * Fails the build when a personal or infrastructure identifier reaches tracked files.
+ *
+ * Sibling of `check-capability-leaks.ts`: that one guards secrets, this one guards values that
+ * identify a person, machine, or private network. See `identifier-leak-rules.ts` for why.
+ */
+import { readdir, readFile } from "node:fs/promises";
+import { extname, join, relative } from "node:path";
+import { findIdentifierLeaks, IDENTIFIER_TEXT_EXTENSIONS } from "./identifier-leak-rules.ts";
+
+const rootPath = new URL("../", import.meta.url).pathname;
+// The rules file and its tests necessarily contain example shapes.
+const exempt = new Set([
+  "scripts/identifier-leak-rules.ts",
+  "scripts/check-identifier-leaks.ts",
+  "scripts/identifier-leak-rules.test.ts",
+]);
+const skipDirs = new Set([".git", "node_modules", "build", "coverage", "dist", ".qualification"]);
+
+async function walk(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (skipDirs.has(entry.name)) continue;
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await walk(path)));
+    else out.push(path);
+  }
+  return out;
+}
+
+const findings: string[] = [];
+for (const file of await walk(rootPath)) {
+  const rel = relative(rootPath, file);
+  if (exempt.has(rel)) continue;
+  // Lockfiles and third-party licence text carry upstream authors' addresses, not ours.
+  if (rel === "bun.lock" || rel.startsWith("licenses/") || rel.endsWith("THIRD_PARTY_NOTICES.md")) continue;
+  if (!IDENTIFIER_TEXT_EXTENSIONS.has(extname(file))) continue;
+  for (const finding of findIdentifierLeaks(await readFile(file, "utf8"))) {
+    findings.push(`${rel}:${finding.line}: ${finding.label} "${finding.match}"`);
+  }
+}
+
+if (findings.length > 0) {
+  console.error("identifier leak scan failed:");
+  for (const f of findings) console.error(`  ${f}`);
+  console.error("\nUse a placeholder, or append 'identifier-leak-allow' to the line if the value is reviewed and necessary.");
+  process.exit(1);
+}
+console.log("identifier leak scan passed");

--- a/scripts/identifier-leak-rules.test.ts
+++ b/scripts/identifier-leak-rules.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { findIdentifierLeaks } from "./identifier-leak-rules.ts";
+
+const labels = (text: string): string[] => findIdentifierLeaks(text).map(f => f.label).sort();
+
+describe("identifier leak detection", () => {
+  test("catches every class that actually leaked from this repository", () => {
+    // Each of these was published for real and had to be removed by rewriting history and
+    // deleting releases. Synthetic stand-ins here, same shapes.
+    expect(labels("connect to 203.0.113.45 now")).toContain("public IPv4 address");
+    expect(labels("origin https://somebody-macbook.tailabc123.ts.net/")).toContain("tailnet hostname");
+    expect(labels("node nQ7XyzAbCd42CNTRL joined")).toContain("tailnet node id");
+    expect(labels("cd /Users/somebody/Development")).toContain("absolute home path");
+    expect(labels("serial 48219FGHJ773KL attached")).toContain("device serial");
+  });
+
+  test("does not fire on loopback, private ranges, or the CGNAT range", () => {
+    // The gateway binds loopback by design and Tailscale uses CGNAT; flagging those would make the
+    // check noise, and a check people silence is worse than no check.
+    for (const text of ["127.0.0.1:4317", "10.0.0.5", "192.168.1.10", "172.16.4.2", "100.64.1.1", "0.0.0.0"]) {
+      expect(findIdentifierLeaks(text)).toEqual([]);
+    }
+  });
+
+  test("does not fire on documentation placeholders", () => {
+    for (const text of ["gateway.example.ts.net", "host.tailnet.ts.net", "/Users/test/x", "/home/runner/work"]) {
+      expect(findIdentifierLeaks(text)).toEqual([]);
+    }
+  });
+
+  test("does not mistake version strings or system paths for identifiers", () => {
+    // Regressions observed while building this: Chrome's UA reports 151.0.0.0, and $HOME/Library is
+    // a system directory rather than an account name.
+    expect(findIdentifierLeaks("Chrome/151.0.0.0 Mobile Safari")).toEqual([]);
+    expect(findIdentifierLeaks("$HOME/Library/LaunchAgents")).toEqual([]);
+    expect(findIdentifierLeaks("%2FUPSTREAM.lock.json")).toEqual([]);
+    expect(findIdentifierLeaks("sha256 ABCDEF0123456789")).toEqual([]);
+  });
+
+  test("honours an explicit reviewed opt-out", () => {
+    expect(findIdentifierLeaks("203.0.113.45 // identifier-leak-allow")).toEqual([]);
+  });
+});

--- a/scripts/identifier-leak-rules.ts
+++ b/scripts/identifier-leak-rules.ts
@@ -1,0 +1,112 @@
+/**
+ * Patterns for personal and infrastructure identifiers that must not enter this public repository.
+ *
+ * This is a sibling of `capability-leak-rules.ts`, which guards secrets. This file guards a
+ * different class: values that are not credentials but still identify a person, a machine, or a
+ * private network. Nothing here would grant access; publishing it is a privacy failure rather than
+ * a security one, which is exactly why it is easy to be careless with.
+ *
+ * It exists because I published a workstation hostname, a phone's hardware serial, a home directory
+ * path, a private tailnet address, a tailnet node id, and a production VPS address into a public
+ * repository and its pull requests, then had to rewrite history and delete three releases to get
+ * them back out. Every one of those was avoidable by a reviewer noticing. A check does not get
+ * tired.
+ *
+ * The rules are shape-based rather than a denylist of known values. A denylist only catches the
+ * values already leaked, which is precisely the set that no longer matters.
+ */
+
+export interface IdentifierFinding {
+  readonly label: string;
+  readonly match: string;
+  readonly line: number;
+}
+
+/** Extensions worth scanning. Binary and lockfile noise is skipped by the caller. */
+export const IDENTIFIER_TEXT_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".mjs", ".json", ".md", ".yml", ".yaml", ".sh", ".ps1", ".hujson", ".patch"]);
+
+/**
+ * Literals that look like an identifier but are documentation, reserved, or otherwise safe.
+ * Keep this list short and justified; every entry is a hole in the check.
+ */
+const ALLOWED = [
+  /^127\./, // loopback, which this project binds to deliberately
+  /^0\.0\.0\.0$/,
+  /^255\./,
+  /^10\./, // RFC1918
+  /^192\.168\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^169\.254\./, // link-local
+  /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./, // CGNAT, which Tailscale uses; addresses are not routable
+  /^(1\.2\.3\.4|8\.8\.8\.8|93\.184\.216\.34)$/, // conventional documentation addresses
+  /^\d+\.\d+\.\d+\.\d+$/u.source === "" ? /^$/ : /^(?:0|1)\.\d+\.\d+\.\d+$/, // version-like leading 0./1.
+];
+
+function isAllowed(value: string): boolean {
+  return ALLOWED.some(rule => rule.test(value));
+}
+
+/** A dotted quad that is a plausible public address rather than a version string or loopback. */
+function looksLikePublicIpv4(value: string): boolean {
+  const parts = value.split(".");
+  if (parts.length !== 4) return false;
+  if (parts.some(p => p.length > 3 || !/^\d+$/u.test(p) || Number(p) > 255)) return false;
+  // A leading octet of 0 is not a host address, and semantic versions rarely reach four octets.
+  if (Number(parts[0]) === 0) return false;
+  // `151.0.0.0` is a browser version, not a host; no real address ends in three zero octets.
+  if (parts.slice(1).every(p => Number(p) === 0)) return false;
+  return !isAllowed(value);
+}
+
+interface Rule {
+  readonly label: string;
+  readonly pattern: RegExp;
+  readonly accept?: (match: string) => boolean;
+}
+
+const RULES: readonly Rule[] = [
+  { label: "public IPv4 address", pattern: /\b(?:\d{1,3}\.){3}\d{1,3}\b/gu, accept: looksLikePublicIpv4 },
+  // Tailscale MagicDNS names embed the machine name and the tailnet, so they identify both.
+  {
+    label: "tailnet hostname",
+    pattern: /\b[a-z0-9-]+\.[a-z0-9-]+\.ts\.net\b/giu,
+    // Documentation placeholders are the whole point of having placeholders.
+    accept: value => !/(^|\.)(example|tailnet|invalid)\./iu.test(value),
+  },
+  // Tailscale node identifiers.
+  { label: "tailnet node id", pattern: /\b[A-Za-z0-9]{10,20}CNTRL\b/gu },
+  // A macOS or Linux home directory reveals the account name.
+  {
+    label: "absolute home path",
+    // Case-sensitive on the account segment: `$HOME/Library` is a system path, not a username.
+    pattern: /\/(?:Users|home)\/(?!runner\b|test\b|user\b|you\b|ompqual\b|alice\b|bob\b|me\b|someone\b)[a-z][a-z0-9_-]{1,31}\b/gu,
+  },
+  // Android/Apple hardware serials: long uppercase alphanumerics with digits and letters mixed.
+  { label: "device serial", pattern: /\b(?=[0-9A-Z]{10,20}\b)(?=.*\d)(?=.*[A-Z])[0-9A-Z]{10,20}\b/gu },
+];
+
+/** Matches that the serial rule would otherwise flag: hex digests, base32, and shouty constants. */
+const SERIAL_FALSE_POSITIVE = /^(?:[0-9A-F]+|[A-Z]+|[A-Z0-9]*(?:SHA|HMAC|UUID|HTTP|JSON|TTL|API|URL|CI|OMP|UPSTREAM)[A-Z0-9]*)$/u;
+
+/** Real hardware serials carry several digits; a shouty token with one or two does not. */
+function hasSerialDigitDensity(value: string): boolean {
+  return (value.match(/\d/gu) ?? []).length >= 3;
+}
+
+export function findIdentifierLeaks(text: string): IdentifierFinding[] {
+  const findings: IdentifierFinding[] = [];
+  const lines = text.split("\n");
+  for (const [index, line] of lines.entries()) {
+    // A line may explicitly opt out where a real identifier is unavoidable and reviewed.
+    if (line.includes("identifier-leak-allow")) continue;
+    for (const rule of RULES) {
+      for (const match of line.matchAll(rule.pattern)) {
+        const value = match[0];
+        if (rule.accept && !rule.accept(value)) continue;
+        if (rule.label === "device serial" && (SERIAL_FALSE_POSITIVE.test(value) || !hasSerialDigitDensity(value))) continue;
+        findings.push({ label: rule.label, match: value, line: index + 1 });
+      }
+    }
+  }
+  return findings;
+}

--- a/scripts/ledger-structure.test.ts
+++ b/scripts/ledger-structure.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+/**
+ * Structural guards for the two documents that carry the release decision.
+ *
+ * These exist because a whitespace-normalising substitution once matched newlines and collapsed
+ * both files: `COMPATIBILITY.md` fell from 176 lines to 98 with a single surviving heading, and
+ * `RELEASE_STATUS.md` lost all but two of its sections. It reached `main` because the only
+ * validation in use counted table delimiters, and table rows happened to survive. Table shape says
+ * nothing about whether the surrounding document still exists.
+ *
+ * Sections are asserted by name rather than by count so that deleting one is a failure even if
+ * another is added, and so the failure message names what went missing.
+ */
+
+const REQUIRED_SECTIONS: Readonly<Record<string, readonly string[]>> = {
+  "docs/RELEASE_STATUS.md": [
+    "# Release status",
+    "## Status rules",
+    "## Recorded implementation evidence",
+    "## Alpha gate ledger",
+    "## Current release blockers",
+    "## Known limitations",
+    "## Updating this ledger",
+  ],
+  "docs/COMPATIBILITY.md": [
+    "# Compatibility and support policy",
+    "## Current claim",
+    "## Status vocabulary",
+    "## Exact OMP baseline",
+    "## Versioned interfaces",
+    "## Host and client matrix",
+    "## Deployment dependency matrix",
+    "## Upstream refresh procedure",
+    "## Protocol evolution",
+  ],
+};
+
+function read(path: string): string[] {
+  return readFileSync(new URL(`../${path}`, import.meta.url), "utf8").split("\n");
+}
+
+describe("release document structure", () => {
+  for (const [path, sections] of Object.entries(REQUIRED_SECTIONS)) {
+    test(`${path} keeps every required section`, () => {
+      const lines = read(path);
+      const missing = sections.filter(heading => !lines.includes(heading));
+      expect(missing).toEqual([]);
+    });
+
+    test(`${path} keeps its tables well formed`, () => {
+      // A delimiter row fixes the column count; every body row until the table ends must match it.
+      const malformed: string[] = [];
+      let expected: number | undefined;
+      for (const [index, line] of read(path).entries()) {
+        if (!line.startsWith("|")) {
+          expected = undefined;
+          continue;
+        }
+        const cells = line.split("|").length;
+        if (/^\|[\s:|-]+\|$/u.test(line)) {
+          expected = cells;
+          continue;
+        }
+        if (expected !== undefined && cells !== expected) malformed.push(`line ${index + 1}: ${cells} vs ${expected}`);
+      }
+      expect(malformed).toEqual([]);
+    });
+
+    test(`${path} is not collapsed onto a handful of lines`, () => {
+      // The specific failure mode: paragraphs merged, so the file shrinks dramatically while
+      // remaining valid Markdown. A floor catches it without pinning an exact length.
+      const lines = read(path);
+      expect(lines.length).toBeGreaterThan(90);
+      const overlong = lines.filter(line => !line.startsWith("|") && line.length > 900);
+      expect(overlong).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
Two failures this round were caught by a human reading a diff — the least reliable control available. Both are now checks.

## `check:identifier-leaks`

Sibling of the existing capability scan. That one guards **secrets**; this guards values that identify a person, machine, or private network: public addresses, tailnet hostnames and node ids, absolute home paths, hardware serials. None of them grant access, which is precisely why they are easy to be careless with.

Shape-based, not a denylist — a denylist only catches what has already leaked, which is the set that no longer matters.

Kept quiet enough to be trusted: loopback, RFC1918, the CGNAT range Tailscale uses, and documentation placeholders all pass. **A check people learn to silence is worse than no check.** A reviewed exception can opt out per line with `identifier-leak-allow`.

Three false positives found by *running* it against the tree rather than reasoning about it:

| Looked like | Actually |
|---|---|
| `151.0.0.0` | Chrome's user-agent version, parses as a dotted quad |
| `/home/Library` | `$HOME/Library`, a system path under case-insensitive matching |
| `2FUPSTREAM` | a percent-encoded fragment |

Each fixed in the rule, not allowlisted at the callsite.

## `ledger-structure` tests

The two release documents must keep their sections **by name**, so deleting one fails even if another is added, and the message says what went missing.

This exists because a substitution recently collapsed both files — `COMPATIBILITY.md` from 176 lines to 98 with one surviving heading — and it reached `main` because the only validation counted table delimiters and the rows happened to survive. **Table shape says nothing about whether the document around it still exists.**

## Verification

Both mutation-proven, not merely passing:

- replaying the exact collapse on `COMPATIBILITY.md` fails the structure suite (5 pass / 1 fail), restoring gives 6/6
- the detection tests assert each class that actually leaked, using synthetic stand-ins of the same shape

`bun run check` green from a clean tree — 167 tests, 845 assertions, 26 files, both scans passing.

## Threat-model impact

Adds a preventive control and no product code. It narrows a disclosure path that has already been exercised once, and deliberately does not weaken the existing capability scan, which continues to run first.