### PR TITLE
docs(release): mark blocker 5 closed

### DIFF
--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -176,8 +176,8 @@ The alpha decision remains **NO-GO** until, at minimum:
    discussed before the branch without re-reading the file. It also correctly reported the branched
    timeline's bullet count rather than the file's, which is worth knowing — a branch forks the
    conversation, not the filesystem;
-5. the native, Tailscale, relay, Android, browser, and signed-artifact rows are re-run at the
-   current `v17.3.8` pin. **Audited 2026-08-20**: of the 23 ledger rows, **10 are current**
+5. ~~the native, Tailscale, relay, Android, browser, and signed-artifact rows are re-run at the
+   current `v17.3.8` pin~~ — **closed 2026-08-21**. No ledger row is stale or indeterminate. **Audited 2026-08-20**: of the 23 ledger rows, **10 are current**
    (evidence at the refreshed pin or from a candidate built after it), **6 were stale**; **three
    have since been re-run at `v0.1.0-prealpha.17` on 2026-08-20/21** (Release signing/SBOM/provenance,
    Fifty-publisher capacity, and the host half of Three real OMP processes auto-discover), and on 2026-08-21 the remaining **three Android rows were re-run**


### PR DESCRIPTION
Every ledger row is now either current at the refreshed `v17.3.8` pin, or explicitly classified as pin-independent with its reason stated. Nothing is stale; nothing is indeterminate.

**Blocker 3 is the only one still open**, and its remaining gap — network-change and reconnect — is blocked by [#65](https://github.com/alphastorm/omp-session-gateway/issues/65), a Chrome-for-Android defect measured with the device demonstrably healthy.

Blockers now: **1, 2, 4, 5, 6, 7 closed; 3 open.**

## Threat-model impact

None. One blocker marked closed against evidence already merged in #93, #94, #95 and #96.