### PR TITLE
feat(linux): qualify the rollback command and fix the persistence assertion

### DIFF
--- a/.github/workflows/droplet-qualification.yml
+++ b/.github/workflows/droplet-qualification.yml
@@ -189,8 +189,8 @@ jobs:
           if [ -n "$QUAL_LANES" ]; then
             for lane in $QUAL_LANES; do
               case "$lane" in
-                host | artifact | lifecycle | migration | identity | persistence | uninstall) ;;
-                *) fail "Unknown lane '$lane'" "Choose from: host artifact lifecycle migration identity persistence uninstall." ;;
+                host | artifact | lifecycle | migration | rollback | identity | persistence | uninstall) ;;
+                *) fail "Unknown lane '$lane'" "Choose from: host artifact lifecycle migration rollback identity persistence uninstall." ;;
               esac
             done
             case " $QUAL_LANES " in

--- a/docs/LINUX_QUALIFICATION.md
+++ b/docs/LINUX_QUALIFICATION.md
@@ -53,18 +53,34 @@ ambiguous by default: it can mean lingering started the user manager at boot, or
 login used to check created a session that pulled in `default.target`.
 
 Lane `persistence` removes the ambiguity by rebooting twice and measuring from **root only**, so the
-qualified user has zero login sessions at the instant of measurement:
+qualified user has no *login* session at the instant of measurement:
 
 - **Pass A, negative control.** `loginctl disable-linger ompqual`, reboot, then measure as root. The
-  daemon must be absent, `user@<uid>.service` must be `inactive`, and the loopback probe must fail.
-  A follow-up SSH login as `ompqual` then shows the unit starting, with a process age far smaller
-  than system uptime — which is what "a login session started it" looks like.
+  daemon must be absent and the user must own **no session of any class**; `user@<uid>.service` is
+  `inactive` and the loopback probe fails. A follow-up SSH login as `ompqual` then shows the unit
+  starting, with a process age far smaller than system uptime — which is what "a login session
+  started it" looks like.
 - **Pass B, the persistence claim.** `loginctl enable-linger ompqual`, reboot, measure as root again.
-  The daemon must be running while `loginctl list-sessions` shows **zero** sessions for that user,
-  and its process age must track system uptime rather than the age of our connection.
+  The daemon must be running, the user must own **no session of class `user`**, and it must own **at
+  least one session of class `manager`**. Its process age must track system uptime rather than the
+  age of our connection.
 
-Both passes print the session count and the `process Ns old, system up Ms` pair. Pass B is evidence
-only in combination with pass A; on its own it cannot distinguish the two causes.
+**The measurement is session class, never session count.** When lingering works the count can never
+be zero: the lingering user manager is itself a session, of class `manager`, type `unspecified`,
+`Remote=no`. Its presence is exactly what lingering succeeding looks like, and #69's original
+evidence recorded class `manager` for the same reason. Only a session of class `user` means somebody
+is logged in. An earlier revision of this lane printed the count and a narrative line claiming the
+count was zero; against candidate `v0.1.0-prealpha.17` the count printed `1` while the narrative
+asserted `0`, which read as the lane contradicting itself. The count was the wrong measurement, not
+the product's behaviour.
+
+Both passes print every session the user owns as `id(class=…,type=…,remote=…)`, the class-`user` and
+class-`manager` counts, and the `process Ns old, system up Ms` pair, and then assert the properties
+above and fail the lane if they do not hold. Sessions are enumerated by session id — the one column
+`loginctl list-sessions` has had in every systemd version — and classified with `loginctl
+show-session`, because that table's column layout has changed across releases and a positional field
+is not a fact. Pass B is evidence only in combination with pass A; on its own it cannot distinguish
+the two causes.
 
 Reboots are detected by boot id, not by a sleep: the script records
 `/proc/sys/kernel/random/boot_id`, issues the reboot, and returns only when SSH answers with a
@@ -220,18 +236,20 @@ sequence again:
 ./scripts/provision-linux-qual.sh qualify host
 ./scripts/provision-linux-qual.sh qualify artifact lifecycle
 ./scripts/provision-linux-qual.sh qualify migration
+./scripts/provision-linux-qual.sh qualify rollback
 ./scripts/provision-linux-qual.sh qualify identity
 ./scripts/provision-linux-qual.sh qualify persistence
 ./scripts/provision-linux-qual.sh qualify uninstall
 ```
 
-Default order is `host artifact lifecycle migration identity persistence uninstall`. The lanes are
-ordered so the identity matrix is captured before the reboots: a reboot failure then costs no
-identity evidence. `migration`, `identity`, and `persistence` all assume `lifecycle` has already
-installed the service; run them after it, or after a previous full run, not standalone on a fresh
-droplet. With `OMP_QUAL_INIT=openrc` the default becomes `host artifact init` and the five lanes that
-need an installed service are refused by name before a droplet is touched; see
-[section 10](#10-the-non-systemd-path-alpine-and-openrc).
+Default order is `host artifact lifecycle migration rollback identity persistence uninstall`. The
+lanes are ordered so the identity matrix is captured before the reboots: a reboot failure then costs
+no identity evidence. `migration`, `identity`, and `persistence` all assume `lifecycle` has already
+installed the service, and `rollback` additionally assumes `migration` has run — see
+[section 11](#11-the-two-rollback-mechanisms). Run them after those lanes, or after a previous full
+run, not standalone on a fresh droplet. With `OMP_QUAL_INIT=openrc` the default becomes
+`host artifact init` and the six lanes that need an installed service are refused by name before a
+droplet is touched; see [section 10](#10-the-non-systemd-path-alpine-and-openrc).
 
 Lane `migration` proves explicit forward upgrade and rollback on a real systemd user manager, which
 the macOS harness in [`UPGRADE_ROLLBACK.md`](UPGRADE_ROLLBACK.md) cannot do: it has no user unit, no
@@ -245,8 +263,25 @@ active version instead of going stale, the unit is still `enabled`, the main pid
 across the upgrade so the daemon is genuinely replaced, and the listener stays loopback-only. It
 skips with a message rather than failing when the two tags are equal.
 
-Do not set `OMP_QUAL_PREVIOUS_TAG` to `v0.1.0-prealpha.14` or earlier: those units predate the
-`RuntimeDirectory=` fix and fail after a reboot, which would confound a rollback result with #69.
+Every step `migration` takes is an `install`, so what it proves is **rollback-by-reinstall**. It
+never runs the `omp-gateway rollback` command. Lane `rollback` does, and the two are different code
+paths; do not read either as covering the other. See
+[section 11](#11-the-two-rollback-mechanisms).
+
+**Predecessor tags and the `RuntimeDirectory=` fix.** A predecessor at `v0.1.0-prealpha.14` or
+earlier renders a *pre-#69* unit: it names the runtime directory in `ReadWritePaths=` instead of
+letting systemd own it with `RuntimeDirectory=`, and such a unit fails after a reboot. That is only a
+hazard if a pre-fix unit is still installed when something reboots the box, so the ordering matters:
+lane `rollback` deliberately ends by putting the candidate back, which rewrites the unit into the
+post-fix shape and asserts it, so `persistence` never reboots onto a pre-fix unit. Running
+`migration` and then `persistence` **without** `rollback` in between does reboot onto one, and the
+failure you would get is #69 rather than anything about upgrade or rollback.
+
+At the time of writing the only published releases are `v0.1.0-prealpha.13` and
+`v0.1.0-prealpha.17`; `.14`, `.15`, and `.16` exist as neither releases nor tags, so the script's
+`OMP_QUAL_PREVIOUS_TAG` default of `v0.1.0-prealpha.15` names nothing reproducible. Set it
+explicitly. `.13` is the only predecessor a third party can currently fetch, and it is a pre-#69
+artifact, which is why the paragraph above is an ordering rule rather than a prohibition.
 
 Lane `uninstall` leaves the droplet clean — no service, no Serve mapping — so the next `qualify` starts
 from the same state as the first.
@@ -268,7 +303,7 @@ from the same state as the first.
 | `OMP_QUAL_GH_VERSION` | `2.97.0` | `gh` release fetched onto the droplet. |
 | `OMP_QUAL_COSIGN_VERSION` | `3.1.3` | `cosign` release fetched onto the droplet. |
 | `OMP_QUAL_TAG` | `tag:omp-session-gateway` | Tag the auth key is expected to carry; used in messages only. |
-| `OMP_QUAL_PREVIOUS_TAG` | `v0.1.0-prealpha.15` | Predecessor tag for the `migration` lane. Must be `.15` or later; earlier units predate the `RuntimeDirectory=` fix. |
+| `OMP_QUAL_PREVIOUS_TAG` | `v0.1.0-prealpha.15` | Predecessor tag for the `migration` lane, and the first of the two archives lane `rollback` reads. **The default names nothing reproducible** — no `.15` release or tag exists — so set it explicitly; see [section 4](#4-running-the-lane). |
 | `OMP_QUAL_INIT` | `systemd` | `systemd` is the historical path and changes nothing. `openrc` provisions a non-systemd box — no Tailscale, an Alpine-shaped cloud-config, the `init` lane instead of the install lanes — to measure the installer's refusal. Any other value is rejected in preflight before anything is created. |
 | `GH_TOKEN` | unset | If set, the droplet verifies attestations online instead of offline. |
 
@@ -302,7 +337,8 @@ what is measured and where; it does not assert that any row should change.
 | Ledger row | Command | Observable |
 |---|---|---|
 | Linux host lifecycle | `qualify host lifecycle uninstall` | `systemd-detect-virt` on a booting machine; `status` returning `{installed:true,active:true,ready:true,authMode:"tailscale-serve"}` from the archive CLI; `config.json` `600` in a `700` directory; `publisher-token` `600`; `registry.sock` under `$XDG_RUNTIME_DIR`; main PID before/after `rotate-publisher-token`; `uninstall --no-stop` refused while active; unit file, process, and listener all gone after `uninstall`. |
-| Linux host lifecycle (reboot/login half) | `qualify persistence` | Pass A: lingering off, zero sessions, `user@<uid>.service` `inactive`, no daemon PID, loopback probe fails. Pass B: lingering on, zero sessions, `user@<uid>.service` `active`, daemon PID present, process age ≈ system uptime, loopback probe `403`. |
+| Linux host lifecycle (reboot/login half) | `qualify persistence` | Pass A: lingering off, no session of any class for the user, `user@<uid>.service` `inactive`, no daemon PID, loopback probe fails. Pass B: lingering on, no session of class `user` and at least one of class `manager`, `user@<uid>.service` `active`, daemon PID present, process age ≈ system uptime, loopback probe `403`. Every session the user owns is printed with its class, type, and remote flag. |
+| Configuration migration and rollback (command path) | `qualify rollback` | `omp-gateway rollback` refusing to guess when the activation history names no predecessor, with its message compared against the one `installation.ts` documents; `rollback --to <version-directory>` and the bare form each moving `current.json`, rewriting the unit's `ExecStart` to an absolute versioned path, reloading the unit, restarting the daemon, rebinding the loopback listener, and leaving `config.json` and the publisher token byte-identical; `history.json` gaining one activation equal to the new pointer and written after it; and an induced definition-newer-than-pointer divergence reported by `status` and repaired back to the older proven version. See [section 11](#11-the-two-rollback-mechanisms). |
 | Tailscale Serve identity and application allowlist | `qualify identity` | `403` for the tagged self-probe with zero `Tailscale-User-*` headers reaching the backend, and `tailscale whois` reporting no user profile; `403` for the workstation's real identity while the allowlist holds a synthetic address; `200` once its login is allowlisted; the forged-header pair denied-then-ignored. |
 | Loopback-only exposure | `qualify identity` | `ss` showing only `127.0.0.1:4317`; connection refused to the droplet's tailnet IP on `4317`; connection refused to the droplet's **public** IP on `4317` from the workstation; `tailscale funnel status` showing no funnel. |
 | Platform install/doctor/uninstall | `qualify artifact lifecycle uninstall` | `sha256sum --check` result and measured archive digest; `cosign verify-blob` against all three `.sigstore.json` bundles at the exact certificate identity; `gh attestation verify` for all three artifacts at `--source-ref refs/tags/<tag>`; then install/doctor/uninstall executed from that verified archive's CLI. |
@@ -317,14 +353,19 @@ commit (relevant to the ledger's requirement that platform rows be re-run at the
 **The sibling lane.** `Configuration migration and rollback` is also measured on macOS by
 [`UPGRADE_ROLLBACK.md`](UPGRADE_ROLLBACK.md) and `scripts/qualify-rollback.sh`. That harness has no
 user unit, no `enable` state, and no service manager owning the runtime directory, which is why lane
-`migration` above exists: the Linux half of the same claim. The two are independent, so this
+`migration` above exists: the Linux half of the same claim. It also predates the `omp-gateway
+rollback` command and installs with `--no-start` throughout, so it never activates anything and never
+runs the command — which is why lane `rollback` exists as well. The three are independent, so this
 `qualify` can run before or after that one.
 
 ## 6. Teardown and cost
 
-One `s-1vcpu-2gb` droplet at **$0.01786 per hour**, about **$0.43 per day**. A full `qualify` run is
-roughly twenty minutes including two reboots, so the qualification itself costs well under a cent.
-The only way this lane becomes expensive is by being forgotten, which is why:
+One `s-1vcpu-2gb` droplet at **$0.01786 per hour**, about **$0.43 per day**. A full `qualify` run was
+roughly twenty minutes including two reboots before lane `rollback` existed; that lane adds up to
+seven service restarts and one reinstall, each bounded by its own 30-second listener wait, so budget
+a few minutes more. Either way the qualification itself costs well under a cent, and the whole
+sequence still fits inside one billed hour. The only way this lane becomes expensive is by being
+forgotten, which is why:
 
 - `provision` prints the hourly rate;
 - `status` prints hours elapsed and dollars accrued;
@@ -407,7 +448,17 @@ before `droplet delete`, which is the one failure mode teardown must never have.
 - **`doctor` does not reach 16/16 on the tagged node,** by construction. See the table in
   [section 2](#gap-3--denied-tailscale-identity). A full-pass `doctor` on Linux would require a
   user-owned node, which would in turn make the denial case unavailable.
-- **Upgrade and rollback are out of scope here.**
+- **Neither rollback lane proves the crash window is small.** Lane `rollback` induces the one
+  reachable divergence between the service definition and `current.json` and measures how the next
+  command treats it. It says nothing about how likely that window is, and it does not reach
+  `rollback`'s own repair path — the branch that rebuilds the definition from `current.json` when an
+  activation fails — because reaching it means breaking a staged runtime, and a deliberately
+  corrupted runtime is not evidence about this candidate. See
+  [section 11](#11-the-two-rollback-mechanisms).
+- **The conservative divergence repair was not performed by the rollback command.** With two
+  installed versions no invocation can do it, so the reinstall that `status`'s `DIVERGED` message
+  also prescribes is what the lane measures. No third version is manufactured to make the command
+  reach it.
 - **Persistence is proven for systemd user lingering on this distribution only.** It says nothing
   about the macOS LaunchAgent or the Windows scheduled task, both of which have their own untested
   reboot/login story.
@@ -561,11 +612,12 @@ Two lanes are weaker on a runner than on a workstation, by construction:
 - **The public-IP probe is better from CI, not worse.** A GitHub runner is a genuine public-Internet
   host, so "connection refused to the droplet's public IP on `4317`" is measured from one.
 
-`migration` needs `OMP_QUAL_PREVIOUS_TAG` to name a published release that is `v0.1.0-prealpha.15` or
-later, for the reason in [section 4](#4-running-the-lane). Both tags are inputs with explicit
-defaults rather than a lookup of the newest release: a scheduled run must qualify a decided candidate,
-and silently following the newest tag would change what the evidence is about without anybody choosing
-that. The preflight checks that both tags exist and carry all six expected assets before provisioning.
+`migration` needs `OMP_QUAL_PREVIOUS_TAG` to name a published release, and `rollback` needs
+`migration` to have run in front of it; see [section 4](#4-running-the-lane) for the ordering rule a
+pre-#69 predecessor unit imposes. Both tags are inputs with explicit defaults rather than a lookup of
+the newest release: a scheduled run must qualify a decided candidate, and silently following the
+newest tag would change what the evidence is about without anybody choosing that. The preflight
+checks that both tags exist and carry all six expected assets before provisioning.
 
 ### 9.6 Reading a failure
 
@@ -695,8 +747,8 @@ Nothing when it is unset. When it is set to `openrc`:
 | Tailscale | installed, joined, tagged, `--operator` granted | none. Serve only serves lanes that need a running gateway, and installing `tailscaled` would mean writing an OpenRC service — precisely the thing this lane must not quietly do |
 | `loginctl enable-linger` | applied | not applicable |
 | Provision's last check | tailnet DNS name, tags, node id | distribution, kernel, pid 1, `/run/systemd/system`, `systemctl`, `rc-service`, `bash`; **fails if systemd is present**, because a systemd box cannot answer the question it was paid for |
-| Default lanes | `host artifact lifecycle migration identity persistence uninstall` | `host artifact init` |
-| `lifecycle`, `migration`, `identity`, `persistence`, `uninstall` | run | refused by name in preflight, before the droplet is contacted |
+| Default lanes | `host artifact lifecycle migration rollback identity persistence uninstall` | `host artifact init` |
+| `lifecycle`, `migration`, `rollback`, `identity`, `persistence`, `uninstall` | run | refused by name in preflight, before the droplet is contacted |
 
 Lane `init` needs `artifact` to have run first — it executes the extracted archive's CLI, not a
 development checkout — and says so rather than failing obscurely if it has not. Run on a systemd host
@@ -723,14 +775,155 @@ What a clean refusal would let the ledger say, once run, is narrower and more us
 A **failing** run is the more valuable outcome: it would mean an unsupported host is left holding a
 token, a staged runtime, or a listener, and that is a defect to file rather than a scope note to write.
 
-## 11. Related documents
+## 11. The two rollback mechanisms
+
+**This lane has not been executed yet.** It was validated statically — `bash -n`, `shellcheck` with
+zero findings, every remote heredoc extracted and parsed on its own, and its pure-shell helpers
+unit-tested against known inputs — and no part of it has run against a droplet. Nothing below is a
+measurement; it is what the lane will measure. The first real run is the lead's.
+
+### 11.1 Why there are two
+
+There is no single rollback implementation. There are two, and they share almost nothing:
+
+| | Rollback by reinstall | The `rollback` command |
+|---|---|---|
+| How | `omp-gateway install` from the predecessor's archive again | `omp-gateway rollback [--to <version-directory>]` |
+| Chooses its target by | whatever archive the operator points at | reading `installation/history.json`, or `--to` |
+| Refuses when | the prior runtime cannot be verified | the history names no predecessor, `--to` is malformed, names the active version, or names a version that is not installed |
+| Stages a payload | yes, a fresh one | no, it activates a runtime already on disk |
+| Repairs a diverged definition | by rewriting it for the payload it just staged | by rebuilding it from `current.json` when its own activation fails |
+| Linux lane | `migration` | `rollback` |
+| macOS harness | `scripts/qualify-rollback.sh` | not covered: the command postdates it |
+
+Lane `migration` drives the left column only — all three of its steps are installs — and it passes
+11/11 against `v0.1.0-prealpha.17` on a Debian 13 droplet. It never invokes the command, so nothing
+in the right column was covered on any platform before lane `rollback` existed. Do not read either
+lane as evidence for the other, and do not read the macOS harness as evidence for the command.
+
+### 11.2 The two-artifact prerequisite
+
+Both artifacts are the ones lane `migration` already downloaded, verified, and extracted:
+`~/runtime-prev` from `OMP_QUAL_PREVIOUS_TAG` and `~/runtime-root` from `OMP_QUAL_RELEASE_TAG`. Lane
+`rollback` downloads nothing and stages nothing; it reads those two roots and the install `migration`
+left behind. It therefore needs `artifact lifecycle migration` in front of it, has no environment
+knob of its own, and fails closed by name — not obscurely — when any of that is missing.
+
+Two properties of the artifacts decide what the lane can observe, and both are consequences of
+[#78](https://github.com/alphastorm/omp-session-gateway/pull/78) rather than of tag ordering:
+
+- **The candidate must carry the command.** The lane greps the candidate's own `cli.js` for the
+  rollback target resolver and refuses when it is absent, because a candidate that predates #78 gives
+  it nothing to exercise. `v0.1.0-prealpha.17` is the first release that carries it.
+- **The predecessor decides whether a bare `rollback` can resolve anything at first.**
+  `history.json` is written only by the CLI performing an activation, so a predecessor older than #78
+  records nothing. Installing `.13` then `.17` then `.13` — what `migration` does — leaves a history
+  naming only `.17`'s staged directory, and a bare `rollback` from `.13` then correctly refuses:
+  *"refusing to guess a rollback target: no activation of the active version … is recorded"*. The
+  lane asserts that refusal rather than stepping around it, then seeds the history with two explicit
+  `rollback --to` invocations, which the candidate's CLI does record, and only then exercises the bare
+  form. It works the same way if both artifacts carry #78; the refusal step simply becomes an asserted
+  success instead.
+
+Which staged directory belongs to which archive is decided by digest, never by `current.json` and
+never by the history: the installer copies a `.js` CLI into the staged runtime verbatim in both
+artifacts, so a staged version directory whose `apps/gateway/src/cli.js` matches an archive's byte for
+byte was staged from that archive. Every "it went back to the predecessor" claim is anchored to that,
+so none of them can be satisfied by a pointer that merely changed.
+
+### 11.3 Invoking it
+
+```sh
+export OMP_QUAL_RELEASE_TAG=v0.1.0-prealpha.17   # the candidate; must carry PR #78
+export OMP_QUAL_PREVIOUS_TAG=v0.1.0-prealpha.13  # the only other published release
+
+./scripts/provision-linux-qual.sh qualify artifact lifecycle migration rollback
+```
+
+On a droplet that has already run `artifact lifecycle migration` in an earlier invocation,
+`./scripts/provision-linux-qual.sh qualify rollback` is enough. The lane is also in the default order,
+between `migration` and `identity`.
+
+### 11.4 What it proves
+
+Every row below is asserted, prints the value it observed, and fails the lane when it does not hold.
+
+1. **The refusal.** A bare `rollback` with no recorded predecessor exits non-zero, names no target,
+   and changes nothing — not the pointer, not the service definition, not the daemon, not the
+   history. Its message is compared against the one `apps/gateway/src/installation.ts` documents, so
+   a drift between the command and its own docstring shows up as a failing row rather than being
+   absorbed.
+2. **`--to <version-directory>`,** three times, reporting selection `requested`.
+3. **The bare form,** twice, reporting selection `recorded-predecessor` and landing on the
+   predecessor the lane computes independently from `history.json` — which also demonstrates the
+   documented oscillation between two versions.
+4. **Around every one of those:** `current.json` names the target; the unit *file* and the *loaded*
+   unit both name it, so the definition was rewritten and `daemon-reload` really happened; the
+   `ExecStart` path is absolute and under that version directory; the daemon's main PID changes; the
+   loopback listener is bound again and is loopback-only; `config.json` and the publisher token are
+   byte-identical to their pre-lane digests and the token keeps mode `600`; `history.json` gains one
+   activation equal to the new pointer — or none, when the history already ended with that version,
+   which is the documented idempotence — and its nanosecond mtime is at or after `current.json`'s, so
+   the append followed the pointer commit; and `status` reports
+   `installed/active/ready` with `diverged: false`.
+5. **The induced divergence.** `install` and `rollback` both write the service definition first and
+   advance `current.json` only after the new runtime proves loopback readiness, so exactly one
+   divergence direction is reachable: a crash between those two writes leaves the definition naming a
+   *newer* version than the pointer. The lane reproduces that state by hand, including the restart a
+   real crash would already have completed, and then asserts that `status` reports `diverged: true`
+   with `activeVersion` at the pointer and `serviceVersion` at the definition, exits non-zero, and
+   prints `DIVERGED`; that `rollback --to` the pointer's own version is refused; and that the repair
+   returns the service to the older proven version, adopting the newer one neither in the pointer nor
+   in the definition, and recording no new activation.
+6. **The exit state.** The lane finishes by putting the candidate back with a third `--to`, and
+   asserts the unit it leaves behind carries `RuntimeDirectory=`. Later lanes measure the candidate,
+   and `persistence` reboots; a predecessor unit predating the #69 fix would fail that reboot for
+   reasons that are #69 and not rollback.
+
+### 11.5 What it does not prove
+
+- **The command did not perform the conservative divergence repair.** With two installed versions no
+  invocation can: `--to` the pointer's own version is refused, and every other target adopts a
+  version the pointer never proved. The repair the lane measures is the reinstall that `status`'s
+  `DIVERGED` message also prescribes, and the lane says so in its own output. No third version is
+  manufactured to make the command reach it, because that would be testing a state the product
+  cannot be in.
+- **`rollback`'s own repair branch is not reached.** The `catch` that rebuilds the definition from
+  `current.json` runs only when a rollback's activation fails, which means breaking a staged runtime.
+  A deliberately corrupted runtime is not evidence about this candidate.
+- **The opposite divergence direction is not induced,** because no command produces it: neither
+  `install` nor `rollback` writes `current.json` before the service definition.
+- **The crash window is not measured,** only the state a crash inside it leaves and how the next
+  command treats that state.
+- **History ordering is shown by mtime,** which orders two writes and says nothing about atomicity.
+  Those two writes are documented as *not* atomic.
+- **Nothing here is isolated from a production daemon,** and it does not need to be: the droplet has
+  one user, one service, and no live daemon to protect. The macOS harness's host-daemon and
+  host-plist invariants have no analogue and are not simulated.
+- **Five of lane 4's rows are not re-asserted here** — predecessor install names a version, the
+  active version changes on the forward upgrade, the predecessor directory survives it, the unit
+  stays `enabled`, and a reinstall preserves config and token. They belong to the reinstall path,
+  lane `migration` already establishes them, and two overlapping sources of truth for one claim are
+  worse than one. The lane prints them where they are cheap to read.
+
+### 11.6 One thing to check before recording numbers
+
+The `lanes` dispatch input in
+[`droplet-qualification.yml`](../.github/workflows/droplet-qualification.yml) validates lane names
+against a fixed list that does not yet include `rollback`, so an explicit CI subset naming it fails
+preflight. An empty `lanes` input runs the script's full default order and therefore picks the lane up
+already. That file is the lead's.
+
+## 12. Related documents
 
 - [`RELEASE_STATUS.md`](RELEASE_STATUS.md) — the ledger; the only place a row's status changes.
 - [`TEST_PLAN.md`](TEST_PLAN.md) — §4.E authorization and §4.F persistence scenarios this lane feeds.
 - [`SECURITY.md`](SECURITY.md) — §4 network exposure, §8 tailnet authorization, §13 acceptance gates.
 - [`RELEASE.md`](RELEASE.md) — the canonical artifact verification commands this lane runs remotely.
 - [`OPERATIONS.md`](OPERATIONS.md) — install, Serve, paths, and `doctor` semantics.
-- [`UPGRADE_ROLLBACK.md`](UPGRADE_ROLLBACK.md) — the sibling lane for forward upgrade and rollback.
+- [`UPGRADE_ROLLBACK.md`](UPGRADE_ROLLBACK.md) — the macOS harness for forward upgrade and
+  rollback-by-reinstall. It predates the `omp-gateway rollback` command and never runs it; see
+  [section 11](#11-the-two-rollback-mechanisms) for why that leaves a second lane to run.
 - [`COMPATIBILITY.md`](COMPATIBILITY.md) — where a "non-systemd Linux is out of scope" statement would
   belong once [section 10](#10-the-non-systemd-path-alpine-and-openrc) has been run. Owned by the lead.
 - [`.github/workflows/droplet-qualification.yml`](../.github/workflows/droplet-qualification.yml) —

--- a/scripts/provision-linux-qual.sh
+++ b/scripts/provision-linux-qual.sh
@@ -63,7 +63,10 @@
 #   scripts/provision-linux-qual.sh status
 #   scripts/provision-linux-qual.sh destroy
 #
-# Lanes, systemd: host artifact lifecycle migration identity persistence uninstall (default: all).
+# Lanes, systemd: host artifact lifecycle migration rollback identity persistence uninstall
+#                 (default: all). `migration` reinstalls to move between versions; `rollback` drives
+#                 the `omp-gateway rollback` command, which is a different code path, and reads the
+#                 two archive roots `migration` leaves on the droplet.
 # Lanes, OpenRC:  host artifact init (default: all three; the rest presume a working install).
 #
 set -euo pipefail
@@ -649,6 +652,36 @@ cmd_status() {
   remote_root QUAL_USER="$QUAL_USER" GATEWAY_PORT="$GATEWAY_PORT" <<'REMOTE'
 show() { printf '   %-38s %s\n' "$1:" "$2"; }
 uid="$(id -u "$QUAL_USER")"
+
+# Sessions belonging to the qualified user, as "class|id|type|remote". Enumerated by session id --
+# the one column `loginctl list-sessions` has had in every systemd version -- and classified with
+# `show-session`, because that table's column layout has changed across releases and a positional
+# field is not a fact. Ownership is matched on uid or user name, whichever this systemd renders.
+#
+# Class is the measurement, never the count. When lingering works the count can never be zero: the
+# lingering user manager is itself a session, of class `manager`, and its presence is what lingering
+# succeeding looks like. Only a session of class `user` means somebody is logged in.
+sessions_of_user() {
+  local id owner name class type remote
+  while read -r id; do
+    [ -n "$id" ] || continue
+    owner="$(loginctl show-session "$id" --property=User --value 2>/dev/null || true)"
+    name="$(loginctl show-session "$id" --property=Name --value 2>/dev/null || true)"
+    [ "$owner" = "$uid" ] || [ "$name" = "$QUAL_USER" ] || continue
+    class="$(loginctl show-session "$id" --property=Class --value 2>/dev/null || true)"
+    type="$(loginctl show-session "$id" --property=Type --value 2>/dev/null || true)"
+    remote="$(loginctl show-session "$id" --property=Remote --value 2>/dev/null || true)"
+    printf '%s|%s|%s|%s\n' "${class:-unknown}" "$id" "${type:-unknown}" "${remote:-unknown}"
+  done < <(loginctl list-sessions --no-legend 2>/dev/null | awk '{print $1}')
+}
+session_display() {
+  printf '%s' "$1" | awk -F'|' 'NF { printf "%s(class=%s,type=%s,remote=%s) ", $2, $1, $3, $4 }' |
+    sed 's/ *$//' | grep . || printf 'none'
+}
+session_class_count() {
+  printf '%s\n' "$1" | awk -F'|' -v want="$2" 'NF && $1 == want { n++ } END { print n + 0 }'
+}
+sessions="$(sessions_of_user)"
 show "kernel" "$(uname -srm)"
 show "virtualisation" "$(systemd-detect-virt || true)"
 show "uptime seconds" "$(awk '{printf "%d", $1}' /proc/uptime)"
@@ -656,7 +689,9 @@ show "tailscale backend" "$(tailscale status --json | jq -r '.BackendState + " o
 show "node tags" "$(tailscale status --json | jq -r '(.Self.Tags // []) | join(",") | if . == "" then "<none>" else . end')"
 show "linger marker" "$(test -e "/var/lib/systemd/linger/$QUAL_USER" && echo present || echo absent)"
 show "user@${uid}.service" "$(systemctl is-active "user@${uid}.service" 2>/dev/null || true)"
-show "sessions for qualified user" "$(loginctl list-sessions --no-legend 2>/dev/null | awk -v u="$QUAL_USER" '$3 == u' | wc -l | tr -d ' ')"
+show "sessions for qualified user" "$(session_display "$sessions")"
+show "sessions of class user" "$(session_class_count "$sessions" user)"
+show "sessions of class manager" "$(session_class_count "$sessions" manager)"
 show "gateway pids" "$(pgrep -u "$QUAL_USER" -f 'cli.js serve' | tr '\n' ' ' | grep . || echo none)"
 show "loopback probe" "$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "http://127.0.0.1:${GATEWAY_PORT}/api/v1/sessions" 2>/dev/null || echo request-failed)"
 show "listeners on gateway port" "$(ss -ltnH "sport = :${GATEWAY_PORT}" | awk '{print $4}' | tr '\n' ' ' | grep . || echo none)"
@@ -1087,12 +1122,50 @@ REMOTE
 
 # Everything here runs as root, never as the qualified user, so measuring cannot create the very login
 # session whose absence is the whole point.
+#
+# $3 is what lingering is expected to be doing: `off` for the negative control, `on` for the
+# persistence claim. It decides the assertions, because the two passes require opposite outcomes from
+# the same measurements and a function that only printed them left the reader to adjudicate.
 measure_after_reboot() {
-  note "$1, measured from root only, with no session for $QUAL_USER"
-  remote_root QUAL_USER="$QUAL_USER" TARGET_UID="$2" GATEWAY_PORT="$GATEWAY_PORT" <<'REMOTE'
+  note "$1, measured from root only, with no login session for $QUAL_USER"
+  remote_root QUAL_USER="$QUAL_USER" TARGET_UID="$2" EXPECT_LINGER="$3" GATEWAY_PORT="$GATEWAY_PORT" <<'REMOTE'
 show() { printf '   %-38s %s\n' "$1:" "$2"; }
+uid="$TARGET_UID"
+
+# Sessions belonging to the qualified user, as "class|id|type|remote". Enumerated by session id --
+# the one column `loginctl list-sessions` has had in every systemd version -- and classified with
+# `show-session`, because that table's column layout has changed across releases and a positional
+# field is not a fact. Ownership is matched on uid or user name, whichever this systemd renders.
+#
+# Class is the measurement, never the count. When lingering works the count can never be zero: the
+# lingering user manager is itself a session, of class `manager`, and its presence is what lingering
+# succeeding looks like. Only a session of class `user` means somebody is logged in.
+sessions_of_user() {
+  local id owner name class type remote
+  while read -r id; do
+    [ -n "$id" ] || continue
+    owner="$(loginctl show-session "$id" --property=User --value 2>/dev/null || true)"
+    name="$(loginctl show-session "$id" --property=Name --value 2>/dev/null || true)"
+    [ "$owner" = "$uid" ] || [ "$name" = "$QUAL_USER" ] || continue
+    class="$(loginctl show-session "$id" --property=Class --value 2>/dev/null || true)"
+    type="$(loginctl show-session "$id" --property=Type --value 2>/dev/null || true)"
+    remote="$(loginctl show-session "$id" --property=Remote --value 2>/dev/null || true)"
+    printf '%s|%s|%s|%s\n' "${class:-unknown}" "$id" "${type:-unknown}" "${remote:-unknown}"
+  done < <(loginctl list-sessions --no-legend 2>/dev/null | awk '{print $1}')
+}
+session_display() {
+  printf '%s' "$1" | awk -F'|' 'NF { printf "%s(class=%s,type=%s,remote=%s) ", $2, $1, $3, $4 }' |
+    sed 's/ *$//' | grep . || printf 'none'
+}
+session_class_count() {
+  printf '%s\n' "$1" | awk -F'|' -v want="$2" 'NF && $1 == want { n++ } END { print n + 0 }'
+}
+sessions="$(sessions_of_user)"
+session_total="$(printf '%s' "$sessions" | grep -c . || true)"
+
 show "linger marker" "$(test -e "/var/lib/systemd/linger/$QUAL_USER" && echo present || echo absent)"
-show "sessions for qualified user" "$(loginctl list-sessions --no-legend 2>/dev/null | awk -v u="$QUAL_USER" '$3 == u' | wc -l | tr -d ' ')"
+show "sessions for qualified user" "$(session_display "$sessions")"
+show "sessions of class user / manager" "$(session_class_count "$sessions" user) / $(session_class_count "$sessions" manager)"
 show "user@${TARGET_UID}.service" "$(systemctl is-active "user@${TARGET_UID}.service" 2>/dev/null || true)"
 pid="$(pgrep -u "$QUAL_USER" -f 'cli.js serve' | head -1 || true)"
 show "gateway pid" "${pid:-none}"
@@ -1101,6 +1174,27 @@ if [ -n "$pid" ]; then
 fi
 show "loopback probe (403 = up, closed)" "$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "http://127.0.0.1:${GATEWAY_PORT}/api/v1/sessions" 2>/dev/null || echo request-failed)"
 show "listeners on gateway port" "$(ss -ltnH "sport = :${GATEWAY_PORT}" | awk '{print $4}' | tr '\n' ' ' | grep . || echo none)"
+
+fail=0
+check() {
+  if [ "$2" = "$3" ]; then printf '   %-44s %-24s %s\n' "$1" "$2" PASS
+  else printf '   %-44s %-24s %s\n' "$1" "expected $3, got $2" FAIL; fail=1; fi
+}
+printf '\n   %-44s %-24s %s\n' INVARIANT OBSERVED RESULT
+if [ "$EXPECT_LINGER" = off ]; then
+  # Lingering disabled: nothing may have started the user manager, so the user owns no session of any
+  # class and no daemon exists. This is the control that gives the other pass its meaning.
+  check "no session of any class for the user" "$session_total" 0
+  check "no gateway daemon" "$(if [ -n "$pid" ]; then printf '%s' "$pid"; else printf 'none'; fi)" none
+else
+  # Lingering enabled: nobody is logged in, so no session of class `user` may exist. A `manager`
+  # session must exist, because that session *is* lingering having taken effect; its absence would
+  # mean the daemon came back for some other reason and the pass would prove nothing.
+  check "no session of class user" "$(session_class_count "$sessions" user)" 0
+  check "manager session present (lingering)" "$(if [ "$(session_class_count "$sessions" manager)" -ge 1 ]; then printf 'present'; else printf 'absent'; fi)" present
+  check "gateway daemon present" "$(if [ -n "$pid" ]; then printf 'present'; else printf 'absent'; fi)" present
+fi
+[ "$fail" -eq 0 ] || { echo "reboot persistence invariants failed with lingering $EXPECT_LINGER" >&2; exit 1; }
 REMOTE
 }
 
@@ -1119,7 +1213,7 @@ loginctl disable-linger "$QUAL_USER"
 printf '   %-38s %s\n' "linger marker:" "$(test -e "/var/lib/systemd/linger/$QUAL_USER" && echo present || echo absent)"
 REMOTE
   reboot_and_wait
-  measure_after_reboot "pass A (lingering off)" "$uid"
+  measure_after_reboot "pass A (lingering off)" "$uid" off
 
   note "pass A follow-up: a login session should pull the unit in through default.target"
   remote_user <<'REMOTE'
@@ -1146,9 +1240,11 @@ show "linger marker" "$(test -e "/var/lib/systemd/linger/$QUAL_USER" && echo pre
 show "loginctl Linger property" "$(loginctl show-user "$QUAL_USER" --property=Linger --value 2>/dev/null || echo unavailable)"
 REMOTE
   reboot_and_wait
-  measure_after_reboot "pass B (lingering on)" "$uid"
-  note "Pass B proves persistence only because the session count is zero: the daemon is running with"
-  note "nobody logged in, and its age tracks system uptime rather than the age of our connection."
+  measure_after_reboot "pass B (lingering on)" "$uid" on
+  note "Pass B proves persistence because no session of class 'user' exists: the only session the"
+  note "qualified user owns is the 'manager' session that lingering itself creates, which is why the"
+  note "count is one rather than zero. Nobody is logged in, and the daemon's age tracks system uptime"
+  note "rather than the age of our connection."
 }
 
 # Explicit forward upgrade and rollback on a real systemd user manager. `qualify-rollback.sh` proves
@@ -1267,6 +1363,564 @@ check "listener loopback only after rollback" "$(printf '%s' "$(field "$c" 9)" |
 
 [ "$fail" -eq 0 ] || { echo "migration invariants failed" >&2; exit 1; }
 REMOTE
+}
+
+# Lane `rollback`: the `omp-gateway rollback` command itself, on a real systemd user manager.
+#
+# WHY THIS IS NOT LANE 4 AGAIN. Lane 4 walks predecessor -> successor -> predecessor and every one of
+# its three steps is an `install` of an archive root. That is rollback-by-reinstall. PR #78 added a
+# second and different code path: `omp-gateway rollback` resolves a target from
+# `installation/history.json`, refuses rather than guessing when the history cannot name one,
+# rewrites the service definition from that target, and rebuilds the definition from `current.json`
+# when its own activation fails. An install exercises none of that, and `scripts/qualify-rollback.sh`
+# cannot either: the command postdates that harness, and it installs with `--no-start` throughout so
+# nothing there is ever activated at all.
+#
+# This lane therefore asserts lane 4's class of invariants around the command, and deliberately does
+# not re-measure five things lane 4 already establishes on the reinstall path: that a predecessor
+# install names a version, that the active version changes on the forward upgrade, that the
+# predecessor's version directory survives that upgrade, that the unit stays `enabled`, and that a
+# reinstall preserves configuration and the publisher token. Those are lane 4's rows. They are
+# printed here wherever they are cheap to read and never asserted, because two overlapping sources of
+# truth for one claim are worse than one.
+#
+# WHAT IT NEEDS ON THE DROPLET. Lane 4's two extracted roots, ~/runtime-prev and ~/runtime-root, and
+# the install lane 4 left behind. Both are read and neither is written: this lane downloads nothing
+# and stages nothing, so the archives it measures are exactly the ones lane 4 verified by checksum
+# and Cosign bundle. It needs the same two candidate tags lane 4 needs and has no knob of its own.
+#
+# WHICH STAGED DIRECTORY IS WHICH ARTIFACT. Answered by digest, not by `current.json` and not by the
+# activation history: the installer copies a `.js` CLI into the staged runtime verbatim, in both
+# artifacts, so a staged version directory whose `apps/gateway/src/cli.js` matches an archive's byte
+# for byte was staged from that archive. Every "it went back to the predecessor" claim below is
+# anchored to that, so none of them can be satisfied by a pointer that merely changed.
+#
+# WHY THE WALK STARTS WITH A REFUSAL, THEN `--to`. A bare `rollback` resolves its target from the
+# activation history, and the history is written only by the CLI that performs an activation. A
+# predecessor artifact older than PR #78 records nothing, so the history can name only what the newer
+# artifact activated and a bare `rollback` must refuse to guess. That refusal is a safety property, so
+# it is asserted first, with its message compared against the one installation.ts documents. Two
+# explicit `rollback --to` invocations then follow: they are half of what this lane has to exercise
+# anyway, they are recorded whichever artifact is installed because the newer CLI performs them, and
+# they leave a history whose predecessor is known. Only then is the bare command run, twice, so the
+# documented oscillation between two versions is measured rather than assumed.
+lane_rollback() {
+  local dns_name
+  step "Lane 8: the rollback command, its --to form, and induced divergence"
+  dns_name="$(require_dns_name)"
+
+  remote_user DNS_NAME="$dns_name" ALLOWED_LOGIN="$SYNTHETIC_DENIED_LOGIN" \
+    GATEWAY_PORT="$GATEWAY_PORT" <<'REMOTE'
+set -euo pipefail
+show() { printf '   %-38s %s\n' "$1:" "$2"; }
+bun=~/.bun/bin/bun
+state_dir="$HOME/.local/state/omp-session-gateway"
+versions="$state_dir/installation/versions"
+pointer="$state_dir/installation/current.json"
+history="$state_dir/installation/history.json"
+unit="$HOME/.config/systemd/user/omp-session-gateway.service"
+config="$HOME/.config/omp-session-gateway/config.json"
+token="$HOME/.config/omp-session-gateway/publisher-token"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+digest_of() { sha256sum "$1" | awk '{print $1}'; }
+clip() { printf '%.12s' "$1"; }
+# Nanosecond mtime, kept as its printed form: the pointer write and the history append are
+# consecutive awaits inside one command and whole seconds cannot order two writes that fast.
+mtime_of() { if [ -f "$1" ]; then stat -c '%.9Y' "$1"; else printf '0'; fi; }
+pointer_version() { if [ -f "$pointer" ]; then jq -r '.versionDirectory' "$pointer"; else printf 'absent'; fi; }
+version_dirs() { find "$versions" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort; }
+history_entries() { if [ -f "$history" ]; then jq -r '.activations[]' "$history"; fi; }
+history_count() { history_entries | grep -c . || true; }
+history_last() { history_entries | tail -1 | grep . || printf 'none'; }
+main_pid() { systemctl --user show -p MainPID --value omp-session-gateway.service; }
+unit_enabled() { systemctl --user is-enabled omp-session-gateway.service 2>&1 || true; }
+# Which shape the unit file has, independent of which staged runtime its ExecStart executes. The CLI
+# that last wrote the definition decides this, so a mixed-version droplet can hold a post-#69 unit
+# executing an older runtime, or the reverse.
+unit_shape() {
+  if grep -q '^RuntimeDirectory=omp-session-gateway$' "$unit"; then printf 'RuntimeDirectory='
+  else printf 'ReadWritePaths-only'; fi
+}
+listener() {
+  ss -ltnH "sport = :${GATEWAY_PORT}" | awk '{print $4}' | sort | tr '\n' ' ' | sed 's/ *$//' |
+    grep . || printf 'none'
+}
+loopback_only() {
+  if [ "$(listener)" = "127.0.0.1:${GATEWAY_PORT}" ]; then printf 'loopback'; else listener; fi
+}
+
+# The unit FILE is what the CLI reads to decide whether the definition and the pointer agree; the
+# LOADED unit is what systemd would actually execute. They agree only after a daemon-reload, so both
+# are measured, separately, every time.
+unit_exec_path() {
+  grep -o '"[^"]*/installation/versions/[^"]*/apps/gateway/src/cli\.js"' "$unit" |
+    head -1 | tr -d '"' | grep . || printf 'no-versioned-path'
+}
+version_of_path() {
+  case "$1" in
+    */installation/versions/*) printf '%s' "$1" | sed 's|.*/installation/versions/\([^/]*\)/.*|\1|' ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+unit_version() { version_of_path "$(unit_exec_path)"; }
+loaded_exec_version() {
+  local value
+  value="$(systemctl --user show -p ExecStart --value omp-session-gateway.service |
+    grep -o '/installation/versions/[^/]*/' | head -1 || true)"
+  if [ -z "$value" ]; then printf 'none'; else printf '%s' "$value" | sed 's|.*/versions/\([^/]*\)/|\1|'; fi
+}
+
+# A restart is asynchronous, so reading the listener the instant a command returns is a false
+# negative rather than a finding. Bounded, and the wait it actually needed is printed.
+LISTENER_WAIT=""
+await_listener() {
+  local index=0
+  while [ "$index" -lt 30 ]; do
+    if [ "$(loopback_only)" = "loopback" ]; then
+      LISTENER_WAIT="${index}s"
+      printf 'loopback'
+      return 0
+    fi
+    sleep 1
+    index=$((index + 1))
+  done
+  LISTENER_WAIT="timed out after 30s"
+  loopback_only
+}
+
+status_quad() {
+  printf '%s' "$1" |
+    jq -r '[(.installed|tostring),(.active|tostring),(.ready|tostring),(.diverged|tostring)] | join("/")' 2>/dev/null ||
+    printf 'unparseable'
+}
+# `//` is wrong here: jq's alternative operator also fires on `false`, which is exactly the value
+# `.diverged` carries when nothing is wrong.
+status_field() {
+  printf '%s' "$1" | jq -r --arg key "$2" 'if has($key) then (.[$key] | tostring) else "absent" end' 2>/dev/null ||
+    printf 'unparseable'
+}
+# Exact, not floating point. Both values are ten digits, a dot, then nine digits until the year 2286,
+# so removing the dot leaves equal-length digit strings that compare correctly as strings. Feeding
+# them to awk as numbers would land on the edge of double precision at nanosecond scale.
+later_or_equal() {
+  awk -v first="$1" -v second="$2" 'BEGIN {
+    gsub(/\./, "", first); gsub(/\./, "", second)
+    print ((second "") >= (first "")) ? "after" : "before"
+  }'
+}
+contains() { if grep -qF -- "$2" "$1"; then printf 'present'; else printf 'absent'; fi; }
+
+CHECKS=0
+FAILURES=0
+check() {
+  CHECKS=$((CHECKS + 1))
+  if [ "$2" = "$3" ]; then printf '   %-48s %-30s %s\n' "$1" "$2" PASS
+  else printf '   %-48s %-30s %s\n' "$1" "expected $3, got $2" FAIL; FAILURES=$((FAILURES + 1)); fi
+}
+table_head() { printf '   %-48s %-30s %s\n' INVARIANT OBSERVED RESULT; }
+
+# ---------------------------------------------------------------- preconditions and identification
+[ -s ~/runtime-root ] || {
+  echo "~/runtime-root is missing: lane 'artifact' extracts the candidate. Run 'qualify artifact lifecycle migration' first." >&2
+  exit 1
+}
+next_root="$(cat ~/runtime-root)"
+prev_root="$(find ~/runtime-prev -maxdepth 1 -mindepth 1 -type d 2>/dev/null | head -1 || true)"
+[ -n "$prev_root" ] || {
+  echo "~/runtime-prev holds no extracted archive. Lane 'migration' puts the predecessor there, and it skips itself when OMP_QUAL_PREVIOUS_TAG equals OMP_QUAL_RELEASE_TAG. Run 'qualify migration' with two different published candidate tags first." >&2
+  exit 1
+}
+# Every rollback here is driven by the candidate's CLI: it is the newer of the two artifacts, it is
+# what an operator on this box would reach for, and the predecessor may predate the command entirely.
+cli="$next_root/apps/gateway/src/cli.js"
+grep -q -a -F 'refusing to guess a rollback target' "$cli" || {
+  echo "the candidate artifact carries no rollback target resolver, so it predates PR #78 and there is no command for this lane to exercise. Point OMP_QUAL_RELEASE_TAG at a candidate that has it." >&2
+  exit 1
+}
+systemctl --user is-active omp-session-gateway.service >/dev/null || {
+  echo "the gateway service is not active, and rollback refuses without an installed active service. Run 'qualify lifecycle migration' first." >&2
+  exit 1
+}
+
+version_for_archive() {
+  local want dir
+  want="$(digest_of "$1/apps/gateway/src/cli.js")"
+  while read -r dir; do
+    [ -f "$versions/$dir/apps/gateway/src/cli.js" ] || continue
+    if [ "$(digest_of "$versions/$dir/apps/gateway/src/cli.js")" = "$want" ]; then
+      printf '%s' "$dir"
+      return 0
+    fi
+  done < <(version_dirs)
+  printf 'none'
+}
+prev_version="$(version_for_archive "$prev_root")"
+next_version="$(version_for_archive "$next_root")"
+
+show "predecessor archive root" "$(basename "$prev_root")"
+show "candidate archive root" "$(basename "$next_root")"
+show "predecessor staged as" "$prev_version"
+show "candidate staged as" "$next_version"
+show "version directories present" "$(version_dirs | tr '\n' ' ')"
+show "activations recorded / last" "$(history_count) / $(history_last)"
+show "active version directory" "$(pointer_version)"
+show "unit file / loaded version" "$(unit_version) / $(loaded_exec_version)"
+show "unit file shape" "$(unit_shape)"
+show "unit enabled (lane 4 asserts this)" "$(unit_enabled)"
+
+[ "$prev_version" != none ] && [ "$next_version" != none ] || {
+  echo "one of the two archives has no staged version directory whose CLI matches it byte for byte, so this droplet was not left by lane 'migration'. Run 'qualify migration' immediately before this lane." >&2
+  exit 1
+}
+[ "$prev_version" != "$next_version" ] || {
+  echo "both archives stage the same version directory $prev_version, so there is no second version to roll back to. Name two different published candidate tags." >&2
+  exit 1
+}
+[ "$(version_dirs | grep -c .)" -ge 2 ] || {
+  echo "fewer than two installed version directories, so no predecessor is retained and rollback must refuse." >&2
+  exit 1
+}
+case "$(pointer_version)" in
+  "$prev_version" | "$next_version") ;;
+  *)
+    echo "current.json names $(pointer_version), which is neither archive's staged directory. Run 'qualify migration' immediately before this lane." >&2
+    exit 1
+    ;;
+esac
+
+# Baselines for "survived byte-identically". Read once, before the first command, compared in full,
+# and only ever printed as their first twelve hex digits.
+BASE_CONFIG="$(digest_of "$config")"
+BASE_TOKEN="$(digest_of "$token")"
+BASE_TOKEN_MODE="$(stat -c '%a' "$token")"
+show "baseline config / token digest" "$(clip "$BASE_CONFIG") / $(clip "$BASE_TOKEN")"
+show "baseline token mode" "$BASE_TOKEN_MODE"
+
+# The same rule installation.ts documents for a `--to`-less rollback: the newest recorded activation
+# before the last activation of whatever is active now, skipping repeats. Computed here rather than
+# trusted, so both "it refused because there is none" and "it returned to the recorded predecessor"
+# are independent claims about history.json rather than restatements of the command's own output.
+recorded_predecessor() {
+  history_entries | awk -v active="$1" '
+    { line[NR] = $0; if ($0 == active) last = NR }
+    END { for (index_ = last - 1; index_ >= 1; index_--) if (line[index_] != active) { print line[index_]; exit } }'
+}
+
+# ---------------------------------------------------------------- one measured rollback
+# Every successful invocation goes through these two functions, so a later step cannot quietly be
+# measured more loosely than an earlier one and the table reads as a sequence rather than as a set of
+# special cases.
+ROLL_FROM=""; ROLL_TO=""; ROLL_OUTPUT=""; ROLL_PID_BEFORE=""; ROLL_PID=""
+ROLL_UNIT_PATH=""; ROLL_UNIT_VERSION=""; ROLL_LOADED_VERSION=""; ROLL_LISTENER=""; ROLL_ABS=""
+ROLL_CONFIG=""; ROLL_TOKEN=""; ROLL_TOKEN_MODE=""; ROLL_ENABLED=""; ROLL_SHAPE=""
+ROLL_HISTORY_BEFORE=""; ROLL_HISTORY=""; ROLL_HISTORY_LAST=""; ROLL_HISTORY_LAST_BEFORE=""
+ROLL_POINTER_MTIME=""; ROLL_HISTORY_MTIME=""; ROLL_STATUS=""
+
+roll() {
+  printf '\n   -- %s --\n' "$1"
+  shift
+  ROLL_FROM="$(pointer_version)"
+  ROLL_PID_BEFORE="$(main_pid)"
+  ROLL_HISTORY_BEFORE="$(history_count)"
+  ROLL_HISTORY_LAST_BEFORE="$(history_last)"
+  ROLL_OUTPUT="$("$bun" "$cli" rollback "$@" | tr '\n' ' ')"
+  ROLL_TO="$(pointer_version)"
+  ROLL_UNIT_PATH="$(unit_exec_path)"
+  ROLL_UNIT_VERSION="$(version_of_path "$ROLL_UNIT_PATH")"
+  ROLL_LOADED_VERSION="$(loaded_exec_version)"
+  ROLL_PID="$(main_pid)"
+  ROLL_LISTENER="$(await_listener)"
+  ROLL_CONFIG="$(digest_of "$config")"
+  ROLL_TOKEN="$(digest_of "$token")"
+  ROLL_TOKEN_MODE="$(stat -c '%a' "$token")"
+  ROLL_ENABLED="$(unit_enabled)"
+  ROLL_SHAPE="$(unit_shape)"
+  ROLL_HISTORY="$(history_count)"
+  ROLL_HISTORY_LAST="$(history_last)"
+  ROLL_POINTER_MTIME="$(mtime_of "$pointer")"
+  ROLL_HISTORY_MTIME="$(mtime_of "$history")"
+  ROLL_STATUS="$("$bun" "$cli" status || true)"
+  case "$ROLL_UNIT_PATH" in
+    /*/installation/versions/*/apps/gateway/src/cli.js) ROLL_ABS="absolute" ;;
+    *) ROLL_ABS="$ROLL_UNIT_PATH" ;;
+  esac
+  show "command" "rollback${*:+ $*}"
+  show "output" "$ROLL_OUTPUT"
+  show "current.json" "$ROLL_FROM -> $ROLL_TO"
+  show "unit file / loaded version" "$ROLL_UNIT_VERSION / $ROLL_LOADED_VERSION"
+  show "unit ExecStart path" "$(printf '%s' "$ROLL_UNIT_PATH" | sed "s|^$HOME|~|")"
+  show "unit file shape" "$ROLL_SHAPE"
+  show "daemon main pid" "$ROLL_PID_BEFORE -> $ROLL_PID"
+  show "listener / wait" "$ROLL_LISTENER / $LISTENER_WAIT"
+  show "config / token digest" "$(clip "$ROLL_CONFIG") / $(clip "$ROLL_TOKEN")"
+  show "token mode / unit enabled" "$ROLL_TOKEN_MODE / $ROLL_ENABLED"
+  show "activations / last" "$ROLL_HISTORY_BEFORE -> $ROLL_HISTORY / $ROLL_HISTORY_LAST"
+  show "current.json / history mtime" "$ROLL_POINTER_MTIME / $ROLL_HISTORY_MTIME"
+  show "status" "$ROLL_STATUS"
+}
+
+# $1 = row prefix, $2 = version directory the command had to activate, $3 = selection word it had to
+# report. Paired values are folded into one row each so the observed column stays readable while
+# still naming both halves of a mismatch.
+assert_roll() {
+  local expected_activations=1
+  # Activation history is deliberately idempotent: re-activating the version the history already ends
+  # with appends nothing, so that a run of identical entries cannot evict a genuine predecessor. The
+  # expected delta is therefore derived from what the history held, not fixed at one.
+  [ "$ROLL_HISTORY_LAST_BEFORE" != "$2" ] || expected_activations=0
+  table_head
+  check "$1: current.json names the target" "$ROLL_TO" "$2"
+  check "$1: reported selection" "$(if printf '%s' "$ROLL_OUTPUT" | grep -qF "($3)"; then printf '%s' "$3"; else printf 'not reported'; fi)" "$3"
+  check "$1: definition and loaded unit follow" "$ROLL_UNIT_VERSION / $ROLL_LOADED_VERSION" "$2 / $2"
+  check "$1: ExecStart absolute and versioned" "$ROLL_ABS" absolute
+  check "$1: daemon restarted" "$(if [ "$ROLL_PID_BEFORE" != "$ROLL_PID" ]; then printf 'changed'; else printf 'same'; fi)" changed
+  check "$1: listener bound, loopback only" "$ROLL_LISTENER" loopback
+  check "$1: config and token survived" "$(if [ "$ROLL_CONFIG" = "$BASE_CONFIG" ] && [ "$ROLL_TOKEN" = "$BASE_TOKEN" ]; then printf 'identical'; else printf 'differs'; fi)" identical
+  check "$1: token mode unchanged" "$ROLL_TOKEN_MODE" "$BASE_TOKEN_MODE"
+  check "$1: activations recorded" "$((ROLL_HISTORY - ROLL_HISTORY_BEFORE))" "$expected_activations"
+  check "$1: last activation is the pointer" "$ROLL_HISTORY_LAST" "$ROLL_TO"
+  # Only meaningful when something was appended. When the history already ended with this version
+  # nothing was rewritten, so its mtime is legitimately older than the pointer's and an unconditional
+  # ordering row would fail on correct behaviour. Say which case it was instead of hiding either.
+  check "$1: history appended after the pointer" \
+    "$(if [ "$expected_activations" -eq 1 ]; then later_or_equal "$ROLL_POINTER_MTIME" "$ROLL_HISTORY_MTIME"; else printf 'nothing appended'; fi)" \
+    "$(if [ "$expected_activations" -eq 1 ]; then printf 'after'; else printf 'nothing appended'; fi)"
+  check "$1: installed/active/ready/diverged" "$(status_quad "$ROLL_STATUS")" "true/true/true/false"
+}
+
+# ---------------------------------------------------------------- W0: what a bare rollback does first
+printf '\n   -- W0: rollback with no --to, against whatever lane 4 left recorded --\n'
+w0_active="$(pointer_version)"
+w0_expected="$(recorded_predecessor "$w0_active" | grep . || printf 'none')"
+w0_pid_before="$(main_pid)"
+w0_unit_before="$(unit_version)"
+w0_history_before="$(history_count)"
+w0_history_last_before="$(history_last)"
+show "active version directory" "$w0_active"
+show "activations recorded" "$(history_entries | tr '\n' ' ' | sed 's/ *$//' | grep . || printf 'none')"
+show "recorded predecessor, computed here" "$w0_expected"
+w0_rc=0
+"$bun" "$cli" rollback >"$work/w0.log" 2>&1 || w0_rc=$?
+show "exit code" "$w0_rc"
+show "output" "$(head -c 240 "$work/w0.log" | tr '\n' ' ')"
+show "current.json after" "$(pointer_version)"
+show "unit file version after" "$(unit_version)"
+show "daemon main pid" "$w0_pid_before -> $(main_pid)"
+
+if [ "$w0_expected" = none ]; then
+  # The predecessor artifact predates PR #78, so it recorded no activation of its own and the command
+  # has nothing to resolve. Refusing is the safety property; the message rows are transcribed from
+  # apps/gateway/src/installation.ts, so a FAIL among them is a discrepancy between the command and
+  # its own documented refusal, to be reported rather than absorbed by loosening this lane.
+  printf '\n   %s\n' "No activation is recorded for the active version, so the documented behaviour is a"
+  printf '   %s\n' "refusal that changes nothing. The message rows are transcribed from installation.ts."
+  table_head
+  check "W0: refuses without a recorded predecessor" "$(if [ "$w0_rc" -ne 0 ]; then printf 'refused'; else printf 'accepted'; fi)" refused
+  check "W0: exit code" "$w0_rc" 1
+  check "W0: message refuses to guess" "$(contains "$work/w0.log" 'refusing to guess a rollback target')" present
+  check "W0: message names the remedy" "$(contains "$work/w0.log" 'pass --to <version-directory>')" present
+  check "W0: message lists installed versions" "$(contains "$work/w0.log" 'installed: ')" present
+  check "W0: refusal changed no pointer" "$(pointer_version)" "$w0_active"
+  check "W0: refusal changed no definition" "$(unit_version)" "$w0_unit_before"
+  w0_history_after="$(history_count)"
+  check "W0: refusal recorded no activation" "$((w0_history_after - w0_history_before))" 0
+  check "W0: refusal did not restart the daemon" "$(if [ "$w0_pid_before" = "$(main_pid)" ]; then printf 'unchanged'; else printf 'restarted'; fi)" unchanged
+else
+  # Both artifacts record activations, so the bare command has a predecessor to resolve and must land
+  # on the one computed above. Measured with the same routine as every later invocation.
+  printf '\n   %s\n' "A predecessor is recorded, so the documented behaviour is a rollback onto it."
+  ROLL_FROM="$w0_active"
+  ROLL_PID_BEFORE="$w0_pid_before"
+  ROLL_HISTORY_BEFORE="$w0_history_before"
+  ROLL_HISTORY_LAST_BEFORE="$w0_history_last_before"
+  ROLL_OUTPUT="$(tr '\n' ' ' <"$work/w0.log")"
+  ROLL_TO="$(pointer_version)"
+  ROLL_UNIT_PATH="$(unit_exec_path)"
+  ROLL_UNIT_VERSION="$(version_of_path "$ROLL_UNIT_PATH")"
+  ROLL_LOADED_VERSION="$(loaded_exec_version)"
+  ROLL_PID="$(main_pid)"
+  ROLL_LISTENER="$(await_listener)"
+  ROLL_CONFIG="$(digest_of "$config")"
+  ROLL_TOKEN="$(digest_of "$token")"
+  ROLL_TOKEN_MODE="$(stat -c '%a' "$token")"
+  ROLL_HISTORY="$(history_count)"
+  ROLL_HISTORY_LAST="$(history_last)"
+  ROLL_POINTER_MTIME="$(mtime_of "$pointer")"
+  ROLL_HISTORY_MTIME="$(mtime_of "$history")"
+  ROLL_STATUS="$("$bun" "$cli" status || true)"
+  case "$ROLL_UNIT_PATH" in
+    /*/installation/versions/*/apps/gateway/src/cli.js) ROLL_ABS="absolute" ;;
+    *) ROLL_ABS="$ROLL_UNIT_PATH" ;;
+  esac
+  table_head
+  check "W0: succeeded with a recorded predecessor" "$(if [ "$w0_rc" -eq 0 ]; then printf 'accepted'; else printf 'exit %s' "$w0_rc"; fi)" accepted
+  assert_roll W0 "$w0_expected" recorded-predecessor
+fi
+
+# ---------------------------------------------------------------- the walk
+# Recomputed after W0, because its successful branch moves the pointer and every step below is
+# defined against wherever the command actually left it.
+start_version="$(pointer_version)"
+if [ "$start_version" = "$prev_version" ]; then other_version="$next_version"; else other_version="$prev_version"; fi
+
+roll "W1: rollback --to $other_version, the version that is not active" --to "$other_version"
+assert_roll W1 "$other_version" requested
+
+roll "W2: rollback --to $start_version, back again, which seeds the history" --to "$start_version"
+assert_roll W2 "$start_version" requested
+
+roll "W3: rollback with no --to, which must now resolve a recorded predecessor"
+assert_roll W3 "$other_version" recorded-predecessor
+check "W3: target matches the history, read here" "$other_version" "$(recorded_predecessor "$start_version" | grep . || printf 'none')"
+
+roll "W4: rollback again, which must oscillate back"
+assert_roll W4 "$start_version" recorded-predecessor
+
+# The divergence step needs the predecessor active: it has to point the definition at a version the
+# pointer does not name, and the only reachable direction is definition-newer. The walk ends where it
+# started, so one more bare rollback is needed exactly when the lane began on the candidate.
+if [ "$(pointer_version)" != "$prev_version" ]; then
+  roll "W5: rollback once more, to reach the predecessor"
+  assert_roll W5 "$prev_version" recorded-predecessor
+else
+  printf '\n   %s\n' "W5 not needed: the walk already ends on the predecessor $prev_version."
+fi
+
+# ---------------------------------------------------------------- D: induced divergence
+printf '\n   -- D: induced divergence, definition newer than current.json --\n'
+[ "$(pointer_version)" = "$prev_version" ] && [ "$(unit_version)" = "$prev_version" ] || {
+  echo "the walk did not end with both current.json and the service definition on $prev_version, so the divergence below would not be the documented direction. Refusing to induce it." >&2
+  exit 1
+}
+# install and rollback both write the service definition first and advance current.json only once the
+# new runtime has proven loopback readiness, so exactly one divergence direction is reachable: a
+# crash between those two writes leaves the definition naming a NEWER version than the pointer.
+# Reproduce that by hand, including the restart a real crash would already have completed, so the
+# daemon genuinely executes the version the pointer does not name.
+diverge_pid_before="$(main_pid)"
+sed -i "s|/installation/versions/${prev_version}/|/installation/versions/${next_version}/|g" "$unit"
+systemctl --user daemon-reload
+systemctl --user restart omp-session-gateway.service
+diverged_listener="$(await_listener)"
+diverged_unit_version="$(unit_version)"
+diverged_loaded_version="$(loaded_exec_version)"
+diverged_pointer="$(pointer_version)"
+diverged_history="$(history_count)"
+diverged_pid="$(main_pid)"
+show "unit file / loaded version" "$diverged_unit_version / $diverged_loaded_version"
+show "current.json still names" "$diverged_pointer"
+show "daemon main pid" "$diverge_pid_before -> $diverged_pid"
+show "listener / wait" "$diverged_listener / $LISTENER_WAIT"
+
+status_rc=0
+diverged_status="$("$bun" "$cli" status 2>"$work/status.err")" || status_rc=$?
+show "status" "$diverged_status"
+show "status exit code" "$status_rc"
+show "status stderr" "$(head -c 240 "$work/status.err" | tr '\n' ' ')"
+
+# `status` names two remedies: `rollback --to <version>` or a reinstall. With two installed versions
+# the command cannot reach the conservative outcome at all -- naming the pointer's own version is
+# refused, and every other target adopts a version the pointer never proved -- so the refusal is
+# measured here and the repair below is the reinstall. The command did not perform this repair, and
+# no third version is manufactured to pretend otherwise.
+refusal_rc=0
+"$bun" "$cli" rollback --to "$prev_version" >"$work/refusal.log" 2>&1 || refusal_rc=$?
+# Captured before the repair runs, because the repair rewrites the very definition this asserts was
+# left untouched.
+refusal_unit_version="$(unit_version)"
+refusal_pointer="$(pointer_version)"
+show "rollback --to <active> exit" "$refusal_rc"
+show "rollback --to <active> message" "$(head -c 240 "$work/refusal.log" | tr '\n' ' ')"
+show "after refusal: unit / pointer" "$refusal_unit_version / $refusal_pointer"
+
+repair_pid_before="$(main_pid)"
+"$bun" "$prev_root/apps/gateway/src/cli.js" install \
+  --origin "https://${DNS_NAME}" --allow "$ALLOWED_LOGIN" >/dev/null
+repair_pointer="$(pointer_version)"
+repair_unit_version="$(unit_version)"
+repair_loaded_version="$(loaded_exec_version)"
+repair_pid="$(main_pid)"
+repair_listener="$(await_listener)"
+repair_history="$(history_count)"
+repair_status="$("$bun" "$cli" status || true)"
+show "repair: current.json" "$diverged_pointer -> $repair_pointer"
+show "repair: unit file / loaded" "$repair_unit_version / $repair_loaded_version"
+show "repair: unit file shape" "$(unit_shape)"
+show "repair: daemon main pid" "$repair_pid_before -> $repair_pid"
+show "repair: listener / wait" "$repair_listener / $LISTENER_WAIT"
+show "repair: activations recorded" "$diverged_history -> $repair_history"
+show "repair: status" "$repair_status"
+show "repair: config / token digest" "$(clip "$(digest_of "$config")") / $(clip "$(digest_of "$token")")"
+show "repair: unit enabled" "$(unit_enabled)"
+
+table_head
+check "D: induced definition is the newer version" "$diverged_unit_version" "$next_version"
+check "D: induced pointer stays the older one" "$diverged_pointer" "$prev_version"
+check "D: the daemon really ran the newer one" "$diverged_loaded_version" "$next_version"
+check "D: the restart really happened" "$(if [ "$diverge_pid_before" != "$diverged_pid" ]; then printf 'changed'; else printf 'same'; fi)" changed
+check "D: listener bound while diverged" "$diverged_listener" loopback
+check "D: status reports the divergence" "$(status_field "$diverged_status" diverged)" true
+check "D: status names the pointer version" "$(status_field "$diverged_status" activeVersion)" "$prev_version"
+check "D: status names the definition version" "$(status_field "$diverged_status" serviceVersion)" "$next_version"
+check "D: status exits non-zero while diverged" "$(if [ "$status_rc" -ne 0 ]; then printf 'nonzero'; else printf 'zero'; fi)" nonzero
+check "D: status stderr says DIVERGED" "$(contains "$work/status.err" 'DIVERGED')" present
+check "D: rollback --to the active version refuses" "$(if [ "$refusal_rc" -ne 0 ]; then printf 'refused'; else printf 'accepted'; fi)" refused
+check "D: refusal names the active version" "$(contains "$work/refusal.log" 'refusing rollback to the active version')" present
+check "D: refusal left the diverged state alone" "$refusal_unit_version / $refusal_pointer" "$next_version / $prev_version"
+check "D: repair keeps the older proven version" "$repair_pointer" "$prev_version"
+check "D: repair rewrites definition and unit" "$repair_unit_version / $repair_loaded_version" "$prev_version / $prev_version"
+check "D: repair adopts nothing unrecorded" "$(if [ "$repair_pointer" != "$next_version" ] && [ "$repair_unit_version" != "$next_version" ]; then printf 'not adopted'; else printf 'adopted'; fi)" "not adopted"
+check "D: repair recorded no new activation" "$((repair_history - diverged_history))" 0
+check "D: repair cleared the divergence" "$(status_field "$repair_status" diverged)" false
+check "D: repair restarted the daemon" "$(if [ "$repair_pid_before" != "$repair_pid" ]; then printf 'changed'; else printf 'same'; fi)" changed
+check "D: listener bound after repair" "$repair_listener" loopback
+
+# ---------------------------------------------------------------- F: leave the candidate active
+# Not tidying. Every lane after this one measures whatever is installed, and the ledger's subject is
+# the candidate rather than its predecessor -- including lane `persistence`, which reboots, and which
+# a predecessor unit predating the RuntimeDirectory= fix would fail for reasons that are #69 and not
+# rollback. It is also a third `--to`, from a definition and pointer that were just repaired.
+roll "F: rollback --to $next_version, leaving the candidate active" --to "$next_version"
+assert_roll F "$next_version" requested
+check "F: droplet left on a post-#69 unit shape" "$ROLL_SHAPE" "RuntimeDirectory="
+
+printf '\n   Not checked here, and why:\n'
+printf '   %s\n' "* the conservative divergence repair was NOT performed by the rollback command. With"
+printf '   %s\n' "  two installed versions no invocation can do it: --to the pointer's own version is"
+printf '   %s\n' "  refused, and any other target adopts a version the pointer never proved. The"
+printf '   %s\n' "  reinstall measured above is the other remedy status prints, and it is what ran."
+printf '   %s\n' "* the opposite divergence direction, a pointer newer than the definition, is not"
+printf '   %s\n' "  induced because no command produces it: neither install nor rollback writes"
+printf '   %s\n' "  current.json before the service definition."
+printf '   %s\n' "* rollback's own repair path, the catch block that rebuilds the definition from"
+printf '   %s\n' "  current.json when an activation fails, is not reached. Reaching it needs a rollback"
+printf '   %s\n' "  whose target fails readiness, which means breaking a staged runtime, and a"
+printf '   %s\n' "  deliberately corrupted runtime is not evidence about this candidate."
+printf '   %s\n' "* the crash window between the two writes is not measured, only the state a crash"
+printf '   %s\n' "  inside it leaves and how the next command treats that state."
+printf '   %s\n' "* history.json ordering is shown by nanosecond mtime, which orders two writes and"
+printf '   %s\n' "  says nothing about atomicity. Those two writes are documented as not atomic."
+printf '   %s\n' "* the macOS harness's host-daemon and host-plist invariants have no analogue here:"
+printf '   %s\n' "  that harness protects a live daemon on the operator's own machine, and this"
+printf '   %s\n' "  droplet has one user, one service, and nothing to protect it from."
+printf '   %s\n' "* lane 4's five reinstall-path rows are printed above but never re-asserted here:"
+printf '   %s\n' "  predecessor install names a version, the active version changes on the forward"
+printf '   %s\n' "  upgrade, the predecessor directory survives it, the unit stays enabled, and a"
+printf '   %s\n' "  reinstall preserves config and token."
+
+if [ "$FAILURES" -eq 0 ]; then
+  printf '\n   %d/%d invariants PASS\n' "$CHECKS" "$CHECKS"
+else
+  printf '\n   %d of %d invariants FAILED\n' "$FAILURES" "$CHECKS"
+  echo "rollback invariants failed" >&2
+  exit 1
+fi
+REMOTE
+  note "The lane ends with the candidate active and a post-#69 unit, so later lanes measure the"
+  note "candidate. A failure between the induced divergence and its repair leaves the droplet"
+  note "deliberately diverged: re-run this lane, or reinstall, to rebuild the unit from current.json."
 }
 
 lane_uninstall() {
@@ -1444,18 +2098,18 @@ cmd_qualify() {
     if [ "$QUAL_INIT" = "openrc" ]; then
       lanes="host artifact init"
     else
-      lanes="host artifact lifecycle migration identity persistence uninstall"
+      lanes="host artifact lifecycle migration rollback identity persistence uninstall"
     fi
   fi
   # Reject a typo, and an impossible lane, before anything slow or billable is touched.
   for lane in $lanes; do
     case "$lane" in
       host | artifact | init) ;;
-      lifecycle | migration | identity | persistence | uninstall)
+      lifecycle | migration | rollback | identity | persistence | uninstall)
         [ "$QUAL_INIT" != "openrc" ] ||
           die "lane '$lane' needs an installed service, and on a non-systemd host the install is expected to be refused. Run 'host artifact init' instead, or unset OMP_QUAL_INIT to qualify a systemd droplet."
         ;;
-      *) die "unknown lane '$lane'; choose from host artifact lifecycle migration identity persistence uninstall init" ;;
+      *) die "unknown lane '$lane'; choose from host artifact lifecycle migration rollback identity persistence uninstall init" ;;
     esac
   done
 
@@ -1473,11 +2127,12 @@ cmd_qualify() {
       artifact) lane_artifact ;;
       lifecycle) lane_lifecycle ;;
       migration) lane_migration ;;
+      rollback) lane_rollback ;;
       identity) lane_identity ;;
       persistence) lane_persistence ;;
       uninstall) lane_uninstall ;;
       init) lane_init ;;
-      *) die "unknown lane '$lane'; choose from host artifact lifecycle migration identity persistence uninstall init" ;;
+      *) die "unknown lane '$lane'; choose from host artifact lifecycle migration rollback identity persistence uninstall init" ;;
     esac
   done
 


### PR DESCRIPTION
Two changes, both prompted by a real droplet run against candidate `.17`.

## The persistence fix matters more

Pass B printed `sessions for qualified user: 1` and then asserted, one line below, that the proof held *"only because the session count is zero"*. A reviewer reading that reasonably concludes the lane contradicts itself and distrusts the row.

**The product was never wrong.** That session is the systemd lingering-created user manager — verified live on the droplet as `class=manager, type=unspecified, remote=no`, while an SSH login appears separately as `class=user`. When lingering works the count can *never* be zero, so the count was simply the wrong measurement.

Both call sites now enumerate sessions **by class**, print each one, and assert what actually matters: no session of class `user` exists for the qualified user, and in pass B a `manager` session must be *present*, since its absence would mean lingering never took effect. `measure_after_reboot` also stopped being print-only and now fails.

## Lane `rollback`

The existing `migration` lane is titled "explicit upgrade and rollback" and passes 11/11, but it rolls back by **reinstalling the predecessor root** (`install_root "$prev_root"`). It never invokes the rollback command added in PR #78. Those are different code paths and only the first was covered, so the command, its `--to` form, `history.json` activation ordering, and induced divergence were all unproven on Linux.

The lane is honest about a limit it found: with only two versions installed, **no** rollback invocation can repair the divergence direction the docstring describes, so it measures the conservative reinstall that `status`'s DIVERGED message already prescribes and says so in its output rather than implying the command did it. Manufacturing a third version to make that case reachable would be testing a state the product cannot be in.

It also asserts the initial refusal explicitly: with `.13` as predecessor (whose installer predates `history.json`), a bare `rollback` correctly refuses because no activation of the active version is recorded. A rollback that refuses when it has no recorded predecessor is a safety property worth pinning.

Also adds `rollback` to the droplet workflow's lane whitelist, which would otherwise reject an explicit subset naming it.

## Verification

`bash -n` clean; `shellcheck -s bash` **zero findings** (baseline also zero). All **27** remote heredocs were extracted to individual files and parsed standalone, so a syntax error inside one cannot reach a real run. **38** helper unit tests against the heredoc's pure-shell functions with real bash/jq/awk, 38/38 pass — including the live `[V17]`-with-active-`V13` case and proof that a jq `//` default would wrongly report `diverged:false` as absent.

**Neither lane has been executed yet**, and `persistence` must be re-run because its assertions changed. That run is next.

## Ledger

No ledger, compatibility, or changelog file is touched. Promotes nothing.

## Threat-model impact

None to the running product — qualification tooling only. One prior teardown hazard was fixed on the way in the merged Alpine PR; this change adds no new external effect. The corrected persistence assertion strengthens an existing claim rather than relaxing it: it can now fail where it previously only printed.
