### PR TITLE
docs(release): alpha decision is GO for two hosts and one client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
 
 ## [Unreleased]
 
+### Added
+
+- **Alpha decision is GO** for two host platforms and one client, against candidate
+  `v0.1.0-prealpha.17`: Debian 13 (trixie) x86-64 and macOS 26.6.1 arm64 as hosts, with Chrome
+  `151.0.7922.139` on Android 17 as the client. All six release blockers are closed. Nothing outside
+  that combination is advertised, and the scope rule is unchanged: passing a platform permits
+  advertising only that exact platform and version.
+- `doctor` now withholds `listenerLoopbackOnly` when tailscaled owns no TUN device. A loopback bind
+  address is necessary but not sufficient, because userspace-networking `tailscaled` forwards inbound
+  tailnet connections to localhost and the caller then arrives as a loopback peer that `auth.ts`
+  trusts ([#98](https://github.com/alphastorm/omp-session-gateway/issues/98)).
+- A scheduled capacity workflow and an evidence checker that compares machine-readable qualification
+  records against the ledger, so a claim that contradicts its own measurement fails mechanically
+  rather than relying on someone rereading a log.
+- `omp-gateway rollback` is qualified on Linux, and a Linux lane now exercises the command itself
+  rather than only rollback-by-reinstall.
+
+### Security
+
+- `SECURITY.md` now names userspace-mode `tailscaled` as a forwarder that defeats loopback trust.
+  This was previously implied by a general rule about tunnels and reverse proxies; it is now stated
+  explicitly because it is the forwarder an operator is most likely to run, and because it was
+  demonstrated as a working remote authentication bypass against a real host.
+
+### Known limitations
+
+- Recovery after an abrupt radio transition on Android may require force-stopping Chrome.
+  Chrome-for-Android wedges its own network stack browser-wide while the device remains healthy, so
+  network-change and reconnect are not proven
+  ([#65](https://github.com/alphastorm/omp-session-gateway/issues/65)).
+- Windows is implemented and partly qualified but not advertised
+  ([#90](https://github.com/alphastorm/omp-session-gateway/issues/90)).
+- Self-hosted and proxied relay modes remain unsupported.
+
 ### Fixed
 
 - Mirror the upstream fix for the silent publisher latch

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -2,12 +2,19 @@
 
 ## Current claim
 
-**No operating system, browser, or Android device is currently advertised as supported.**
+**Advertised as supported for the alpha:** Debian 13 (trixie) x86-64 and macOS 26.6.1 arm64 as hosts,
+with Chrome `151.0.7922.139` on Android 17 as the client, running alpha candidate
+`v0.1.0-prealpha.17`. Nothing else is advertised. Tailscale Serve over tailnet HTTPS is the only
+supported remote path, Funnel must remain disabled, and Tailscale must run its **TUN-mode** client:
+userspace-networking `tailscaled` makes the loopback listener remotely reachable and permits
+identity forgery ([#98](https://github.com/alphastorm/omp-session-gateway/issues/98)).
 The repository version is `0.1.0`, classified as an implemented **pre-alpha** rather than an alpha
 or a production-qualified release, and the alpha decision in
-[`RELEASE_STATUS.md`](RELEASE_STATUS.md) is **NO-GO**. Of that ledger's rows, 35 are **PASS** within
-their own narrow scope, 14 are **PARTIAL**, and one is **N/A**. A PASS row says nothing about a
-broader scope, and 14 PARTIAL rows are why nothing below carries a support claim.
+[`RELEASE_STATUS.md`](RELEASE_STATUS.md) is **GO** for the combinations named above. Of that ledger's rows, 38 are **PASS** within
+their own narrow scope, 13 are **PARTIAL**, and two are **N/A**. A PASS row still says nothing about a
+broader scope: the support claim comes from the two host platforms whose complete matrices passed
+against the alpha candidate, not from the row count. The remaining PARTIAL rows are why every other
+combination below stays unadvertised.
 
 Signed pre-alpha candidates now exist, which changes what an artifact *is* without changing what it
 is *claimed* to be. `v0.1.0-prealpha.14`, `.15`, and `.16` are published and independently

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -1,30 +1,40 @@
 # Release status
 
-**Updated:** 2026-08-20<br>
-**Repository version:** `0.1.0` (no published candidate; `v0.1.0-prealpha.14` through `.16` were deleted, latest surviving tag is `v0.1.0-prealpha.13`)<br>
-**Classification:** implemented pre-alpha<br>
-**Alpha decision:** **NO-GO**<br>
-**Advertised host/client platforms:** none yet; Debian 13 x86-64 host with a Chrome-on-Android client is the only combination whose matrix has passed, pending the blockers below
+**Updated:** 2026-08-21<br>
+**Repository version:** `0.1.0`, alpha candidate **`v0.1.0-prealpha.17`** (published, independently verified)<br>
+**Classification:** qualified alpha<br>
+**Alpha decision:** **GO**, for the combinations named immediately below and for nothing else<br>
 
-The repository implements the intended v1 path and may publish deterministic Bun-runtime
-pre-alpha archives for evaluation. It is not production-qualified, no alpha artifact is
-approved for publication, and no operating system, browser, or Android device is currently
-supported. Repository commits, pre-alpha archives, and provenance-test archives are engineering
-inputs for qualification only.
+**Advertised host platforms**
 
-**Pin refreshed to `v17.3.8` on 2026-08-19.** The OMP pin moved from `v17.0.6` /
-`89d6a8f6d14286f32f09ec9c8aa8af7b3451d2d6` to `v17.3.8` /
-`858f7dd91fff9b84cf8a2c6a6bb85aa0e6d03a55`. Every row below whose evidence predates that date was
-recorded against the previous pin. Source-level rows were re-run and are marked; native host,
-Tailscale, relay, Android, signed-artifact, and browser rows were **not** re-run and are **NOT RUN**
-for this pin regardless of the status they carry for the old one. Nothing here promotes `v17.3.8`
-to a qualified platform claim.
+| host | qualified on | candidate |
+| --- | --- | --- |
+| Debian 13 (trixie) x86-64, systemd 257, kernel `6.12.94+deb13-amd64` | 2026-08-21, 49 assertions / 0 failures | `v0.1.0-prealpha.17` |
+| macOS 26.6.1 arm64 (`Mac14,3`, build `25G76`) | 2026-08-21, reboot/login persistence and distinct-device identity | `v0.1.0-prealpha.17` |
 
-**Physical Android baseline changed on 2026-08-20.** The Pixel 10 Pro is now on Android 17
-build `CP2A.260805.005` (SDK 37) with Chrome `151.0.7922.139`. Every Android evidence row below
-predates this current device/browser combination and must be re-run before any result can be
-claimed for it. The older build and browser strings retained in those rows identify the trials
-actually run; they are historical evidence, not current-device values.
+**Advertised client:** Chrome `151.0.7922.139` on Android 17 (Pixel 10 Pro, build `CP2A.260805.005`, SDK 37).
+
+**Required deployment preconditions.** These are conditions of the claim, not advice. Tailscale Serve
+over tailnet HTTPS is the only supported remote path; Funnel must stay disabled; and Tailscale must
+run its **TUN-mode** client. Userspace-networking `tailscaled` forwards inbound tailnet connections to
+localhost, which makes the loopback listener remotely reachable and permits identity forgery
+([#98](https://github.com/alphastorm/omp-session-gateway/issues/98)); `doctor` now withholds
+`listenerLoopbackOnly` when no TUN device owns the node's tailnet address.
+
+**Known limitations of this alpha.** Recovery after an abrupt radio transition on Android may require
+force-stopping Chrome: Chrome-for-Android wedges its own network stack browser-wide, with the device
+demonstrably healthy, so network-change and reconnect are **not** proven
+([#65](https://github.com/alphastorm/omp-session-gateway/issues/65)). Windows is implemented and
+partly qualified but **is not advertised**
+([#90](https://github.com/alphastorm/omp-session-gateway/issues/90)). Self-hosted or proxied relay
+modes remain unsupported.
+
+Anything outside the table above is unqualified and must not be presented as a working deployment
+path. Repository commits and provenance-test archives remain engineering inputs only.
+
+**Pin.** OMP `v17.3.8` / `858f7dd91fff9b84cf8a2c6a6bb85aa0e6d03a55`, refreshed 2026-08-19. Every
+ledger row is either current at that pin or explicitly classified as pin-independent with its reason;
+no row is stale or indeterminate.
 
 This ledger is the source of truth for the current release decision. Compatibility claims live
 in [`COMPATIBILITY.md`](COMPATIBILITY.md); required scenarios are defined in
@@ -122,7 +132,8 @@ native qualification and attach those records to its tag.
 
 ## Current release blockers
 
-The alpha decision remains **NO-GO** until, at minimum:
+The alpha decision was **NO-GO** until the following were closed. **All six are now closed** and
+the decision is **GO** for the combinations named at the top of this document:
 
 1. ~~at least one proposed host platform passes its complete native lifecycle and security matrix
    from the signed candidate artifact, including reboot/login persistence, upgrade, rollback,
@@ -142,21 +153,23 @@ The alpha decision remains **NO-GO** until, at minimum:
    allowlisted login, and `200` for the real allowlisted identity, with a forged header from an
    already-allowlisted caller simply ignored. Direct LAN and Tailscale-IP access already failed and
    Funnel is disabled. Measured against candidate `v0.1.0-prealpha.16`;
-3. a physical Android device passes install, automatic discovery, View, Control, interrupt,
-   generation replacement, lock/resume, network-change, back-navigation, reconnect, and leak checks.
-   **Partially closed 2026-08-20 against `v0.1.0-prealpha.17`** on a physical Pixel 10 Pro running
-   Chrome `151.0.7922.139`: automatic discovery of a disposable session at revision 5 without
-   Refresh, View and Control each `200` with a `no-store` capability, stale View **and** stale
-   Control each `409 generation_mismatch`, an unknown session `404 not_found`, lock/resume `200` in
-   72 ms, and the leak sweep in blocker 6. **Network-change and reconnect remain unproven** and are
-   blocked by an environment defect, not by this project:
-   [#65](https://github.com/alphastorm/omp-session-gateway/issues/65). Two runs on this candidate
-   each wedged Chrome's network stack after a single airplane transition, with the device itself
-   healthy throughout (airplane off, Wi-Fi on, `ping 1.1.1.1` 0% loss) while Chrome's own DevTools
-   socket stopped answering and 6 Chrome processes stayed alive; `am force-stop` restored it
-   immediately. The defect survived a Chrome major-version bump from 150 to 151. Either these two
-   gates are recorded as blocked-by-environment or they are dropped from the advertised claim; they
-   must not be closed by re-running until Chrome cooperates;
+3. ~~a physical Android device passes install, automatic discovery, View, Control, interrupt,
+   generation replacement, lock/resume, network-change, back-navigation, reconnect, and leak
+   checks~~ — **closed 2026-08-21 by explicit founder decision to advertise without the two
+   environment-blocked gates.** Everything the project is answerable for passed on the physical
+   Pixel 10 Pro with Chrome `151.0.7922.139` against `v0.1.0-prealpha.17`: automatic discovery
+   without Refresh, View and Control each `200` with a `no-store` capability, stale View **and**
+   stale Control each `409 generation_mismatch`, unknown session `404`, generation replacement with
+   revoke ordered before publish, lock/resume, PWA installability, the full attention appear-and-clear
+   cycle, back navigation as a real history entry carrying no fragment, and a self-verifying
+   capability-leak sweep clean across all seven forbidden sinks.
+   **Network-change and reconnect are not proven and are advertised as a known limitation.** They are
+   blocked by [#65](https://github.com/alphastorm/omp-session-gateway/issues/65), a Chrome-for-Android
+   defect measured with the device healthy throughout — airplane off, Wi-Fi on, `ping 1.1.1.1` at 0%
+   loss — while Chrome's own DevTools socket stopped answering with six Chrome processes alive, and
+   `am force-stop` restored it instantly. It survived a Chrome 150 to 151 major-version bump. This is
+   recorded as an environment defect with its evidence rather than dropped, and it was **not** closed
+   by re-running until Chrome cooperated;
 4. ~~the candidate OMP path passes branch, saved-session resume, and applicable default-relay
    connectivity scenarios without exposing a stale capability~~ — **closed 2026-08-20**. Switch
    ordering, socket-close crash removal, and TTL-sweeper expiry were measured at the `v17.3.8` pin on
@@ -230,7 +243,8 @@ candidate, its publisher token digest `f361650a4974` is unchanged since Jul 19, 
 origin kept answering `200`.
 
 Passing one platform permits advertising only that exact qualified platform/version combination.
-It does not promote untested rows or broaden the pinned OMP range.
+It does not promote untested rows or broaden the pinned OMP range. Two platforms passed, so two
+are advertised; every other host, browser, device and OMP version remains unqualified.
 
 ## Known limitations
 


### PR DESCRIPTION
**All six release blockers are closed.** NO-GO → **GO**.

## What is advertised

| host | qualified | candidate |
| --- | --- | --- |
| Debian 13 (trixie) x86-64, systemd 257 | 49 assertions / 0 failures | `v0.1.0-prealpha.17` |
| macOS 26.6.1 arm64 (`Mac14,3`) | reboot/login persistence + distinct-device identity | `v0.1.0-prealpha.17` |

**Client:** Chrome `151.0.7922.139` on Android 17 (Pixel 10 Pro).

Nothing else. The scope rule is unchanged — passing a platform permits advertising *that* platform and no more.

## Blocker 3, closed honestly

Closed by your explicit decision to advertise without two environment-blocked gates, and that decision is **written into the row** rather than left implicit.

Everything the project is answerable for passed on the physical device: discovery without Refresh, View and Control `200 no-store`, stale View **and** stale Control `409`, unknown `404`, generation replacement with revoke ordered before publish, lock/resume, PWA installability, the full attention appear-and-clear cycle, back navigation as a real history entry carrying no fragment, and a self-verifying leak sweep clean across all seven sinks.

Network-change and reconnect did **not** pass. Recorded as a named known limitation with its evidence — not dropped, and explicitly not closed by re-running until Chrome cooperated.

## Preconditions are conditions, not advice

One is load-bearing and was discovered during this qualification: **Tailscale must run its TUN-mode client.** Userspace-networking `tailscaled` makes the loopback listener remotely reachable and permits identity forgery (#98). `doctor` now withholds `listenerLoopbackOnly` when no TUN device owns the node's tailnet address, so an operator in that configuration is told rather than left to find out.

## Doc corrections

`COMPATIBILITY.md` claimed no platform was advertised and quoted **stale counts** (35 PASS / 14 PARTIAL). Now names the combination and the measured counts (**38 PASS / 13 PARTIAL**), with the support claim attributed to the two complete host matrices rather than to a row count — a PASS row still says nothing about broader scope.

## Threat-model impact

This is the change that turns qualification into an advertised claim, so the security-relevant content is the preconditions. Serve-only, Funnel-disabled and TUN-mode are stated as conditions of the claim, with the userspace-`tailscaled` bypass named and detected rather than merely documented. The two known limitations are stated in the header where someone deciding whether to deploy will actually read them.

`bun run check` green from a clean tree: **187 pass, 0 fail**, both leak scans passing.
