### PR TITLE
feat(test): report coverage, and prove the security guards discriminate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-24.04
     # Observed ~20s. A bound keeps a hung step from holding a required check for the 6h default.
     timeout-minutes: 15
+    env:
+      # Referenced by the upload step's `if`, which cannot read `secrets` directly. Absent on
+      # Dependabot and fork pull requests, which do not receive repository secrets.
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -21,6 +25,19 @@ jobs:
       - run: bun install --frozen-lockfile
         if: ${{ hashFiles('bun.lock', 'bun.lockb') != '' }}
       - run: bun run check
+      # A second run rather than folding `--coverage` into `bun run check`, so a coverage or upload
+      # problem can never turn the required gate red. The suite is a few seconds, so the duplication
+      # costs less than the coupling would.
+      - run: bun run test:coverage
+      - name: Upload coverage to Codecov
+        if: ${{ env.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
+          # Coverage reporting must not gate a merge on a third-party service being reachable. A
+          # failed upload shows up as a stale Codecov status on the pull request instead.
+          fail_ci_if_error: false
 
   browser-notifications:
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![CI][ci-badge]][ci]
 [![Windows lifecycle][windows-badge]][windows]
+[![Coverage][coverage-badge]][coverage]
 [![Latest pre-alpha][release-badge]][releases]
 [![License][license-badge]][license]
 
@@ -25,12 +26,14 @@
 [ci-badge]: https://img.shields.io/github/actions/workflow/status/alphastorm/omp-session-gateway/ci.yml?branch=main&label=CI&labelColor=0B0E11
 [windows]: https://github.com/alphastorm/omp-session-gateway/actions/workflows/platform-qualification.yml
 [windows-badge]: https://img.shields.io/github/actions/workflow/status/alphastorm/omp-session-gateway/platform-qualification.yml?event=pull_request&label=windows%20lifecycle&labelColor=0B0E11
+[coverage]: https://codecov.io/gh/alphastorm/omp-session-gateway
+[coverage-badge]: https://img.shields.io/codecov/c/github/alphastorm/omp-session-gateway?label=coverage&color=1C232B&labelColor=0B0E11
 [releases]: https://github.com/alphastorm/omp-session-gateway/releases
 [release-badge]: https://img.shields.io/github/v/release/alphastorm/omp-session-gateway?include_prereleases&filter=v*-prealpha.*&label=pre-alpha&color=C99B45&labelColor=0B0E11
 [license]: LICENSE
 [license-badge]: https://img.shields.io/github/license/alphastorm/omp-session-gateway?color=1C232B&labelColor=0B0E11
 [status]: docs/RELEASE_STATUS.md
-[status-badge]: https://img.shields.io/badge/status-pre--alpha%2C%20unqualified-C99B45?labelColor=0B0E11
+[status-badge]: https://img.shields.io/badge/status-alpha%2C%20two%20hosts%20qualified-C99B45?labelColor=0B0E11
 [omp-lock]: UPSTREAM.lock.json
 [omp-badge]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falphastorm%2Fomp-session-gateway%2Fmain%2FUPSTREAM.lock.json&query=%24.tag&label=OMP%20baseline&color=1C232B&labelColor=0B0E11
 [bun]: https://bun.sh
@@ -40,7 +43,17 @@
 
 </div>
 
-> **Project status: implemented pre-alpha, not production-qualified.** The daemon, authenticated IPC registry, PWA, pinned collaboration client, management CLI, service definitions, release builder, tests, and OMP patch are present. Real Android, Tailscale, relay, and cross-OS acceptance gates remain unqualified. See the [release gate ledger](docs/RELEASE_STATUS.md) and [compatibility matrix](docs/COMPATIBILITY.md).
+> **Project status: alpha, qualified for two host platforms and one client.** The alpha decision is
+> **GO** for Debian 13 (trixie) x86-64 and macOS 26.6.1 arm64 as hosts, with Chrome `151.0.7922.139`
+> on Android 17 as the client, against candidate `v0.1.0-prealpha.17`. Anything outside that
+> combination is unqualified and must not be treated as a working deployment path: Windows is
+> implemented but **not advertised**, and self-hosted or proxied relay modes remain unsupported.
+> Tailscale must run its **TUN-mode** client — the gateway refuses identity headers otherwise, because
+> userspace-networking `tailscaled` makes the loopback listener reachable from the whole tailnet
+> ([#98](https://github.com/alphastorm/omp-session-gateway/issues/98)). Android recovery after an
+> abrupt radio transition is a known limitation
+> ([#65](https://github.com/alphastorm/omp-session-gateway/issues/65)). See the
+> [release gate ledger](docs/RELEASE_STATUS.md) and [compatibility matrix](docs/COMPATIBILITY.md).
 
 OMP Session Gateway is a local-first companion for [Oh My Pi](https://github.com/can1357/oh-my-pi) (OMP). After one-time setup, it automatically discovers collaboration endpoints for every live interactive OMP process on a computer and presents them through a private, mobile-first Progressive Web App (PWA).
 

--- a/apps/gateway/src/doctor.ts
+++ b/apps/gateway/src/doctor.ts
@@ -296,7 +296,17 @@ async function relayReachable(): Promise<boolean> {
   }
 }
 
-export async function runDoctorChecks(): Promise<DoctorReport> {
+export async function runDoctorChecks(
+  options: {
+    /**
+     * Whether Tailscale's tunnel device is present. Injectable for the same reason
+     * `createHttpHandler` takes it: the real probe reads this host's interface table, so a test that
+     * used it would assert whatever the machine running it happens to be, and the unsafe topology —
+     * the one case worth pinning — could not be expressed on a developer workstation at all.
+     */
+    readonly tunDevicePresent?: () => boolean;
+  } = {},
+): Promise<DoctorReport> {
   const checks: Record<string, boolean> = {
     config: false,
     permissions: false,
@@ -390,7 +400,12 @@ export async function runDoctorChecks(): Promise<DoctorReport> {
   // Reported from the interface table rather than from the configuration: a config that declares
   // `auth.trustIdentityWithoutTailnetDevice` asserts trust, it does not establish it, so a host that
   // sets the flag while running userspace mode must still fail here.
-  checks.loopbackTrustSound = tailscaleTunDevicePresent();
+  const tunDevicePresent = options.tunDevicePresent ?? (() => tailscaleTunDevicePresent());
+  checks.loopbackTrustSound = tunDevicePresent();
+  if (checks.tailscaleConnected && !checks.loopbackTrustSound) {
+    // A loopback bind address cannot be claimed while a netstack forwarder can reach it.
+    checks.listenerLoopbackOnly = false;
+  }
   if (checks.tailscaleConnected && !tailnetAddressIsLocallyBound(tailscaleIp)) {
     checks.listenerLoopbackOnly = false;
   }

--- a/apps/gateway/src/synthetic-publisher.ts
+++ b/apps/gateway/src/synthetic-publisher.ts
@@ -22,139 +22,149 @@ interface PublisherState {
   buffer: string;
 }
 
-const countArgument = process.argv[2] ?? "3";
-if (!/^\d+$/u.test(countArgument) || Number(countArgument) < 1 || Number(countArgument) > 50) {
-  throw new Error("synthetic publisher count must be from 1 to 50");
-}
-const count = Number(countArgument);
-const paths = defaultGatewayPaths();
-let token = (await readFile(paths.tokenPath, "utf8")).trim();
-const sockets: Bun.Socket<PublisherState>[] = [];
-let ready = 0;
+/**
+ * Entry point rather than top-level code. Every statement below connects to the operator's real
+ * registry socket and publishes sessions, so while this ran at module scope, merely importing the
+ * file — from a test, a tool, or an editor's auto-import — published synthetic sessions into a live
+ * gateway and then hung waiting for a signal. Guarded the same way `cli.ts` guards its own entry.
+ */
+async function main(): Promise<void> {
+  const countArgument = process.argv[2] ?? "3";
+  if (!/^\d+$/u.test(countArgument) || Number(countArgument) < 1 || Number(countArgument) > 50) {
+    throw new Error("synthetic publisher count must be from 1 to 50");
+  }
+  const count = Number(countArgument);
+  const paths = defaultGatewayPaths();
+  let token = (await readFile(paths.tokenPath, "utf8")).trim();
+  const sockets: Bun.Socket<PublisherState>[] = [];
+  let ready = 0;
 
-for (let index = 0; index < count; index += 1) {
-  const suffix = randomBytes(12).toString("base64url");
-  const instanceId = `synthetic-instance-${index.toString().padStart(3, "0")}-${suffix}`;
-  const socket = await Bun.connect<PublisherState>({
-    unix: paths.socketPath,
-    socket: {
-      open(connection) {
-        connection.write(
-          `${JSON.stringify({
-            v: 1,
-            op: "hello",
-            clientNonce: connection.data.clientNonce,
-            instanceId,
-            pid: process.pid,
-          })}\n`,
-        );
-      },
-      data(connection, chunk) {
-        connection.data.buffer += Buffer.from(chunk).toString("utf8");
-        if (Buffer.byteLength(connection.data.buffer, "utf8") > 1_024) {
-          connection.end();
-          throw new Error("gateway returned an oversized synthetic publisher handshake");
-        }
-        while (!connection.data.authenticated && connection.data.buffer.includes("\n")) {
-          const lineEnd = connection.data.buffer.indexOf("\n");
-          const value = parseJsonFrame(new TextEncoder().encode(connection.data.buffer.slice(0, lineEnd)));
-          connection.data.buffer = connection.data.buffer.slice(lineEnd + 1);
-          if (!connection.data.challengeAccepted) {
-            const challenge = parseChallengeFrame(value);
-            const binding: RegistryAuthBinding = {
-              clientNonce: connection.data.clientNonce,
-              serverNonce: challenge.serverNonce,
-              instanceId: connection.data.instanceId,
-              pid: process.pid,
-            };
-            if (!registryAuthProofMatches(createRegistryServerProof(token, binding), challenge.proof)) {
-              connection.end();
-              throw new Error("gateway server authentication failed");
-            }
-            connection.write(
-              `${JSON.stringify({
-                v: 1,
-                op: "authenticate",
-                proof: createRegistryClientProof(token, binding),
-              })}\n`,
-            );
-            connection.data.challengeAccepted = true;
-            continue;
-          }
-
-          parseHelloOkFrame(value);
-          connection.data.authenticated = true;
+  for (let index = 0; index < count; index += 1) {
+    const suffix = randomBytes(12).toString("base64url");
+    const instanceId = `synthetic-instance-${index.toString().padStart(3, "0")}-${suffix}`;
+    const socket = await Bun.connect<PublisherState>({
+      unix: paths.socketPath,
+      socket: {
+        open(connection) {
           connection.write(
             `${JSON.stringify({
               v: 1,
-              op: "upsert",
-              session: {
-                instanceId: connection.data.instanceId,
-                generation: 1,
-                pid: process.pid,
-                sessionId: `synthetic-session-${connection.data.index}`,
-                title: `Synthetic OMP session ${connection.data.index + 1}`,
-                cwdLabel: `fixture-${connection.data.index + 1}`,
-                model: "fixture/model",
-                startedAt: new Date(Date.now() - connection.data.index * 60_000).toISOString(),
-                inputRequired: false,
-                viewLink: connection.data.viewLink,
-                controlLink: connection.data.controlLink,
-              },
+              op: "hello",
+              clientNonce: connection.data.clientNonce,
+              instanceId,
+              pid: process.pid,
             })}\n`,
           );
-          ready += 1;
-          if (ready === count) {
-            token = "";
-            console.log(`published ${count} synthetic sessions`);
+        },
+        data(connection, chunk) {
+          connection.data.buffer += Buffer.from(chunk).toString("utf8");
+          if (Buffer.byteLength(connection.data.buffer, "utf8") > 1_024) {
+            connection.end();
+            throw new Error("gateway returned an oversized synthetic publisher handshake");
           }
-        }
+          while (!connection.data.authenticated && connection.data.buffer.includes("\n")) {
+            const lineEnd = connection.data.buffer.indexOf("\n");
+            const value = parseJsonFrame(new TextEncoder().encode(connection.data.buffer.slice(0, lineEnd)));
+            connection.data.buffer = connection.data.buffer.slice(lineEnd + 1);
+            if (!connection.data.challengeAccepted) {
+              const challenge = parseChallengeFrame(value);
+              const binding: RegistryAuthBinding = {
+                clientNonce: connection.data.clientNonce,
+                serverNonce: challenge.serverNonce,
+                instanceId: connection.data.instanceId,
+                pid: process.pid,
+              };
+              if (!registryAuthProofMatches(createRegistryServerProof(token, binding), challenge.proof)) {
+                connection.end();
+                throw new Error("gateway server authentication failed");
+              }
+              connection.write(
+                `${JSON.stringify({
+                  v: 1,
+                  op: "authenticate",
+                  proof: createRegistryClientProof(token, binding),
+                })}\n`,
+              );
+              connection.data.challengeAccepted = true;
+              continue;
+            }
+
+            parseHelloOkFrame(value);
+            connection.data.authenticated = true;
+            connection.write(
+              `${JSON.stringify({
+                v: 1,
+                op: "upsert",
+                session: {
+                  instanceId: connection.data.instanceId,
+                  generation: 1,
+                  pid: process.pid,
+                  sessionId: `synthetic-session-${connection.data.index}`,
+                  title: `Synthetic OMP session ${connection.data.index + 1}`,
+                  cwdLabel: `fixture-${connection.data.index + 1}`,
+                  model: "fixture/model",
+                  startedAt: new Date(Date.now() - connection.data.index * 60_000).toISOString(),
+                  inputRequired: false,
+                  viewLink: connection.data.viewLink,
+                  controlLink: connection.data.controlLink,
+                },
+              })}\n`,
+            );
+            ready += 1;
+            if (ready === count) {
+              token = "";
+              console.log(`published ${count} synthetic sessions`);
+            }
+          }
+        },
+        close() {},
+        error() {
+          process.exitCode = 1;
+        },
       },
-      close() {},
-      error() {
-        process.exitCode = 1;
+      data: {
+        index,
+        instanceId,
+        clientNonce: createRegistryAuthNonce(),
+        challengeAccepted: false,
+        viewLink: ["SYNTHETIC", "VIEW", suffix, "VALUE"].join("__"),
+        controlLink: ["SYNTHETIC", "CONTROL", suffix, "VALUE"].join("__"),
+        authenticated: false,
+        buffer: "",
       },
-    },
-    data: {
-      index,
-      instanceId,
-      clientNonce: createRegistryAuthNonce(),
-      challengeAccepted: false,
-      viewLink: ["SYNTHETIC", "VIEW", suffix, "VALUE"].join("__"),
-      controlLink: ["SYNTHETIC", "CONTROL", suffix, "VALUE"].join("__"),
-      authenticated: false,
-      buffer: "",
-    },
+    });
+    sockets.push(socket);
+  }
+
+  const heartbeat = setInterval(() => {
+    for (const socket of sockets) {
+      if (!socket.data.authenticated) continue;
+      socket.write(
+        `${JSON.stringify({
+          v: 1,
+          op: "heartbeat",
+          instanceId: socket.data.instanceId,
+          generation: 1,
+          observedAt: new Date().toISOString(),
+        })}\n`,
+      );
+    }
+  }, 10_000);
+
+  await new Promise<void>(resolve => {
+    const stop = (): void => resolve();
+    process.once("SIGINT", stop);
+    process.once("SIGTERM", stop);
   });
-  sockets.push(socket);
-}
-
-const heartbeat = setInterval(() => {
+  clearInterval(heartbeat);
   for (const socket of sockets) {
-    if (!socket.data.authenticated) continue;
-    socket.write(
-      `${JSON.stringify({
-        v: 1,
-        op: "heartbeat",
-        instanceId: socket.data.instanceId,
-        generation: 1,
-        observedAt: new Date().toISOString(),
-      })}\n`,
-    );
+    if (socket.data.authenticated) {
+      socket.write(
+        `${JSON.stringify({ v: 1, op: "remove", instanceId: socket.data.instanceId, generation: 1, reason: "shutdown" })}\n`,
+      );
+    }
+    socket.end();
   }
-}, 10_000);
-
-await new Promise<void>(resolve => {
-  const stop = (): void => resolve();
-  process.once("SIGINT", stop);
-  process.once("SIGTERM", stop);
-});
-clearInterval(heartbeat);
-for (const socket of sockets) {
-  if (socket.data.authenticated) {
-    socket.write(
-      `${JSON.stringify({ v: 1, op: "remove", instanceId: socket.data.instanceId, generation: 1, reason: "shutdown" })}\n`,
-    );
-  }
-  socket.end();
 }
+
+if (import.meta.main) await main();

--- a/apps/gateway/test/cli.test.ts
+++ b/apps/gateway/test/cli.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { main } from "../src/cli.ts";
@@ -70,3 +70,331 @@ test("exits promptly and closes staged resources when HTTP startup fails", async
     await rm(root, { recursive: true, force: true });
   }
 }, 10_000);
+
+/**
+ * The option table in `cli.ts` is the whole guard between a mistyped operator command and a
+ * destructive side effect, and `validateCommandOptions` silently accepts *every* option for a
+ * command it has no entry for. Restating the surface here turns that silent hole into a failure:
+ * `usage advertises exactly the commands whose options are validated` fails when a command is added
+ * to the CLI without being added below, and the refusal loop then covers it automatically.
+ */
+const COMMAND_SURFACE: Readonly<Record<string, readonly string[]>> = {
+  serve: ["--dev-localhost", "--port", "--origin", "--readiness-instance"],
+  install: ["--origin", "--allow", "--port", "--no-start"],
+  uninstall: ["--no-stop"],
+  rollback: ["--to"],
+  status: [],
+  doctor: ["--bundle", "--output"],
+  "rotate-publisher-token": [],
+  "serve-guidance": [],
+  help: [],
+  "--help": [],
+};
+
+const EVERY_OPTION: readonly string[] = [...new Set(Object.values(COMMAND_SURFACE).flat())];
+const REPOSITORY_ROOT = new URL("../../..", import.meta.url).pathname;
+const GATEWAY_CLI = new URL("../src/cli.ts", import.meta.url).pathname;
+
+interface SandboxRun {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  /** Sandbox-relative paths of everything the run wrote for the gateway; empty means no mutation. */
+  readonly artifacts: readonly string[];
+}
+
+/**
+ * Runs the CLI with every path it writes to redirected inside a throwaway root, so a refusal that
+ * regressed into a side effect shows up as an artifact rather than as damage to the developer's
+ * machine. `readdir` is filtered rather than compared wholesale because Bun itself populates
+ * `$HOME/Library/Caches/bun` in the sandbox.
+ */
+async function runInSandbox(
+  build: (root: string) => Promise<readonly string[]> | readonly string[],
+): Promise<SandboxRun> {
+  const root = await mkdtemp(join(tmpdir(), "gateway-cli-argv-"));
+  try {
+    const command = await build(root);
+    const subprocess = Bun.spawn([...command], {
+      cwd: REPOSITORY_ROOT,
+      env: {
+        ...process.env,
+        HOME: join(root, "home"),
+        XDG_CONFIG_HOME: join(root, "config"),
+        XDG_STATE_HOME: join(root, "state"),
+        XDG_RUNTIME_DIR: join(root, "run"),
+        TMPDIR: join(root, "tmp"),
+      },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    try {
+      // A real deadline, not a guessed settling delay: every assertion here is about a CLI that
+      // must refuse and exit, so the only thing this races is a hang. The passing path never waits,
+      // because `exited` wins as soon as the process is gone.
+      const exited = await Promise.race([subprocess.exited.then(() => true), Bun.sleep(5_000).then(() => false)]);
+      if (!exited) subprocess.kill(9);
+      const [stdout, stderr] = await Promise.all([
+        new Response(subprocess.stdout).text(),
+        new Response(subprocess.stderr).text(),
+      ]);
+      const exitCode = await subprocess.exited;
+      if (!exited) throw new Error(`the gateway CLI never exited: ${stderr}`);
+      const entries = await readdir(root, { recursive: true });
+      return {
+        exitCode,
+        stdout,
+        stderr,
+        artifacts: entries.filter(entry => entry.includes("omp-session-gateway")).sort(),
+      };
+    } finally {
+      if (subprocess.exitCode === null) subprocess.kill(9);
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function runCli(argv: readonly string[]): Promise<SandboxRun> {
+  return runInSandbox(() => [process.execPath, "apps/gateway/src/cli.ts", ...argv]);
+}
+
+/**
+ * Stands in for the installed `omp-gatewayd` entry point: same import of `main`, same
+ * message-only failure reporting as the `import.meta.main` block in `cli.ts`. The file's *name* is
+ * the subject under test, so it is written per run rather than reused.
+ */
+const DAEMON_ENTRY = `import { main } from ${JSON.stringify(GATEWAY_CLI)};
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}
+`;
+
+describe("command dispatch", () => {
+  test("refuses an unrecognised verb rather than dispatching a neighbour", async () => {
+    // `omp-gateway ""` is what an unset shell variable expands to, and `-h` is what an operator
+    // types before reading the usage text; neither may resolve to a command.
+    for (const verb of ["bogus", "uninstal", "roll-back", "Serve", "install-service", "-h", "--hlep", ""]) {
+      await expect(main([verb])).rejects.toThrow(`unknown command: ${verb}`);
+    }
+  });
+
+  test("reports the unknown verb, not its options, when both are wrong", async () => {
+    // `validateCommandOptions` returns early for commands it does not know. A mistyped verb must
+    // therefore surface as a verb problem, or the operator retypes the option and stays stuck.
+    await expect(main(["uninstal", "--no-stop"])).rejects.toThrow("unknown command: uninstal");
+    await expect(main(["rollbak", "--to=0.1.0-0123456789ab"])).rejects.toThrow("unknown command: rollbak");
+    await expect(main(["insatll", "--origin=https://gateway.example.ts.net"])).rejects.toThrow(
+      "unknown command: insatll",
+    );
+  });
+
+  test("exits non-zero on an unknown verb without creating gateway state", async () => {
+    const run = await runCli(["uninstal"]);
+    expect(run.exitCode).toBe(1);
+    expect(run.stderr).toContain("unknown command: uninstal");
+    expect(run.artifacts).toEqual([]);
+  }, 10_000);
+});
+
+describe("per-command option table", () => {
+  test("every command refuses another command's options and an invented one", async () => {
+    for (const [command, own] of Object.entries(COMMAND_SURFACE)) {
+      for (const option of [...EVERY_OPTION, "--not-an-option"]) {
+        if (own.includes(option)) continue;
+        await expect(main([command, `${option}=value`])).rejects.toThrow(`unknown option for ${command}: ${option}`);
+      }
+    }
+  });
+
+  test("each command's own options reach its handler instead of being refused as unknown", async () => {
+    // Without this control the loop above would still pass if the table refused everything. Each
+    // shape below carries all of a command's own options and is refused for a *later*, in-process
+    // reason, which proves the option names themselves were accepted.
+    // `doctor` has no such shape: `runDoctorChecks` spawns `tailscale` and reaches the network
+    // before its options are read, so its accepted-option side stays uncovered here.
+    await expect(
+      main([
+        "serve",
+        "--dev-localhost",
+        "--port=4317",
+        "--origin=http://127.0.0.1:4317",
+        "--readiness-instance=short",
+      ]),
+    ).rejects.toThrow("--readiness-instance must be a 256-bit base64url value");
+    await expect(main(["install", "--allow=user@example.com", "--port=4317", "--no-start"])).rejects.toThrow(
+      "install requires --origin",
+    );
+    await expect(main(["uninstall", "--no-stop=yes"])).rejects.toThrow("--no-stop does not accept a value");
+    await expect(main(["rollback", "--to"])).rejects.toThrow("--to requires a value");
+  });
+
+  test("usage advertises exactly the commands whose options are validated", async () => {
+    const { stdout, exitCode } = await runCli(["--help"]);
+    expect(exitCode).toBe(0);
+    // `omp-gatewayd` is the daemon binary, not a verb, so it must not match.
+    const advertised = [...stdout.matchAll(/^\s+omp-gateway ([a-z-]+)/gmu)].flatMap(match => match[1] ?? []);
+    expect(advertised.length).toBeGreaterThan(0);
+    expect([...new Set(advertised)].sort()).toEqual(
+      Object.keys(COMMAND_SURFACE)
+        .filter(command => command !== "help" && command !== "--help")
+        .sort(),
+    );
+  }, 10_000);
+});
+
+describe("option arity and values", () => {
+  test("refuses every value-taking option when its value is absent", async () => {
+    // `--output` is missing from this list deliberately: `runDoctor` only reads it inside the
+    // `--bundle` branch, after `runDoctorChecks` has already probed the daemon and the network, so
+    // the refusal is unreachable without a live host.
+    const missing: readonly (readonly [string[], string])[] = [
+      [["serve", "--port"], "--port requires a value"],
+      [["serve", "--origin"], "--origin requires a value"],
+      [["serve", "--readiness-instance"], "--readiness-instance requires a value"],
+      [["install", "--origin"], "--origin requires a value"],
+      [["install", "--origin=https://gateway.example.ts.net", "--allow"], "--allow requires a value"],
+      [["install", "--origin=https://gateway.example.ts.net", "--port"], "--port requires a value"],
+      [["rollback", "--to"], "--to requires a value"],
+    ];
+    for (const [argv, message] of missing) {
+      await expect(main(argv)).rejects.toThrow(message);
+    }
+  });
+
+  test("never swallows the next option as the previous option's value", async () => {
+    await expect(main(["serve", "--port", "--origin=http://127.0.0.1:4317"])).rejects.toThrow(
+      "--port requires a value",
+    );
+    await expect(main(["serve", "--origin", "--dev-localhost"])).rejects.toThrow("--origin requires a value");
+    // A later value for the same option does not rescue the bare one: the sentinel wins over arity.
+    await expect(main(["rollback", "--to", "--to=0.1.0-0123456789ab"])).rejects.toThrow("--to requires a value");
+  });
+
+  test("refuses an unknown option before complaining that a known one lacks a value", async () => {
+    // Ordering matters for the destructive verbs: the table is checked before any handler runs, so
+    // `uninstall --force` must never reach `uninstallUserService`.
+    await expect(main(["uninstall", "--force"])).rejects.toThrow("unknown option for uninstall: --force");
+    await expect(main(["serve", "--allow"])).rejects.toThrow("unknown option for serve: --allow");
+  });
+
+  test("refuses a repeated single-valued option instead of silently picking one", async () => {
+    const repeated: readonly (readonly [string[], string])[] = [
+      [["serve", "--port=4317", "--port=4318"], "--port may be supplied once"],
+      [["serve", "--origin=http://127.0.0.1:4317", "--origin=http://127.0.0.1:4318"], "--origin may be supplied once"],
+      [["serve", "--dev-localhost", "--dev-localhost"], "--dev-localhost may be supplied once"],
+      [["serve", "--readiness-instance=a", "--readiness-instance=b"], "--readiness-instance may be supplied once"],
+      [
+        ["install", "--origin=https://gateway.example.ts.net", "--origin=https://other.example.ts.net"],
+        "--origin may be supplied once",
+      ],
+      [["uninstall", "--no-stop", "--no-stop"], "--no-stop may be supplied once"],
+      [["rollback", "--to=0.1.0-0123456789ab", "--to=0.1.0-ba9876543210"], "--to may be supplied once"],
+    ];
+    for (const [argv, message] of repeated) {
+      await expect(main(argv)).rejects.toThrow(message);
+    }
+    // `--allow` is the one option that accumulates: repeating it must not be an arity error. The
+    // refusal here is the absent `--origin`, which is only reached once both values are accepted.
+    await expect(main(["install", "--allow=user@example.com", "--allow=other@example.com"])).rejects.toThrow(
+      "install requires --origin",
+    );
+  });
+
+  test("refuses a bare positional argument after the command", async () => {
+    await expect(main(["serve", "port"])).rejects.toThrow("unexpected argument: port");
+    await expect(main(["install", "--origin", "https://gateway.example.ts.net", "extra"])).rejects.toThrow(
+      "unexpected argument: extra",
+    );
+  });
+});
+
+describe("numeric options", () => {
+  test("refuses a --port that is not a bare decimal integer", async () => {
+    for (const value of ["abc", "-1", "1.5", "4317.0", " 4317", "4317 ", "+4317", "4_317", "1e3", "0x10ed", "٤٣١٧"]) {
+      await expect(main(["serve", `--port=${value}`])).rejects.toThrow("--port must be an integer");
+    }
+    // A negative supplied as its own token is the shape an operator actually types, and it exercises
+    // the parser branch that treats a non-`--` token as the value.
+    await expect(main(["serve", "--port", "-1"])).rejects.toThrow("--port must be an integer");
+  });
+
+  test("distinguishes an empty value from an absent one", async () => {
+    await expect(main(["serve", "--port="])).rejects.toThrow("--port must be an integer");
+    await expect(main(["serve", "--port"])).rejects.toThrow("--port requires a value");
+  });
+
+  test("refuses an out-of-range --port before writing config or token material", async () => {
+    // 0 and 65536 straddle `validatePort`; both are integers, so only the range check can catch them.
+    for (const port of ["0", "65536"]) {
+      const run = await runCli(["serve", "--dev-localhost", `--port=${port}`]);
+      expect(run.exitCode).toBe(1);
+      expect(run.stderr).toContain("http.port must be an integer from 1 to 65535");
+      expect(run.artifacts).toEqual([]);
+    }
+  }, 20_000);
+});
+
+describe("usage and daemon invocation", () => {
+  test("--help and a bare invocation print the same usage, exit zero, and write nothing", async () => {
+    const [help, bare] = await Promise.all([runCli(["--help"]), runCli([])]);
+    expect(help.exitCode).toBe(0);
+    expect(bare.exitCode).toBe(0);
+    expect(help.stdout).toContain("Usage:");
+    expect(bare.stdout).toBe(help.stdout);
+    expect(help.artifacts).toEqual([]);
+    expect(bare.artifacts).toEqual([]);
+  }, 15_000);
+
+  test("a bare invocation means serve only under the daemon binary name", async () => {
+    // The substitution keys off `basename(process.argv[1])`, so the only way to exercise it is to
+    // enter `main` through a file with that name. Nothing binds: the sandbox has no config file, so
+    // the `tailscale-serve` defaults are refused before any listener or file is created.
+    const daemon = await runInSandbox(async root => {
+      await writeFile(join(root, "omp-gatewayd"), DAEMON_ENTRY);
+      return [process.execPath, join(root, "omp-gatewayd")];
+    });
+    expect(daemon.exitCode).toBe(1);
+    expect(daemon.stderr).toContain("tailscale-serve mode requires an exact HTTPS public origin");
+    expect(daemon.artifacts).toEqual([]);
+
+    const other = await runInSandbox(async root => {
+      await writeFile(join(root, "omp-gateway"), DAEMON_ENTRY);
+      return [process.execPath, join(root, "omp-gateway")];
+    });
+    expect(other.exitCode).toBe(0);
+    expect(other.stdout).toContain("Usage:");
+    expect(other.artifacts).toEqual([]);
+  }, 15_000);
+});
+
+describe("destructive verbs", () => {
+  test("uninstall refuses a malformed --no-stop before stopping the service", async () => {
+    await expect(main(["uninstall", "--no-stop=yes"])).rejects.toThrow("--no-stop does not accept a value");
+    await expect(main(["uninstall", "--no-stop=false"])).rejects.toThrow("--no-stop does not accept a value");
+    await expect(main(["uninstall", "--no-stop", "--no-stop"])).rejects.toThrow("--no-stop may be supplied once");
+    await expect(main(["uninstall", "--to=0.1.0-0123456789ab"])).rejects.toThrow("unknown option for uninstall: --to");
+    await expect(main(["uninstall", "yes"])).rejects.toThrow("unexpected argument: yes");
+  });
+
+  test("rollback refuses a malformed --to before reading any service state", async () => {
+    // `runRollback` reads `--to` first and only then loads the config and the live service status,
+    // so these refusals are the ones reachable without an installed gateway. The refusals that do
+    // need one — an unmanaged active service, a missing installation, and an unresolvable target —
+    // are left uncovered rather than faked, because `userServiceStatus` reads the real OS service
+    // even when every path is redirected into a sandbox.
+    await expect(main(["rollback", "--to"])).rejects.toThrow("--to requires a value");
+    await expect(main(["rollback", "--to=", "--to=0.1.0-0123456789ab"])).rejects.toThrow(
+      "--to may be supplied once",
+    );
+    await expect(main(["rollback", "--no-start"])).rejects.toThrow("unknown option for rollback: --no-start");
+    await expect(main(["rollback", "--bundle=1"])).rejects.toThrow("unknown option for rollback: --bundle");
+    await expect(main(["rollback", "0.1.0-0123456789ab"])).rejects.toThrow(
+      "unexpected argument: 0.1.0-0123456789ab",
+    );
+  });
+});

--- a/apps/gateway/test/config.test.ts
+++ b/apps/gateway/test/config.test.ts
@@ -3,10 +3,13 @@ import { chmod, lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  type ConfigOverrides,
   type GatewayConfig,
+  assertPublisherTokenPrivate,
   captureGatewayConfigFile,
   loadGatewayConfig,
   loadOrCreatePublisherToken,
+  loadPublisherToken,
   publisherTokenMatches,
   publicOriginHttpsPort,
   restoreGatewayConfigFile,
@@ -80,6 +83,38 @@ async function makeFixtureUnsafe(path: string): Promise<void> {
   });
   const stderr = await new Response(subprocess.stderr).text();
   if ((await subprocess.exited) !== 0) throw new Error(`failed to loosen test fixture ACL: ${stderr.trim()}`);
+}
+
+type ConfigPatch = {
+  readonly http?: Record<string, unknown>;
+  readonly auth?: Record<string, unknown>;
+  readonly registry?: Record<string, unknown>;
+};
+
+async function configFixture(text: string): Promise<string> {
+  const path = join(await privateRoot(), "config.json");
+  await writeFile(path, text, { mode: 0o600 });
+  await secureWindowsFixture(path);
+  return path;
+}
+
+async function loadDocument(document: unknown, overrides: ConfigOverrides = {}): Promise<GatewayConfig> {
+  return loadGatewayConfig({ ...overrides, configPath: await configFixture(JSON.stringify(document)) });
+}
+
+function serveDocument(patch: ConfigPatch = {}): Record<string, unknown> {
+  return {
+    http: { hostname: "127.0.0.1", port: 4317, publicOrigin: "https://gateway.example.ts.net", ...patch.http },
+    auth: { mode: "tailscale-serve", allowedLogins: ["user@example.com"], ...patch.auth },
+  };
+}
+
+function devDocument(patch: ConfigPatch = {}): Record<string, unknown> {
+  return {
+    http: { hostname: "127.0.0.1", port: 4317, publicOrigin: "http://127.0.0.1:4317", ...patch.http },
+    auth: { mode: "dev-localhost", allowedLogins: [], ...patch.auth },
+    registry: { heartbeatSeconds: 10, ttlSeconds: 35, maxPublishers: 10, maxSessions: 10, ...patch.registry },
+  };
 }
 
 describe("secure config", () => {
@@ -264,5 +299,305 @@ describe("secure config", () => {
     await writeFile(config.paths.tokenPath, "A".repeat(46), { mode: 0o600 });
     await secureWindowsFixture(config.paths.tokenPath);
     await expect(loadOrCreatePublisherToken(config)).rejects.toThrow("invalid encoding or length");
+  }, 20_000);
+});
+
+describe("auth mode admission", () => {
+  test("serve mode accepts an external origin whose port is not the listener port", async () => {
+    const loaded = await loadDocument(serveDocument({ http: { publicOrigin: "https://gateway.example.ts.net:8443" } }));
+    expect(loaded.http.publicOrigin).toBe("https://gateway.example.ts.net:8443");
+    expect(loaded.http.port).toBe(4317);
+    expect(publicOriginHttpsPort(loaded.http.publicOrigin)).toBe(8443);
+  });
+
+  test("serve mode refuses an origin carrying a path, a trailing slash, or a redundant default port", async () => {
+    for (const publicOrigin of [
+      "https://gateway.example.ts.net/gw",
+      "https://gateway.example.ts.net/",
+      "https://gateway.example.ts.net:443",
+    ]) {
+      await expect(loadDocument(serveDocument({ http: { publicOrigin } }))).rejects.toThrow(
+        "http.publicOrigin must be an exact HTTP(S) origin",
+      );
+    }
+  }, 20_000);
+
+  test("an inexact public origin override is refused after the file itself parses", async () => {
+    await expect(loadDocument(serveDocument(), { publicOrigin: "https://gateway.example.ts.net/gw" })).rejects.toThrow(
+      "http.publicOrigin must be an exact URL origin",
+    );
+  });
+
+  test("serve mode refuses an empty allowlist from the file and from a mode override", async () => {
+    await expect(loadDocument(serveDocument({ auth: { allowedLogins: [] } }))).rejects.toThrow(
+      "tailscale-serve mode requires at least one allowed login",
+    );
+    await expect(
+      loadDocument(devDocument(), { mode: "tailscale-serve", publicOrigin: "https://gateway.example.ts.net" }),
+    ).rejects.toThrow("tailscale-serve mode requires at least one allowed login");
+    const promoted = await loadDocument(devDocument({ auth: { allowedLogins: ["user@example.com"] } }), {
+      mode: "tailscale-serve",
+      publicOrigin: "https://gateway.example.ts.net",
+    });
+    expect(promoted.auth.mode).toBe("tailscale-serve");
+    expect(promoted.http.publicOrigin).toBe("https://gateway.example.ts.net");
+  }, 20_000);
+
+  test("dev mode refuses an origin whose port or host disagrees with the listener", async () => {
+    await expect(loadDocument(devDocument({ http: { publicOrigin: "http://127.0.0.1:4318" } }))).rejects.toThrow(
+      "dev-localhost mode requires the configured loopback HTTP origin",
+    );
+    await expect(
+      loadDocument(devDocument({ http: { hostname: "::1", publicOrigin: "http://127.0.0.1:4317" } })),
+    ).rejects.toThrow("dev-localhost mode requires the configured loopback HTTP origin");
+    const loaded = await loadDocument(devDocument({ http: { port: 4319, publicOrigin: "http://127.0.0.1:4319" } }));
+    expect(loaded.http.publicOrigin).toBe("http://127.0.0.1:4319");
+    expect(loaded.http.port).toBe(4319);
+  }, 20_000);
+
+  test("a dev-mode port override moves the public origin, and an explicit origin must agree with it", async () => {
+    const configPath = await configFixture(JSON.stringify(devDocument()));
+    const moved = await loadGatewayConfig({ configPath, port: 4321 });
+    expect(moved.http.port).toBe(4321);
+    expect(moved.http.publicOrigin).toBe("http://127.0.0.1:4321");
+    await expect(
+      loadGatewayConfig({ configPath, port: 4321, publicOrigin: "http://127.0.0.1:4317" }),
+    ).rejects.toThrow("dev-localhost mode requires the configured loopback HTTP origin");
+  });
+
+  test("an override port stays inside the port range", async () => {
+    const configPath = await configFixture(JSON.stringify(devDocument()));
+    expect((await loadGatewayConfig({ configPath, port: 65_535 })).http.port).toBe(65_535);
+    for (const port of [0, 65_536]) {
+      await expect(loadGatewayConfig({ configPath, port })).rejects.toThrow(
+        "http.port must be an integer from 1 to 65535",
+      );
+    }
+  });
+
+  test("refuses an unrecognized auth mode instead of falling back to a default", async () => {
+    await expect(loadDocument(devDocument({ auth: { mode: "dev" } }))).rejects.toThrow("invalid auth.mode");
+  });
+
+  test("an absent config file yields dev defaults but never a serve-mode gateway", async () => {
+    const configPath = join(await privateRoot(), "absent.json");
+    const loaded = await loadGatewayConfig({ configPath, mode: "dev-localhost" });
+    expect(loaded.http.publicOrigin).toBe("http://127.0.0.1:4317");
+    expect(loaded.auth.allowedLogins).toEqual([]);
+    expect(await Bun.file(configPath).exists()).toBe(false);
+    await expect(loadGatewayConfig({ configPath })).rejects.toThrow(
+      "tailscale-serve mode requires an exact HTTPS public origin",
+    );
+  });
+
+  test("a malformed config file fails the load instead of falling back to defaults", async () => {
+    const configPath = await configFixture("{ not json");
+    await expect(loadGatewayConfig({ configPath, mode: "dev-localhost" })).rejects.toThrow(SyntaxError);
+  });
+});
+
+describe("config key admission", () => {
+  test("rejects an unknown key in every section with a section-specific message", async () => {
+    await expect(loadDocument({ ...devDocument(), htp: {} })).rejects.toThrow("unknown config key: htp");
+    await expect(loadDocument(devDocument({ http: { portt: 4317 } }))).rejects.toThrow(
+      "unknown http config key: portt",
+    );
+    await expect(loadDocument(devDocument({ auth: { trustIdentityWithoutTailnetDevices: true } }))).rejects.toThrow(
+      "unknown auth config key: trustIdentityWithoutTailnetDevices",
+    );
+    await expect(loadDocument(devDocument({ registry: { heartbeatSecond: 10 } }))).rejects.toThrow(
+      "unknown registry config key: heartbeatSecond",
+    );
+  }, 20_000);
+
+  test("rejects a document or a section that is not an object", async () => {
+    await expect(loadDocument([])).rejects.toThrow("config must be an object");
+    await expect(loadGatewayConfig({ configPath: await configFixture("null"), mode: "dev-localhost" })).rejects.toThrow(
+      "config must be an object",
+    );
+    await expect(loadDocument({ http: [] })).rejects.toThrow("config sections must be objects");
+    await expect(loadDocument({ registry: 3 })).rejects.toThrow("config sections must be objects");
+  }, 20_000);
+
+  test("accepts the tailnet trust assertion only as a boolean and records it only when asserted", async () => {
+    const asserted = await loadDocument(devDocument({ auth: { trustIdentityWithoutTailnetDevice: true } }));
+    expect(asserted.auth.trustIdentityWithoutTailnetDevice).toBe(true);
+    const declined = await loadDocument(devDocument({ auth: { trustIdentityWithoutTailnetDevice: false } }));
+    expect("trustIdentityWithoutTailnetDevice" in declined.auth).toBe(false);
+    const absent = await loadDocument(devDocument());
+    expect("trustIdentityWithoutTailnetDevice" in absent.auth).toBe(false);
+    await expect(loadDocument(devDocument({ auth: { trustIdentityWithoutTailnetDevice: "true" } }))).rejects.toThrow(
+      "auth.trustIdentityWithoutTailnetDevice must be a boolean",
+    );
+  }, 20_000);
+
+  test("requires a loopback listener hostname", async () => {
+    for (const hostname of ["0.0.0.0", "localhost", "10.0.0.1"]) {
+      await expect(loadDocument(devDocument({ http: { hostname } }))).rejects.toThrow("http.hostname must be loopback");
+    }
+    expect((await loadDocument(devDocument())).http.hostname).toBe("127.0.0.1");
+    const sixed = await loadDocument(devDocument({ http: { hostname: "::1", publicOrigin: "http://[::1]:4317" } }));
+    expect(sixed.http.hostname).toBe("::1");
+    expect(sixed.http.publicOrigin).toBe("http://[::1]:4317");
+  }, 20_000);
+});
+
+describe("registry bounds admission", () => {
+  test("refuses a heartbeat outside its bounds or of the wrong shape", async () => {
+    for (const heartbeatSeconds of [1, 61, 10.5, "10", true]) {
+      await expect(loadDocument(devDocument({ registry: { heartbeatSeconds } }))).rejects.toThrow(
+        "registry.heartbeatSeconds must be an integer from 2 to 60",
+      );
+    }
+  }, 20_000);
+
+  test("refuses a TTL outside its bounds or of the wrong shape", async () => {
+    for (const ttlSeconds of [4, 301, 35.5, "35", true]) {
+      await expect(loadDocument(devDocument({ registry: { ttlSeconds } }))).rejects.toThrow(
+        "registry.ttlSeconds must be an integer from 5 to 300",
+      );
+    }
+  }, 20_000);
+
+  test("accepts both ends of the heartbeat and TTL ranges", async () => {
+    const minimal = (await loadDocument(devDocument({ registry: { heartbeatSeconds: 2, ttlSeconds: 5 } }))).registry;
+    expect([minimal.heartbeatSeconds, minimal.ttlSeconds]).toEqual([2, 5]);
+    const maximal = (await loadDocument(devDocument({ registry: { heartbeatSeconds: 60, ttlSeconds: 300 } }))).registry;
+    expect([maximal.heartbeatSeconds, maximal.ttlSeconds]).toEqual([60, 300]);
+  }, 20_000);
+
+  test("requires the TTL to exceed two heartbeat intervals at the exact boundary", async () => {
+    await expect(loadDocument(devDocument({ registry: { heartbeatSeconds: 10, ttlSeconds: 20 } }))).rejects.toThrow(
+      "registry.ttlSeconds must exceed two heartbeat intervals",
+    );
+    const short = await loadDocument(devDocument({ registry: { heartbeatSeconds: 10, ttlSeconds: 21 } }));
+    expect(short.registry.ttlSeconds).toBe(21);
+    await expect(loadDocument(devDocument({ registry: { heartbeatSeconds: 60, ttlSeconds: 120 } }))).rejects.toThrow(
+      "registry.ttlSeconds must exceed two heartbeat intervals",
+    );
+    const long = await loadDocument(devDocument({ registry: { heartbeatSeconds: 60, ttlSeconds: 121 } }));
+    expect(long.registry.ttlSeconds).toBe(121);
+    // A TTL below its own floor is a range failure, not a heartbeat-relation failure: the operator is
+    // told which number is wrong rather than being pointed at the pair.
+    await expect(loadDocument(devDocument({ registry: { heartbeatSeconds: 2, ttlSeconds: 4 } }))).rejects.toThrow(
+      "registry.ttlSeconds must be an integer from 5 to 300",
+    );
+  }, 20_000);
+
+  test("bounds the publisher and session ceilings", async () => {
+    const wide = (await loadDocument(devDocument({ registry: { maxPublishers: 1_000, maxSessions: 1 } }))).registry;
+    expect([wide.maxPublishers, wide.maxSessions]).toEqual([1_000, 1]);
+    await expect(loadDocument(devDocument({ registry: { maxPublishers: 0 } }))).rejects.toThrow(
+      "registry.maxPublishers must be an integer from 1 to 1000",
+    );
+    await expect(loadDocument(devDocument({ registry: { maxSessions: 1_001 } }))).rejects.toThrow(
+      "registry.maxSessions must be an integer from 1 to 1000",
+    );
+  }, 20_000);
+});
+
+describe("allowlist admission", () => {
+  test("folds case, trims, and collapses duplicates while preserving first-seen order", async () => {
+    const loaded = await loadDocument(
+      serveDocument({
+        auth: {
+          allowedLogins: [" User@Example.COM ", "user@example.com", "OTHER@Example.com", "USER@EXAMPLE.COM "],
+        },
+      }),
+    );
+    expect(loaded.auth.allowedLogins).toEqual(["user@example.com", "other@example.com"]);
+  });
+
+  test("collapses logins that differ only by Unicode composition", async () => {
+    const loaded = await loadDocument(
+      serveDocument({ auth: { allowedLogins: ["u\u0301ser@example.com", "\u00faser@example.com"] } }),
+    );
+    expect(loaded.auth.allowedLogins).toEqual(["\u00faser@example.com"]);
+  });
+
+  test("refuses an entry that cannot name exactly one login", async () => {
+    for (const login of [
+      "*",
+      "*@example.com",
+      "",
+      "   ",
+      "first@example.com,second@example.com",
+      "first\nsecond@example.com",
+      `${"a".repeat(309)}@example.com`,
+    ]) {
+      await expect(loadDocument(serveDocument({ auth: { allowedLogins: [login] } }))).rejects.toThrow(
+        "invalid Tailscale login allowlist entry",
+      );
+    }
+    const longest = await loadDocument(serveDocument({ auth: { allowedLogins: [`${"a".repeat(308)}@example.com`] } }));
+    expect(longest.auth.allowedLogins[0]?.length).toBe(320);
+  }, 30_000);
+
+  test("refuses an allowlist that is not an array of strings", async () => {
+    await expect(loadDocument(serveDocument({ auth: { allowedLogins: "user@example.com" } }))).rejects.toThrow(
+      "auth.allowedLogins must be an array of login strings",
+    );
+    await expect(loadDocument(serveDocument({ auth: { allowedLogins: ["user@example.com", 42] } }))).rejects.toThrow(
+      "auth.allowedLogins must be an array of login strings",
+    );
+  });
+});
+
+describe("private file admission", () => {
+  test("refuses a config file that any other account could read", async () => {
+    if (process.platform === "win32") return;
+    const configPath = await configFixture(JSON.stringify(devDocument()));
+    expect((await loadGatewayConfig({ configPath })).http.port).toBe(4317);
+    for (const mode of [0o640, 0o604, 0o666]) {
+      await chmod(configPath, mode);
+      await expect(loadGatewayConfig({ configPath })).rejects.toThrow(
+        `unsafe private file permissions: ${configPath}`,
+      );
+    }
+    await chmod(configPath, 0o600);
+    expect((await loadGatewayConfig({ configPath })).http.port).toBe(4317);
+  });
+
+  test("refuses a readable publisher token and never mints one on a plain load", async () => {
+    if (process.platform === "win32") return;
+    const root = await privateRoot();
+    const config = configForRoot(root);
+    await expect(loadPublisherToken(config)).rejects.toThrow("ENOENT");
+    expect(await Bun.file(config.paths.tokenPath).exists()).toBe(false);
+    const token = await loadOrCreatePublisherToken(config);
+    await assertPublisherTokenPrivate(config);
+    await chmod(config.paths.tokenPath, 0o640);
+    await expect(assertPublisherTokenPrivate(config)).rejects.toThrow(
+      `unsafe private file permissions: ${config.paths.tokenPath}`,
+    );
+    await chmod(config.paths.tokenPath, 0o600);
+    expect(await loadPublisherToken(config)).toBe(token);
+    const target = join(root, "external-token");
+    await writeFile(target, `${"A".repeat(43)}\n`, { mode: 0o600 });
+    await rm(config.paths.tokenPath);
+    await symlink(target, config.paths.tokenPath);
+    await expect(loadPublisherToken(config)).rejects.toThrow(`unsafe private file: ${config.paths.tokenPath}`);
+  }, 20_000);
+
+  test("refuses to use a token directory that any other account could enter", async () => {
+    if (process.platform === "win32") return;
+    const config = configForRoot(await privateRoot());
+    const token = await loadOrCreatePublisherToken(config);
+    for (const mode of [0o750, 0o701, 0o777]) {
+      await chmod(config.paths.configDir, mode);
+      await expect(loadPublisherToken(config)).rejects.toThrow(
+        `unsafe private directory: ${config.paths.configDir}`,
+      );
+    }
+    await chmod(config.paths.configDir, 0o700);
+    expect(await loadPublisherToken(config)).toBe(token);
+  }, 20_000);
+
+  test("accepts a config file at exactly the size limit", async () => {
+    const document = JSON.stringify(devDocument());
+    const padded = `${document}${" ".repeat(64 * 1_024 - Buffer.byteLength(document))}`;
+    expect(Buffer.byteLength(padded)).toBe(64 * 1_024);
+    const configPath = await configFixture(padded);
+    expect((await loadGatewayConfig({ configPath })).http.port).toBe(4317);
   }, 20_000);
 });

--- a/apps/gateway/test/doctor.test.ts
+++ b/apps/gateway/test/doctor.test.ts
@@ -1,7 +1,13 @@
-import { expect, test } from "bun:test";
-import { readFile } from "node:fs/promises";
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
-import { EXPECTED_UPSTREAM_CODING_AGENT_VERSION, EXPECTED_UPSTREAM_COMMIT } from "../src/doctor.ts";
+import {
+  EXPECTED_UPSTREAM_CODING_AGENT_VERSION,
+  EXPECTED_UPSTREAM_COMMIT,
+  runDoctorChecks,
+} from "../src/doctor.ts";
 
 /**
  * `compatibilityArtifactsPresent` deliberately hardcodes the upstream identity rather than reading
@@ -29,5 +35,108 @@ test("pin contract: the shipped patch targets the locked upstream commit", async
   // ever regenerates the mbox without them, the gateway integration is not actually present.
   expect(patch).toContain("packages/coding-agent/src/collab/controller.ts");
   expect(patch).toContain("packages/coding-agent/src/collab/registry-publisher.ts");
+});
+
+/**
+ * The wiring, not the predicate.
+ *
+ * `tailscaleTunDevicePresent` has direct unit tests, but nothing exercised its use inside
+ * `runDoctorChecks`: the commit that introduced the check said so outright — "removing that wiring
+ * leaves the suite green". These cases close that, and they are the reason `runDoctorChecks` takes an
+ * injectable probe. Reading the real interface table would make the result depend on whether the
+ * machine running the test has Tailscale in TUN mode, and the unsafe topology — the only case worth
+ * pinning — cannot be produced on a developer workstation at all.
+ *
+ * `tailscale` itself is faked on `PATH` so `tailscaleConnected` is a controlled input rather than a
+ * property of the host. Everything network-facing (the daemon probe, the relay probe) is expected to
+ * fail in an isolated root; these assertions deliberately touch only the trust checks.
+ */
+describe("doctor reports the loopback trust topology", () => {
+  const saved = { ...process.env };
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) if (!(key in saved)) delete process.env[key];
+    Object.assign(process.env, saved);
+  });
+
+  async function isolatedRoot(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "gateway-doctor-"));
+    for (const part of ["config/omp-session-gateway", "state/omp-session-gateway", "run/omp-session-gateway", "bin"]) {
+      await mkdir(join(root, part), { recursive: true, mode: 0o700 });
+    }
+    const configPath = join(root, "config/omp-session-gateway/config.json");
+    await writeFile(
+      configPath,
+      `${JSON.stringify({
+        http: { hostname: "127.0.0.1", port: 4399, publicOrigin: "https://gateway.example.ts.net" },
+        auth: { mode: "tailscale-serve", allowedLogins: ["doctor@example.com"] },
+        registry: { heartbeatSeconds: 10, ttlSeconds: 35, maxPublishers: 10, maxSessions: 10 },
+      })}\n`,
+    );
+    await chmod(configPath, 0o600);
+    const tokenPath = join(root, "config/omp-session-gateway/publisher-token");
+    await writeFile(tokenPath, "D".repeat(43));
+    await chmod(tokenPath, 0o600);
+
+    // A fake `tailscale` so `BackendState` is an input to the test rather than a fact about the host.
+    const fake = join(root, "bin/tailscale");
+    await writeFile(
+      fake,
+      [
+        "#!/bin/sh",
+        'if [ "$1" = "status" ]; then echo \'{"BackendState":"Running","Self":{"TailscaleIPs":["100.101.102.103"]}}\'; exit 0; fi',
+        'if [ "$1" = "serve" ]; then echo \'{}\'; exit 0; fi',
+        'if [ "$1" = "funnel" ]; then echo \'{}\'; exit 0; fi',
+        "exit 1",
+      ].join("\n"),
+    );
+    await chmod(fake, 0o755);
+
+    process.env.XDG_CONFIG_HOME = join(root, "config");
+    process.env.XDG_STATE_HOME = join(root, "state");
+    process.env.XDG_RUNTIME_DIR = join(root, "run");
+    process.env.PATH = `${join(root, "bin")}:${process.env.PATH ?? ""}`;
+    return root;
+  }
+
+  test("withholds the loopback claim and names the finding when no tunnel device is present", async () => {
+    await isolatedRoot();
+
+    const report = await runDoctorChecks({ tunDevicePresent: () => false });
+
+    expect(report.checks.tailscaleConnected).toBe(true);
+    expect(report.checks.loopbackTrustSound).toBe(false);
+    // Deliberately no assertion on `listenerLoopbackOnly` here. It is computed as
+    // `checks.daemon && hostname is loopback`, and no daemon runs in this isolated root, so it is
+    // false either way and an assertion on it would discriminate nothing. Proving the *withholding*
+    // specifically would need a live daemon on the fixture's port, which is a heavier integration
+    // fixture than this secondary claim is worth.
+  }, 30_000);
+
+  test("reports sound trust when a tunnel device is present", async () => {
+    await isolatedRoot();
+
+    const report = await runDoctorChecks({ tunDevicePresent: () => true });
+
+    expect(report.checks.tailscaleConnected).toBe(true);
+    expect(report.checks.loopbackTrustSound).toBe(true);
+  }, 30_000);
+
+  test("answers from the topology, not from a config that declares trust", async () => {
+    const root = await isolatedRoot();
+    const configPath = join(root, "config/omp-session-gateway/config.json");
+    const document = JSON.parse(await readFile(configPath, "utf8")) as {
+      auth: { trustIdentityWithoutTailnetDevice?: boolean };
+    };
+    document.auth.trustIdentityWithoutTailnetDevice = true;
+    await writeFile(configPath, `${JSON.stringify(document)}\n`);
+    await chmod(configPath, 0o600);
+
+    const report = await runDoctorChecks({ tunDevicePresent: () => false });
+
+    // The flag asserts trust; it does not establish it. A host that sets it while running
+    // userspace-mode tailscaled must still fail here, or the escape hatch would hide the exposure.
+    expect(report.checks.loopbackTrustSound).toBe(false);
+  }, 30_000);
 });
 

--- a/apps/gateway/test/doctor.test.ts
+++ b/apps/gateway/test/doctor.test.ts
@@ -47,9 +47,12 @@ test("pin contract: the shipped patch targets the locked upstream commit", async
  * machine running the test has Tailscale in TUN mode, and the unsafe topology — the only case worth
  * pinning — cannot be produced on a developer workstation at all.
  *
- * `tailscale` itself is faked on `PATH` so `tailscaleConnected` is a controlled input rather than a
- * property of the host. Everything network-facing (the daemon probe, the relay probe) is expected to
- * fail in an isolated root; these assertions deliberately touch only the trust checks.
+ * Nothing here asserts `tailscaleConnected`. An earlier version faked `tailscale` on `PATH` to make
+ * it an input; that passed on macOS and failed on Linux, because `Bun.spawn` did not resolve the
+ * fake there. It was scaffolding rather than the contract: `loopbackTrustSound` is assigned from the
+ * injected probe regardless of whether the CLI answered, so the wiring is testable without depending
+ * on process spawning at all. Everything network-facing — the daemon probe, the relay probe — is
+ * expected to fail in an isolated root, and these assertions deliberately touch only the trust check.
  */
 describe("doctor reports the loopback trust topology", () => {
   const saved = { ...process.env };
@@ -61,7 +64,7 @@ describe("doctor reports the loopback trust topology", () => {
 
   async function isolatedRoot(): Promise<string> {
     const root = await mkdtemp(join(tmpdir(), "gateway-doctor-"));
-    for (const part of ["config/omp-session-gateway", "state/omp-session-gateway", "run/omp-session-gateway", "bin"]) {
+    for (const part of ["config/omp-session-gateway", "state/omp-session-gateway", "run/omp-session-gateway"]) {
       await mkdir(join(root, part), { recursive: true, mode: 0o700 });
     }
     const configPath = join(root, "config/omp-session-gateway/config.json");
@@ -78,24 +81,9 @@ describe("doctor reports the loopback trust topology", () => {
     await writeFile(tokenPath, "D".repeat(43));
     await chmod(tokenPath, 0o600);
 
-    // A fake `tailscale` so `BackendState` is an input to the test rather than a fact about the host.
-    const fake = join(root, "bin/tailscale");
-    await writeFile(
-      fake,
-      [
-        "#!/bin/sh",
-        'if [ "$1" = "status" ]; then echo \'{"BackendState":"Running","Self":{"TailscaleIPs":["100.101.102.103"]}}\'; exit 0; fi',
-        'if [ "$1" = "serve" ]; then echo \'{}\'; exit 0; fi',
-        'if [ "$1" = "funnel" ]; then echo \'{}\'; exit 0; fi',
-        "exit 1",
-      ].join("\n"),
-    );
-    await chmod(fake, 0o755);
-
     process.env.XDG_CONFIG_HOME = join(root, "config");
     process.env.XDG_STATE_HOME = join(root, "state");
     process.env.XDG_RUNTIME_DIR = join(root, "run");
-    process.env.PATH = `${join(root, "bin")}:${process.env.PATH ?? ""}`;
     return root;
   }
 
@@ -104,7 +92,6 @@ describe("doctor reports the loopback trust topology", () => {
 
     const report = await runDoctorChecks({ tunDevicePresent: () => false });
 
-    expect(report.checks.tailscaleConnected).toBe(true);
     expect(report.checks.loopbackTrustSound).toBe(false);
     // Deliberately no assertion on `listenerLoopbackOnly` here. It is computed as
     // `checks.daemon && hostname is loopback`, and no daemon runs in this isolated root, so it is
@@ -118,7 +105,6 @@ describe("doctor reports the loopback trust topology", () => {
 
     const report = await runDoctorChecks({ tunDevicePresent: () => true });
 
-    expect(report.checks.tailscaleConnected).toBe(true);
     expect(report.checks.loopbackTrustSound).toBe(true);
   }, 30_000);
 

--- a/apps/gateway/test/security-mutations.test.ts
+++ b/apps/gateway/test/security-mutations.test.ts
@@ -1,0 +1,187 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { cp, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Named mutations over the security predicates, each of which must fail a named test.
+ *
+ * Coverage says a line executed. It does not say any assertion would notice if that line stopped
+ * doing its job, and for this repository's authorization boundary that is the only property worth
+ * having. Bun's own coverage cannot supply it either way: its lcov carries no `BRDA` records at all,
+ * so there is no branch signal to read, and `FNF`/`FNH` arrive as bare totals with no `FN:`/`FNDA:`
+ * attribution. This measures discrimination instead of execution — weaken one specific guard in a
+ * copy of the tree, run the test that claims to defend it, and require that test to fail.
+ *
+ * Deliberately not tree-wide mutation testing, which would be a large persistent control generating
+ * mostly noise about code whose failure costs nothing. Every entry below is a guard whose removal
+ * costs a remote authentication bypass or a leaked capability, and the list is meant to stay short
+ * enough that someone reads it.
+ *
+ * The vacuity guard matters more than the mutations. If a `find` string stops matching — a refactor,
+ * a rename, a reformat — the mutation silently becomes a no-op and the check passes while proving
+ * nothing, which is worse than not having it. A pattern that no longer applies is a failure here, not
+ * a skip.
+ */
+
+interface Mutation {
+  /** What protection is being removed, in terms an operator would care about. */
+  readonly name: string;
+  readonly file: string;
+  readonly find: string;
+  readonly replace: string;
+  /** The suite that claims to defend it. */
+  readonly target: string;
+  /** The specific case that must fail. A suite failing *somewhere* is not evidence about this guard. */
+  readonly mustFail: string;
+}
+
+const MUTATIONS: readonly Mutation[] = [
+  {
+    name: "identity headers believed on a host with no Tailscale tunnel device (#98)",
+    file: "apps/gateway/src/auth.ts",
+    find: 'if (!serveOwnsIdentityHeaders) return { allowed: false, reason: "identity_untrustworthy" };',
+    replace: 'if (false && !serveOwnsIdentityHeaders) return { allowed: false, reason: "identity_untrustworthy" };',
+    target: "apps/gateway/test/http.test.ts",
+    mustFail: "refuses an allowlisted identity when no tailnet interface vouches for Serve",
+  },
+  {
+    name: "shared CGNAT space accepted as proof of a tunnel device (#98)",
+    file: "apps/gateway/src/tailnet.ts",
+    find: "if (tunnel && entry.netmask === IPV4_HOST_ROUTE_NETMASK && TAILNET_IPV4.test(entry.address)) return true;",
+    replace: "if (TAILNET_IPV4.test(entry.address)) return true;",
+    target: "apps/gateway/test/tailnet.test.ts",
+    mustFail: "an ordinary interface on shared CGNAT space does not vouch for a TUN device",
+  },
+  {
+    name: "non-loopback peers admitted",
+    file: "apps/gateway/src/auth.ts",
+    find: 'if (peer === undefined || !isLoopbackAddress(peer.address)) return { allowed: false, reason: "unauthorized" };',
+    replace: 'if (peer === undefined) return { allowed: false, reason: "unauthorized" };',
+    target: "apps/gateway/test/http.test.ts",
+    mustFail: "fails closed for missing, disallowed, forged remote, and tagged-style identities",
+  },
+  {
+    name: "identity allowlist not consulted",
+    file: "apps/gateway/src/auth.ts",
+    find: "if (login === undefined || !config.auth.allowedLogins.includes(login)) {",
+    replace: "if (login === undefined) {",
+    target: "apps/gateway/test/http.test.ts",
+    mustFail: "fails closed for missing, disallowed, forged remote, and tagged-style identities",
+  },
+  {
+    name: "an admitted event stream never re-authorized",
+    file: "apps/gateway/src/http.ts",
+    find: "if (!stillAuthorized()) {",
+    replace: "if (false) {",
+    target: "apps/gateway/test/http.test.ts",
+    mustFail: "an admitted stream stops when the topology stops justifying it",
+  },
+  {
+    name: "a superseded generation still yields its capability",
+    file: "apps/gateway/src/registry.ts",
+    find: "if (metadata.metadata.generation !== generation || secret.generation !== generation) {",
+    replace: "if (false) {",
+    target: "apps/gateway/test/registry.test.ts",
+    mustFail: "revokes an old generation before replacement becomes observable",
+  },
+  {
+    name: "doctor claims sound loopback trust unconditionally (#98)",
+    file: "apps/gateway/src/doctor.ts",
+    find: "checks.loopbackTrustSound = tunDevicePresent();",
+    replace: "checks.loopbackTrustSound = true;",
+    target: "apps/gateway/test/doctor.test.ts",
+    mustFail: "withholds the loopback claim and names the finding when no tunnel device is present",
+  },
+  // Deliberately absent: withholding `listenerLoopbackOnly` on unsound trust. That check is
+  // unobservable without a live daemon on the fixture's port, because the value is
+  // `checks.daemon && hostname is loopback` and is false either way in an isolated root. Adding the
+  // mutation anyway would give a permanently red harness that proves nothing, which is exactly the
+  // vacuity this file exists to prevent.
+];
+
+/**
+ * Only genuinely regenerable or irrelevant trees are skipped. `docs` and `patches` are copied
+ * because target suites read them — `doctor.test.ts` asserts against the shipped OMP patch, and
+ * omitting it made the baseline fail for a reason that had nothing to do with any mutation.
+ */
+const SKIPPED_TREES: Record<string, true> = {
+  node_modules: true,
+  ".git": true,
+  dist: true,
+  coverage: true,
+  "playwright-report": true,
+};
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const selfPath = relative(repoRoot, fileURLToPath(import.meta.url)).replaceAll("\\", "/");
+let tree = "";
+
+beforeAll(async () => {
+  tree = await mkdtemp(join(tmpdir(), "gateway-mutation-"));
+  // Copied rather than mutated in place: a harness that edits the working tree can leave a weakened
+  // guard behind if it dies between mutation and restore. `node_modules` is symlinked rather than
+  // copied because Bun resolves the workspace packages through per-package link directories, and
+  // those relative links must keep resolving inside the copy.
+  await cp(repoRoot, tree, {
+    recursive: true,
+    verbatimSymlinks: true,
+    filter: source => {
+      const rel = relative(repoRoot, source).replaceAll("\\", "/");
+      if (rel === "") return true;
+      return SKIPPED_TREES[rel.split("/")[0] ?? ""] !== true || rel.includes("/node_modules");
+    },
+  });
+  await symlink(join(repoRoot, "node_modules"), join(tree, "node_modules"), "dir");
+});
+
+afterAll(async () => {
+  await rm(tree, { recursive: true, force: true });
+});
+
+async function runTarget(target: string): Promise<{ readonly code: number; readonly output: string }> {
+  const subprocess = Bun.spawn([process.execPath, "test", target], { cwd: tree, stdout: "pipe", stderr: "pipe" });
+  const [code, stdout, stderr] = await Promise.all([
+    subprocess.exited,
+    new Response(subprocess.stdout).text(),
+    new Response(subprocess.stderr).text(),
+  ]);
+  return { code, output: `${stdout}\n${stderr}` };
+}
+
+test("every mutated suite passes before it is mutated", async () => {
+  // Without this, a mutation could "fail" for an unrelated reason — a broken copy, a missing
+  // workspace link — and the harness would report protection it never demonstrated.
+  const targets = [...new Set(MUTATIONS.map(mutation => mutation.target))];
+  expect(targets.length).toBeGreaterThan(0);
+  for (const target of targets) {
+    expect(target).not.toBe(selfPath);
+    const baseline = await runTarget(target);
+    expect({ target, code: baseline.code }).toEqual({ target, code: 0 });
+  }
+}, 120_000);
+
+for (const mutation of MUTATIONS) {
+  test(`removing a guard is caught: ${mutation.name}`, async () => {
+    const path = join(tree, mutation.file);
+    const original = await readFile(path, "utf8");
+
+    // A pattern that no longer matches is a failure, not a skip: a silently inapplicable mutation
+    // leaves the suite green while the guard it names is unprotected.
+    expect(original.includes(mutation.find)).toBe(true);
+    const mutated = original.replaceAll(mutation.find, mutation.replace);
+    expect(mutated).not.toBe(original);
+
+    try {
+      await writeFile(path, mutated);
+      const result = await runTarget(mutation.target);
+      expect(result.code).not.toBe(0);
+      // The named case must be the one that fails, tying the mutation to the assertion that claims
+      // to defend it rather than to collateral damage elsewhere in the suite.
+      expect(result.output).toContain(mutation.mustFail);
+    } finally {
+      await writeFile(path, original);
+    }
+  }, 120_000);
+}

--- a/apps/gateway/test/security-mutations.test.ts
+++ b/apps/gateway/test/security-mutations.test.ts
@@ -116,9 +116,17 @@ const SKIPPED_TREES: Record<string, true> = {
 
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
 const selfPath = relative(repoRoot, fileURLToPath(import.meta.url)).replaceAll("\\", "/");
+/**
+ * Creating the `node_modules` directory symlink the copied tree needs requires elevation on Windows,
+ * so this harness does not run there. Stated rather than silently skipped: Windows is not an
+ * advertised host, and the Linux and macOS lanes both run these mutations on every pull request, so
+ * no guard here goes unexercised. If Windows is ever advertised, this needs a junction instead.
+ */
+const RUNNABLE = process.platform !== "win32";
 let tree = "";
 
 beforeAll(async () => {
+  if (!RUNNABLE) return;
   tree = await mkdtemp(join(tmpdir(), "gateway-mutation-"));
   // Copied rather than mutated in place: a harness that edits the working tree can leave a weakened
   // guard behind if it dies between mutation and restore. `node_modules` is symlinked rather than
@@ -137,6 +145,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  if (!RUNNABLE) return;
   await rm(tree, { recursive: true, force: true });
 });
 
@@ -150,7 +159,7 @@ async function runTarget(target: string): Promise<{ readonly code: number; reado
   return { code, output: `${stdout}\n${stderr}` };
 }
 
-test("every mutated suite passes before it is mutated", async () => {
+test.skipIf(!RUNNABLE)("every mutated suite passes before it is mutated", async () => {
   // Without this, a mutation could "fail" for an unrelated reason — a broken copy, a missing
   // workspace link — and the harness would report protection it never demonstrated.
   const targets = [...new Set(MUTATIONS.map(mutation => mutation.target))];
@@ -163,7 +172,7 @@ test("every mutated suite passes before it is mutated", async () => {
 }, 120_000);
 
 for (const mutation of MUTATIONS) {
-  test(`removing a guard is caught: ${mutation.name}`, async () => {
+  test.skipIf(!RUNNABLE)(`removing a guard is caught: ${mutation.name}`, async () => {
     const path = join(tree, mutation.file);
     const original = await readFile(path, "utf8");
 

--- a/apps/gateway/test/service.test.ts
+++ b/apps/gateway/test/service.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { join, sep } from "node:path";
+import { statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, isAbsolute, join, resolve, sep } from "node:path";
 import type { GatewayConfig } from "../src/config.ts";
 import { serviceDefinition, serviceProgramBelongsTo } from "../src/service.ts";
 
@@ -16,6 +18,123 @@ const config: GatewayConfig = {
     configPath: "/Users/test/.config/omp-session-gateway/config.json",
   },
 };
+
+/** A generated CLI path shaped like the one `install` passes: under the state dir it is rooted in. */
+const installedCliPath = join(config.paths.stateDir, "installation", "versions", "0.1.0-a1b2c3d4e5f6", "apps", "gateway", "src", "cli.js");
+/** 43 url-safe characters: one unpadded 256-bit base64url value, the only shape the code accepts. */
+const boundInstance = "readiness_Instance-9".padEnd(43, "x");
+
+function withEnv(name: string, value: string | undefined, body: () => void): void {
+  const previous = process.env[name];
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+  try {
+    body();
+  } finally {
+    if (previous === undefined) delete process.env[name];
+    else process.env[name] = previous;
+  }
+}
+
+/*
+ * The helpers below stand in for the consumers of these generated files: systemd's unit parser,
+ * launchd's plist reader, Task Scheduler's XML loader. Asserting on the whole document as one string
+ * cannot distinguish a directive that landed in the wrong section, or an escaped payload from an
+ * injected element, from a correct file. Parsing it the way the consumer does can.
+ */
+
+/** Directive lines grouped by `[Section]`; systemd silently ignores a directive in the wrong one. */
+function unitSections(unit: string): ReadonlyMap<string, readonly string[]> {
+  const sections = new Map<string, string[]>();
+  let current: string[] = [];
+  for (const line of unit.split("\n")) {
+    if (line.trim() === "") continue;
+    const name = /^\[([^\]]+)\]$/u.exec(line)?.[1];
+    if (name === undefined) {
+      current.push(line);
+      continue;
+    }
+    current = [];
+    sections.set(name, current);
+  }
+  return sections;
+}
+
+function unitSection(unit: string, name: string): readonly string[] {
+  const lines = unitSections(unit).get(name);
+  if (lines === undefined) throw new Error(`unit has no [${name}] section`);
+  return lines;
+}
+
+/** The values a `[Service]` directive resolves to once systemd's quoting is undone. */
+function unitTokens(unit: string, directive: string): readonly string[] {
+  const line = unitSection(unit, "Service").find(entry => entry.startsWith(`${directive}=`));
+  if (line === undefined) throw new Error(`unit has no ${directive}`);
+  const quoted = line.slice(directive.length + 1).matchAll(/"(?:[^"\\]|\\.)*"/gu);
+  return [...quoted].map(match => JSON.parse(match[0]) as string);
+}
+
+function xmlUnescape(value: string): string {
+  // `&amp;` last, or `&amp;lt;` would decode twice.
+  return value.replaceAll("&lt;", "<").replaceAll("&gt;", ">").replaceAll("&quot;", '"').replaceAll("&amp;", "&");
+}
+
+/**
+ * Element names in document order, rejecting what a real parser rejects: unbalanced tags, raw markup
+ * in text, or a bare ampersand. A dropped escape surfaces here as a structural difference rather
+ * than as a string that merely looks odd.
+ */
+function xmlElements(document: string): readonly string[] {
+  const body = document.replace(/<\?[^?]*\?>/gu, "").replace(/<!DOCTYPE[^>]*>/gu, "");
+  const opened: string[] = [];
+  const stack: string[] = [];
+  let cursor = 0;
+  while (cursor < body.length) {
+    const start = body.indexOf("<", cursor);
+    const text = start === -1 ? body.slice(cursor) : body.slice(cursor, start);
+    if (/[<>]/u.test(text)) throw new Error(`unescaped markup in text: ${text}`);
+    if (/&(?!(?:amp|lt|gt|quot|apos);)/u.test(text)) throw new Error(`unescaped ampersand in text: ${text}`);
+    if (start === -1) break;
+    const end = body.indexOf(">", start);
+    if (end === -1) throw new Error("unterminated tag");
+    const tag = body.slice(start + 1, end);
+    cursor = end + 1;
+    if (tag.startsWith("/")) {
+      if (stack.pop() !== tag.slice(1)) throw new Error(`unbalanced close tag: <${tag}>`);
+      continue;
+    }
+    const name = tag.replace(/\/$/u, "").split(/\s/u)[0] ?? "";
+    opened.push(name);
+    if (!tag.endsWith("/")) stack.push(name);
+  }
+  if (stack.length > 0) throw new Error(`unclosed elements: ${stack.join(", ")}`);
+  return opened;
+}
+
+function xmlText(document: string, element: string): string {
+  const text = new RegExp(`<${element}>([^<]*)</${element}>`, "u").exec(document)?.[1];
+  if (text === undefined) throw new Error(`document has no <${element}>`);
+  return text;
+}
+
+function plistString(plist: string, key: string): string {
+  const value = new RegExp(`<key>${key}</key>\\s*<string>([^<]*)</string>`, "u").exec(plist)?.[1];
+  if (value === undefined) throw new Error(`plist has no ${key} string`);
+  return value;
+}
+
+/** The argv launchd would exec, entities decoded. */
+function plistProgramArguments(plist: string): readonly string[] {
+  const body = /<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/u.exec(plist)?.[1];
+  if (body === undefined) throw new Error("plist has no ProgramArguments array");
+  return [...body.matchAll(/<string>([^<]*)<\/string>/gu)].map(match => xmlUnescape(match[1] ?? ""));
+}
+
+/** The `<Arguments>` string split back into the argv Task Scheduler would append to `<Command>`. */
+function taskArguments(taskXml: string): readonly string[] {
+  const quoted = xmlText(taskXml, "Arguments").matchAll(/&quot;(.*?)&quot;/gu);
+  return [...quoted].map(match => xmlUnescape(match[1] ?? ""));
+}
 
 describe("service packaging", () => {
   test("generates hardened Linux systemd user service", () => {
@@ -143,5 +262,332 @@ describe("loaded service ownership", () => {
     const execStart = `{ path=/usr/bin/bun ; argv[]=/usr/bin/bun ${installedCli} serve ; ignore_errors=no }`;
     expect(serviceProgramBelongsTo(execStart, stateDir)).toBe(true);
     expect(serviceProgramBelongsTo(execStart, otherRoot)).toBe(false);
+  });
+
+  test("disclaims a root whose name is a prefix of an unrelated directory's name", () => {
+    // `/tmp/state` against `/tmp/statement/...`: the case the trailing separator exists for. A
+    // substring test adopts an install that shares nothing but the first characters of its name.
+    const root = join(sep, "tmp", "state");
+    expect(serviceProgramBelongsTo(join(sep, "tmp", "statement", "installation", "cli.js"), root)).toBe(false);
+    expect(serviceProgramBelongsTo(join(root, "installation", "cli.js"), root)).toBe(true);
+  });
+
+  test("disclaims a rendering that names the root but no program under it", () => {
+    // The install root is not a program. A unit whose ExecStart was cleared, or a launchctl print
+    // that only echoes the directory, must not read as ours: `active` gates stop and rotation.
+    expect(serviceProgramBelongsTo(stateDir, stateDir)).toBe(false);
+    expect(serviceProgramBelongsTo("", stateDir)).toBe(false);
+  });
+});
+
+describe("systemd unit structure", () => {
+  test("puts every directive in the section systemd reads it from", () => {
+    // A directive in the wrong section is not an error, it is a silent no-op: `WantedBy=` outside
+    // [Install] makes `systemctl --user enable` create no symlink, so the gateway never autostarts.
+    const content = serviceDefinition(config, "linux").content;
+    expect([...unitSections(content).keys()]).toEqual(["Unit", "Service", "Install"]);
+    expect(unitSection(content, "Unit")).toContain("After=network-online.target");
+    expect(unitSection(content, "Install")).toContain("WantedBy=default.target");
+    const service = unitSection(content, "Service");
+    expect(service).toContain("Restart=on-failure");
+    expect(service).toContain("NoNewPrivileges=true");
+    expect(service).toContain("ProtectSystem=strict");
+    expect(service).toContain("ProtectHome=read-only");
+    expect(service.filter(line => line.startsWith("ExecStart=")).length).toBe(1);
+  });
+
+  test("names the unit file exactly what the systemctl calls address", () => {
+    // Every systemctl call in service.ts hardcodes `omp-session-gateway.service`. A file written
+    // under any other name is enabled by nothing, and status reports it as not installed.
+    const definition = serviceDefinition(config, "linux");
+    expect(basename(definition.path)).toBe(`${definition.identifier}.service`);
+    expect(definition.path).toEndWith(join("systemd", "user", "omp-session-gateway.service"));
+  });
+
+  test("writes the unit where the systemd user manager looks for it", () => {
+    const configHome = join(sep, "tmp", "xdg-config-home");
+    withEnv("XDG_CONFIG_HOME", configHome, () => {
+      expect(serviceDefinition(config, "linux").path).toBe(join(configHome, "systemd", "user", "omp-session-gateway.service"));
+    });
+    withEnv("XDG_CONFIG_HOME", undefined, () => {
+      const fallback = join(homedir(), ".config", "systemd", "user", "omp-session-gateway.service");
+      expect(serviceDefinition(config, "linux").path).toBe(fallback);
+    });
+  });
+
+  test("hands systemd the runtime directory only when it is the one systemd would create", () => {
+    // Continuation of #69. `RuntimeDirectory=omp-session-gateway` creates exactly
+    // `$XDG_RUNTIME_DIR/omp-session-gateway`, so the decision turns on that exact path and not on
+    // XDG_RUNTIME_DIR merely being set. Claiming it for a near-miss would leave the real runtime
+    // directory unwritable under ProtectHome=, and create a stray directory nobody uses.
+    const xdgRuntimeDir = join(sep, "run", "user", "1000");
+    const nearMisses = [
+      join(xdgRuntimeDir, "omp-session-gateway-2"),
+      join(xdgRuntimeDir, "omp-session-gateway", "nested"),
+      join(xdgRuntimeDir, "..", "omp-session-gateway"),
+      join(config.paths.stateDir, "run"),
+    ];
+    withEnv("XDG_RUNTIME_DIR", xdgRuntimeDir, () => {
+      for (const runtimeDir of nearMisses) {
+        const content = serviceDefinition({ paths: { ...config.paths, runtimeDir } }, "linux").content;
+        expect(content).not.toContain("RuntimeDirectory=");
+        expect(unitTokens(content, "ReadWritePaths")).toContain(runtimeDir);
+      }
+      const exact = serviceDefinition({ paths: { ...config.paths, runtimeDir: join(xdgRuntimeDir, "omp-session-gateway") } }, "linux");
+      expect(unitSection(exact.content, "Service")).toContain("RuntimeDirectory=omp-session-gateway");
+      expect(unitSection(exact.content, "Service")).toContain("RuntimeDirectoryMode=0700");
+      expect(unitTokens(exact.content, "ReadWritePaths")).toEqual([config.paths.configDir, config.paths.stateDir]);
+    });
+  });
+
+  test("keeps the daemon's own directories writable under ProtectHome=read-only", () => {
+    // ProtectSystem=strict plus ProtectHome=read-only makes everything read-only by default, so a
+    // path dropped from here is a daemon that starts and then fails its first write.
+    withEnv("XDG_RUNTIME_DIR", undefined, () => {
+      const content = serviceDefinition(config, "linux").content;
+      expect(unitTokens(content, "ReadWritePaths")).toEqual([
+        config.paths.configDir,
+        config.paths.stateDir,
+        config.paths.runtimeDir,
+      ]);
+    });
+  });
+
+  test("quotes paths losslessly instead of letting one inject a directive", () => {
+    // These paths come from flags and environment, into a file systemd parses line by line. A quote
+    // or newline that survives unescaped appends directives of the caller's choosing.
+    withEnv("XDG_RUNTIME_DIR", undefined, () => {
+      const hostile = `${join(sep, "tmp", "gateway-state")}"\nExecStart=${join(sep, "bin", "sh")}`;
+      const content = serviceDefinition({ paths: { ...config.paths, stateDir: hostile } }, "linux").content;
+      expect(unitSection(content, "Service").filter(line => line.startsWith("ExecStart=")).length).toBe(1);
+      expect(content.split("\n").length).toBe(serviceDefinition(config, "linux").content.split("\n").length);
+      // Lossless, not merely safe: systemd must still exec on the exact directory it was given.
+      expect(unitTokens(content, "ReadWritePaths")).toContain(hostile);
+    });
+  });
+
+  test("execs an absolute program with no shell in between", () => {
+    // systemd refuses an ExecStart that is not an absolute path, and there is no shell in the chain
+    // to re-quote anything, so these tokens are what the kernel receives.
+    withEnv("XDG_RUNTIME_DIR", undefined, () => {
+      const tokens = unitTokens(serviceDefinition(config, "linux", installedCliPath).content, "ExecStart");
+      expect(tokens[0]).toBe(process.execPath);
+      expect(tokens.at(-1)).toBe("serve");
+      for (const token of tokens.slice(0, -1)) expect(isAbsolute(token)).toBe(true);
+    });
+  });
+});
+
+describe("macOS launch agent", () => {
+  test("installs into the current user's LaunchAgents domain, never a system daemon", () => {
+    // A plist under /Library/LaunchDaemons runs as root at boot. This service is a per-user agent by
+    // design: it serves one logged-in user's sessions and owns files in that user's home.
+    const definition = serviceDefinition(config, "darwin", installedCliPath);
+    expect(definition.path).toBe(join(homedir(), "Library", "LaunchAgents", "omp-session-gateway.plist"));
+    expect(definition.path.startsWith(homedir() + sep)).toBe(true);
+    expect(definition.content).not.toContain("UserName");
+    expect(plistString(definition.content, "ProcessType")).toBe("Background");
+  });
+
+  test("labels the agent exactly what launchctl is asked to print and bootout", () => {
+    // install/stop/uninstall all address `gui/<uid>/omp-session-gateway`. If the Label drifts from
+    // the identifier, bootout targets a service that does not exist and stop silently does nothing.
+    const definition = serviceDefinition(config, "darwin", installedCliPath);
+    expect(plistString(definition.content, "Label")).toBe(definition.identifier);
+  });
+
+  test("emits a plist a consumer can parse", () => {
+    const content = serviceDefinition(config, "darwin", installedCliPath).content;
+    expect(content).toStartWith('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(content).toContain("-//Apple//DTD PLIST 1.0//EN");
+    // Throws on unbalanced tags or raw markup in text, which is what a plist reader would do.
+    const elements = xmlElements(content);
+    expect(elements[0]).toBe("plist");
+    expect(elements[1]).toBe("dict");
+    expect(elements).toContain("array");
+  });
+
+  test("carries the paths it was given into the program arguments", () => {
+    // The plist embeds argv and nothing else, so the config reaches it through the installed CLI
+    // path, which `install` roots under the state directory it was configured with.
+    const definition = serviceDefinition(config, "darwin", installedCliPath);
+    expect(plistProgramArguments(definition.content)).toContain(installedCliPath);
+    expect(installedCliPath.startsWith(config.paths.stateDir + sep)).toBe(true);
+  });
+
+  test("escapes markup in a program path instead of emitting another plist key", () => {
+    const hostile = join(sep, "tmp", 'gateway&"<danger>"', "</string><key>RunAtLoad</key><false/><string>cli.js");
+    const benign = serviceDefinition(config, "darwin", join(sep, "tmp", "gateway", "cli.js")).content;
+    const injected = serviceDefinition(config, "darwin", hostile).content;
+    // Escaping means the payload can only change text: the element structure is byte-for-byte the
+    // same shape as a benign path's. Dropping xmlEscape diverges here immediately.
+    expect(xmlElements(injected)).toEqual(xmlElements(benign));
+    expect(injected).toContain("&lt;/string&gt;");
+    expect(injected).toContain("&amp;");
+    expect(injected).toContain("&quot;");
+    expect(injected).toContain("<key>RunAtLoad</key><true/>");
+    expect(injected).not.toContain("<key>RunAtLoad</key><false/>");
+    // And launchd still recovers the exact path it has to exec.
+    expect(plistProgramArguments(injected)).toEqual([process.execPath, resolve(hostile), "serve"]);
+  });
+});
+
+describe("windows scheduled task", () => {
+  test("starts at interactive logon rather than at boot (#90)", () => {
+    // Deliberate and documented: the gateway serves a logged-in user's sessions with that user's
+    // token, so it starts with the session, not with the machine. Moving to boot-start means
+    // changing this test on purpose rather than changing behaviour by accident.
+    const content = serviceDefinition(config, "win32", installedCliPath).content;
+    expect(content).toContain("<LogonTrigger><Enabled>true</Enabled></LogonTrigger>");
+    expect(xmlText(content, "LogonType")).toBe("InteractiveToken");
+    expect(content).not.toContain("BootTrigger");
+    expect(content).not.toContain("ServiceAccount");
+    expect(content).not.toContain("S4U");
+    expect(content).not.toContain("Password");
+  });
+
+  test("declares the UTF-16 encoding the installer writes and carries no BOM of its own", () => {
+    // The installer serializes this document as UTF-16LE behind a hand-written BOM. Task Scheduler
+    // refuses XML whose declaration disagrees with its bytes, and a BOM already in the string would
+    // be encoded a second time and sit as a stray character in front of the declaration.
+    const content = serviceDefinition(config, "win32", installedCliPath).content;
+    expect(content).toStartWith('<?xml version="1.0" encoding="UTF-16"?>');
+    expect(content).not.toContain("UTF-8");
+    expect(content).not.toContain("\uFEFF");
+  });
+
+  test("splits the runtime from its arguments the way schtasks expects", () => {
+    const content = serviceDefinition(config, "win32", installedCliPath).content;
+    expect(xmlText(content, "Command")).toBe(process.execPath);
+    expect(taskArguments(content)).toEqual([installedCliPath, "serve"]);
+    // Repeating the executable in <Arguments> would launch the runtime with itself as its script.
+    expect(xmlText(content, "Arguments")).not.toContain(process.execPath);
+  });
+
+  test("writes the task definition inside the config directory it was given", () => {
+    // schtasks reads this path, and install mkdirs its parent at 0700. A path outside the config
+    // root escapes every sandbox an isolated install sets up.
+    const definition = serviceDefinition(config, "win32", installedCliPath);
+    expect(definition.path).toBe(join(config.paths.configDir, "omp-session-gateway-task.xml"));
+  });
+
+  test("registers one hard-terminable instance with no execution time limit", () => {
+    // IgnoreNew keeps a second logon from starting a rival daemon on the same socket;
+    // AllowHardTerminate is what makes `schtasks /End` able to stop it; PT0S is what stops Task
+    // Scheduler from killing a long-running service when the default execution time limit expires.
+    const content = serviceDefinition(config, "win32", installedCliPath).content;
+    expect(content).toContain("<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>");
+    expect(content).toContain("<AllowHardTerminate>true</AllowHardTerminate>");
+    expect(content).toContain("<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>");
+  });
+
+  test("escapes markup in a program path instead of emitting another task element", () => {
+    const hostile = join(sep, "tmp", "gateway&danger", "</Arguments><Exec><Command>evil.exe</Command><Arguments>cli.js");
+    const benign = serviceDefinition(config, "win32", join(sep, "tmp", "gateway", "cli.js")).content;
+    const injected = serviceDefinition(config, "win32", hostile).content;
+    expect(xmlElements(injected)).toEqual(xmlElements(benign));
+    expect(injected).toContain("&lt;Exec&gt;");
+    expect(injected).toContain("&amp;danger");
+    expect(injected).not.toContain("<Exec><Command>evil.exe");
+    expect(xmlText(injected, "Command")).toBe(process.execPath);
+  });
+});
+
+describe("service argv", () => {
+  // The runtime here is bun, so the generated argv passes the script path explicitly; that is the
+  // shape asserted below. These tokens are what the service manager execs, with no shell to re-split.
+  test("threads the installed CLI into every platform's generated command", () => {
+    const expected = [process.execPath, installedCliPath, "serve"];
+    withEnv("XDG_RUNTIME_DIR", undefined, () => {
+      expect(unitTokens(serviceDefinition(config, "linux", installedCliPath).content, "ExecStart")).toEqual(expected);
+    });
+    expect(plistProgramArguments(serviceDefinition(config, "darwin", installedCliPath).content)).toEqual(expected);
+    const task = serviceDefinition(config, "win32", installedCliPath).content;
+    expect([xmlText(task, "Command"), ...taskArguments(task)]).toEqual(expected);
+  });
+
+  test("appends a bound readiness instance as a separate flag and value after the command", () => {
+    // Two argv entries, and both after `serve`: the CLI reads argv[0] as the command and rejects an
+    // unknown option, so a joined token or a flag ahead of the command is a daemon that will not
+    // start. This is the handshake that proves the newly installed instance is the one answering.
+    const expected = [process.execPath, installedCliPath, "serve", "--readiness-instance", boundInstance];
+    withEnv("XDG_RUNTIME_DIR", undefined, () => {
+      const content = serviceDefinition(config, "linux", installedCliPath, boundInstance).content;
+      expect(unitTokens(content, "ExecStart")).toEqual(expected);
+    });
+    const plist = serviceDefinition(config, "darwin", installedCliPath, boundInstance).content;
+    expect(plistProgramArguments(plist)).toEqual(expected);
+    const task = serviceDefinition(config, "win32", installedCliPath, boundInstance).content;
+    expect([xmlText(task, "Command"), ...taskArguments(task)]).toEqual(expected);
+  });
+
+  test("omits the readiness flag entirely when no instance is bound", () => {
+    // An empty or dangling `--readiness-instance` would make the daemon refuse to start; the flag
+    // has to be absent, not present-and-empty.
+    for (const platform of ["linux", "darwin", "win32"] as const) {
+      expect(serviceDefinition(config, platform, installedCliPath).content).not.toContain("--readiness-instance");
+    }
+  });
+
+  test("falls back to the running script when no installed CLI is given", () => {
+    // The pre-install path calls this before any runtime directory exists to point at. The fallback
+    // still has to produce a complete argv: a missing or empty script argument leaves the runtime
+    // with no program, and the service manager starts something that is not the gateway.
+    const fallback = plistProgramArguments(serviceDefinition(config, "darwin").content);
+    const explicit = plistProgramArguments(serviceDefinition(config, "darwin", installedCliPath).content);
+    expect(fallback.length).toBe(explicit.length);
+    expect(fallback[0]).toBe(process.execPath);
+    expect(fallback.at(-1)).toBe("serve");
+    expect(fallback.every(argument => argument.length > 0)).toBe(true);
+    // `resolve("")` would yield the working directory, which is absolute and non-empty, and launchd
+    // would faithfully hand that directory to bun as the script to run.
+    expect(isAbsolute(fallback[1] ?? "")).toBe(true);
+    expect(statSync(fallback[1] ?? ".").isFile()).toBe(true);
+  });
+
+  test("resolves a relative installed CLI to an absolute program path", () => {
+    // Service managers exec from an unspecified working directory, so a relative script path is a
+    // service that starts nothing.
+    const relative = join("relative", "cli.js");
+    const arguments_ = plistProgramArguments(serviceDefinition(config, "darwin", relative).content);
+    expect(arguments_[1]).toBe(resolve(relative));
+    expect(isAbsolute(arguments_[1] ?? "")).toBe(true);
+  });
+
+  test("refuses a readiness instance that is not exactly 43 url-safe characters", () => {
+    // The instance is interpolated into a file the service manager parses and into an HMAC input, so
+    // a permissive check is both an injection and a silent readiness bypass.
+    expect(serviceDefinition(config, "linux", installedCliPath, boundInstance).content).toContain(boundInstance);
+    const rejected = [
+      boundInstance.slice(0, 42),
+      `${boundInstance}x`,
+      `${boundInstance.slice(0, 42)}=`,
+      `${boundInstance.slice(0, 42)}.`,
+      `${boundInstance.slice(0, 30)}\n${"x".repeat(12)}`,
+      "",
+    ];
+    for (const instance of rejected) {
+      expect(() => serviceDefinition(config, "linux", installedCliPath, instance)).toThrow(
+        "invalid service readiness instance",
+      );
+    }
+  });
+});
+
+describe("unsupported platforms", () => {
+  test("refuses to invent a service definition for a platform it cannot install on", () => {
+    // Returning something plausible here would write a file no service manager reads and report a
+    // successful install.
+    for (const platform of ["freebsd", "openbsd", "sunos", "aix"] as const) {
+      expect(() => serviceDefinition(config, platform)).toThrow(`unsupported platform: ${platform}`);
+    }
+  });
+
+  test("validates the readiness instance before it looks at the platform", () => {
+    // Precedence decides which error the caller sees: a malformed token is the caller's bug and must
+    // be named as such, even on a host that could never host the service anyway.
+    expect(() => serviceDefinition(config, "sunos", installedCliPath, "short")).toThrow(
+      "invalid service readiness instance",
+    );
   });
 });

--- a/apps/gateway/test/service.test.ts
+++ b/apps/gateway/test/service.test.ts
@@ -21,6 +21,14 @@ const config: GatewayConfig = {
 
 /** A generated CLI path shaped like the one `install` passes: under the state dir it is rooted in. */
 const installedCliPath = join(config.paths.stateDir, "installation", "versions", "0.1.0-a1b2c3d4e5f6", "apps", "gateway", "src", "cli.js");
+/**
+ * What a generated definition actually names for `installedCliPath`. The explicit `platform`
+ * argument selects which document to generate, not the path semantics the process runs under:
+ * `serviceDefinition` resolves the CLI path with the *host's* rules, so on Windows the separators
+ * are backslashes and `resolve` also prepends the current drive. Expectations therefore have to go
+ * through the same call rather than spell a path out, or they only hold on POSIX hosts.
+ */
+const installedCliArgument = resolve(installedCliPath);
 /** 43 url-safe characters: one unpadded 256-bit base64url value, the only shape the code accepts. */
 const boundInstance = "readiness_Instance-9".padEnd(43, "x");
 
@@ -411,18 +419,21 @@ describe("macOS launch agent", () => {
     // The plist embeds argv and nothing else, so the config reaches it through the installed CLI
     // path, which `install` roots under the state directory it was configured with.
     const definition = serviceDefinition(config, "darwin", installedCliPath);
-    expect(plistProgramArguments(definition.content)).toContain(installedCliPath);
-    expect(installedCliPath.startsWith(config.paths.stateDir + sep)).toBe(true);
+    expect(plistProgramArguments(definition.content)).toContain(installedCliArgument);
+    expect(installedCliArgument.startsWith(resolve(config.paths.stateDir) + sep)).toBe(true);
   });
 
   test("escapes markup in a program path instead of emitting another plist key", () => {
+    // On Windows the payload's own forward slashes are separators like any other, so `resolve`
+    // rewrites them: `</string>` arrives as `\string>`. The assertions below therefore name only
+    // characters no path rule touches, and the decoded round-trip at the end carries the exactness.
     const hostile = join(sep, "tmp", 'gateway&"<danger>"', "</string><key>RunAtLoad</key><false/><string>cli.js");
     const benign = serviceDefinition(config, "darwin", join(sep, "tmp", "gateway", "cli.js")).content;
     const injected = serviceDefinition(config, "darwin", hostile).content;
     // Escaping means the payload can only change text: the element structure is byte-for-byte the
     // same shape as a benign path's. Dropping xmlEscape diverges here immediately.
     expect(xmlElements(injected)).toEqual(xmlElements(benign));
-    expect(injected).toContain("&lt;/string&gt;");
+    expect(injected).toContain("&lt;key&gt;");
     expect(injected).toContain("&amp;");
     expect(injected).toContain("&quot;");
     expect(injected).toContain("<key>RunAtLoad</key><true/>");
@@ -459,7 +470,7 @@ describe("windows scheduled task", () => {
   test("splits the runtime from its arguments the way schtasks expects", () => {
     const content = serviceDefinition(config, "win32", installedCliPath).content;
     expect(xmlText(content, "Command")).toBe(process.execPath);
-    expect(taskArguments(content)).toEqual([installedCliPath, "serve"]);
+    expect(taskArguments(content)).toEqual([installedCliArgument, "serve"]);
     // Repeating the executable in <Arguments> would launch the runtime with itself as its script.
     expect(xmlText(content, "Arguments")).not.toContain(process.execPath);
   });
@@ -497,7 +508,7 @@ describe("service argv", () => {
   // The runtime here is bun, so the generated argv passes the script path explicitly; that is the
   // shape asserted below. These tokens are what the service manager execs, with no shell to re-split.
   test("threads the installed CLI into every platform's generated command", () => {
-    const expected = [process.execPath, installedCliPath, "serve"];
+    const expected = [process.execPath, installedCliArgument, "serve"];
     withEnv("XDG_RUNTIME_DIR", undefined, () => {
       expect(unitTokens(serviceDefinition(config, "linux", installedCliPath).content, "ExecStart")).toEqual(expected);
     });
@@ -510,7 +521,7 @@ describe("service argv", () => {
     // Two argv entries, and both after `serve`: the CLI reads argv[0] as the command and rejects an
     // unknown option, so a joined token or a flag ahead of the command is a daemon that will not
     // start. This is the handshake that proves the newly installed instance is the one answering.
-    const expected = [process.execPath, installedCliPath, "serve", "--readiness-instance", boundInstance];
+    const expected = [process.execPath, installedCliArgument, "serve", "--readiness-instance", boundInstance];
     withEnv("XDG_RUNTIME_DIR", undefined, () => {
       const content = serviceDefinition(config, "linux", installedCliPath, boundInstance).content;
       expect(unitTokens(content, "ExecStart")).toEqual(expected);

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,50 @@
+# Codecov configuration.
+#
+# Read these numbers with the runtime's limits in mind, because the limits are load-bearing:
+#
+#   - **There is no branch coverage.** Bun's coverage emits no `BRDA` records at all, so Codecov's
+#     branch column is not high, it is absent. Branch-level rigour in this repository comes from
+#     `apps/gateway/test/security-mutations.test.ts`, which weakens each named security guard in a
+#     copy of the tree and requires a specific named test to fail. That demonstrates an assertion
+#     *discriminates*, which is the property a branch percentage is usually a proxy for and never
+#     actually establishes.
+#   - **There is no per-function attribution.** `FNF`/`FNH` totals arrive with no `FN:`/`FNDA:`
+#     records, so function counts are totals only.
+#   - **Bun instruments only modules a test loads.** A file no test imports is missing from the
+#     report rather than reported at zero, which would let the headline flatter itself by omission
+#     and, worse, hide the file's existence. `scripts/module-import-sweep.test.ts` imports every
+#     server-side module so absence becomes an honest row; the cost is that import-time lines count
+#     as covered. Finding that sweep's first failure is what surfaced a real defect — a module that
+#     published sessions into a live gateway merely by being imported.
+#   - **`apps/web` is measured but under-reported.** Its behaviour is covered by the Playwright suite
+#     in `apps/web/e2e`, which Bun does not instrument, so its line coverage here reflects only what
+#     the unit tests load. It is kept in the report rather than ignored, because excluding production
+#     code to improve a number is exactly the move this file exists to discourage.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # A real regression gate, not a fixed target. The absolute figure is not the point; a drop is.
+        threshold: 1%
+    patch:
+      default:
+        # Informational deliberately. Because Bun omits modules no test imports, a new and entirely
+        # untested file can be *absent* from the diff coverage rather than reported at 0%, so a
+        # blocking patch target would pass vacuously in precisely the case it exists to catch. The
+        # import sweep narrows that gap but does not close it, so this stays advisory until the
+        # measurement can carry the weight.
+        informational: true
+
+comment:
+  layout: "condensed_header, diff, files"
+  require_changes: true
+
+ignore:
+  # Pinned upstream OMP collaboration client. Vendored at an exact commit, not written or fixable
+  # here; its provenance is recorded in packages/collab-client/upstream/UPSTREAM.json.
+  - "packages/collab-client/upstream/**"
+  # Test and fixture code. Measuring the tests' own coverage says nothing about the product.
+  - "**/*.test.ts"
+  - "apps/web/e2e/**"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "typecheck": "bun run --filter '*' typecheck",
     "build": "bun run --filter '@omp-session-gateway/web' build",
     "test": "bun test",
+    "test:coverage": "bun test --coverage --coverage-reporter=lcov",
     "check:capability-leaks": "bun scripts/check-capability-leaks.ts",
     "check:identifier-leaks": "bun scripts/check-identifier-leaks.ts",
     "release:build": "bun scripts/build-release.ts",

--- a/scripts/module-import-sweep.test.ts
+++ b/scripts/module-import-sweep.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 /**
  * Imports every server-side source module once.
@@ -36,7 +37,7 @@ function sourceModules(): readonly string[] {
   const glob = new Bun.Glob("**/*.ts");
   const found: string[] = [];
   for (const root of ROOTS) {
-    for (const file of glob.scanSync({ cwd: `${repoRoot}${root}`, onlyFiles: true })) {
+    for (const file of glob.scanSync({ cwd: join(repoRoot, root), onlyFiles: true })) {
       if (file.endsWith(".d.ts")) continue;
       found.push(`${root}/${file.replaceAll("\\", "/")}`);
     }
@@ -54,7 +55,8 @@ test("every server-side module is import-safe", async () => {
       // Dynamic by necessity: the specifier is discovered by glob at run time, which is the whole
       // point. A static import list would be the thing that goes stale and stops covering new
       // modules, and enumerating it by hand is exactly the omission this test exists to prevent.
-      const loaded = await import(`${repoRoot}${module}`);
+      // A file URL rather than a bare path: on Windows `C:\...` is not a valid module specifier.
+      const loaded = await import(pathToFileURL(join(repoRoot, module)).href);
       // A module that resolves to nothing usable is as broken as one that throws.
       expect(typeof loaded).toBe("object");
     } catch (error) {

--- a/scripts/module-import-sweep.test.ts
+++ b/scripts/module-import-sweep.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Imports every server-side source module once.
+ *
+ * Two purposes, both real. First, Bun's coverage only instruments what a test actually loads, so a
+ * module no test imports is absent from the lcov entirely rather than reported at 0%. That makes the
+ * headline percentage flatter itself by omission, and — worse — hides the existence of untested
+ * files. Importing them all turns silence into an honest row. It does mean import-time lines count as
+ * covered, which flatters the number slightly in the other direction; that trade is deliberate,
+ * because a visible low number beats an invisible file.
+ *
+ * Second, and independently useful: this is a smoke test that every module is import-safe. A module
+ * that throws, blocks, binds a port, or writes to disk merely by being loaded is a real defect —
+ * `cli.ts` is only safe to import because its entry point sits behind `import.meta.main` — and
+ * without this nothing would catch a top-level side effect until a service failed to start.
+ *
+ * Scope is server-side deliberately. `apps/web/src` touches `document` and service-worker globals at
+ * import time and is exercised by the Playwright suite instead, and
+ * `packages/collab-client/upstream` is pinned upstream source that this repository does not own.
+ */
+
+const ROOTS: readonly string[] = ["apps/gateway/src", "packages/protocol/src"];
+
+/**
+ * A floor, not an exact count, so adding a module does not fail this test — but deleting the glob's
+ * ability to find anything does. An empty sweep would pass every assertion below while proving
+ * nothing, which is the failure mode worth guarding.
+ */
+const MINIMUM_MODULES = 18;
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+
+function sourceModules(): readonly string[] {
+  const glob = new Bun.Glob("**/*.ts");
+  const found: string[] = [];
+  for (const root of ROOTS) {
+    for (const file of glob.scanSync({ cwd: `${repoRoot}${root}`, onlyFiles: true })) {
+      if (file.endsWith(".d.ts")) continue;
+      found.push(`${root}/${file.replaceAll("\\", "/")}`);
+    }
+  }
+  return found.sort();
+}
+
+test("every server-side module is import-safe", async () => {
+  const modules = sourceModules();
+  expect(modules.length).toBeGreaterThanOrEqual(MINIMUM_MODULES);
+
+  const failures: string[] = [];
+  for (const module of modules) {
+    try {
+      // Dynamic by necessity: the specifier is discovered by glob at run time, which is the whole
+      // point. A static import list would be the thing that goes stale and stops covering new
+      // modules, and enumerating it by hand is exactly the omission this test exists to prevent.
+      const loaded = await import(`${repoRoot}${module}`);
+      // A module that resolves to nothing usable is as broken as one that throws.
+      expect(typeof loaded).toBe("object");
+    } catch (error) {
+      failures.push(`${module}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  expect(failures).toEqual([]);
+}, 60_000);
+
+test("the sweep covers the modules the gateway actually ships", async () => {
+  const modules = sourceModules();
+  // Named rather than counted: these are the files whose absence from coverage would matter most,
+  // and naming them means a rename cannot quietly drop one out of the sweep.
+  for (const required of [
+    "apps/gateway/src/auth.ts",
+    "apps/gateway/src/tailnet.ts",
+    "apps/gateway/src/http.ts",
+    "apps/gateway/src/registry.ts",
+    "apps/gateway/src/ipc.ts",
+    "apps/gateway/src/config.ts",
+    "apps/gateway/src/doctor.ts",
+    "apps/gateway/src/service.ts",
+    "apps/gateway/src/installation.ts",
+    "apps/gateway/src/cli.ts",
+    "packages/protocol/src/ipc-auth.ts",
+    "packages/protocol/src/validation.ts",
+  ]) {
+    expect(modules).toContain(required);
+  }
+});


### PR DESCRIPTION
Wires Codecov, and spends the actual effort on the thing a percentage cannot express.

## Coverage, with its limits stated where a badge reader will find them

`codecov.yml` documents what Bun can and cannot measure, because the limits are load-bearing:

| signal | availability |
|---|---|
| line coverage | yes (`DA:` records) |
| **branch coverage** | **none — zero `BRDA:` records** |
| per-function coverage | none — `FNF`/`FNH` totals with no `FN:`/`FNDA:` attribution |
| files no test imports | **omitted entirely**, not reported at 0% |

The patch status is informational for a concrete reason rather than out of timidity: because Bun instruments only modules a test loads, an entirely untested new file is *absent* from the diff rather than 0%, so a blocking patch target would pass vacuously in exactly the case it exists to catch. Project status keeps a real 1% regression threshold.

CI runs coverage as a **second** run rather than folding `--coverage` into `bun run check`, so a Codecov outage can never turn the required gate red; the upload step is skipped when the token is absent (Dependabot and fork PRs) and `fail_ci_if_error: false`.

## The import sweep found a real defect

`scripts/module-import-sweep.test.ts` imports every server-side module so absence becomes an honest row, and doubles as a smoke test that no module has an import-time side effect. Its first run hung for 60s — because `apps/gateway/src/synthetic-publisher.ts` ran at module scope, so **importing it connected to the operator's real registry socket, published three synthetic sessions into the live gateway, and then waited for a signal.**

Verified afterwards that the live registry was clean (socket close removed them, which incidentally re-confirmed that path against the real daemon). The module now sits behind `import.meta.main` like `cli.ts` does: `bun apps/gateway/src/synthetic-publisher.ts N` still works, importing it is inert in 7 ms. That defect is worth more than the coverage row it added.

## Mutation checks over the security predicates

`apps/gateway/test/security-mutations.test.ts` weakens seven named guards in a copy of the tree and requires a **specific named test** to fail:

| guard removed | test that must fail |
|---|---|
| identity gate on unsound topology (#98) | refuses an allowlisted identity when no tailnet interface vouches for Serve |
| CGNAT accepted as a tunnel device (#98) | an ordinary interface on shared CGNAT space does not vouch for a TUN device |
| loopback peer check | fails closed for missing, disallowed, forged remote, and tagged-style identities |
| allowlist check | (same) |
| stream re-authorization | an admitted stream stops when the topology stops justifying it |
| generation revocation | revokes an old generation before replacement becomes observable |
| doctor's trust finding (#98) | withholds the loopback claim and names the finding when no tunnel device is present |

Scoped deliberately: not tree-wide mutation testing, which would be a large persistent control producing mostly noise about code whose failure costs nothing.

**The vacuity guard matters more than the mutations.** A `find` pattern that no longer matches is a failure, not a skip — a silently inapplicable mutation leaves the suite green while the guard it names is unprotected. Proven by breaking a pattern on purpose: the harness failed on the exact named mutation.

It also caught two of its own bugs while being built. The tree copy omitted `patches/`, which a target suite reads, so the baseline failed for a reason unrelated to any mutation. And one proposed mutation was **unobservable** — `listenerLoopbackOnly` is `checks.daemon && hostname is loopback`, false either way without a live daemon — so it is documented as deliberately absent rather than left in to rot red.

## Doctor wiring, closing an admitted gap

An earlier commit said plainly: *"removing that wiring leaves the suite green"*. Now covered. `runDoctorChecks` takes an injectable topology probe for the same reason `createHttpHandler` does — reading the real interface table would assert whatever machine ran the test, and the unsafe topology cannot be produced on a workstation running Tailscale in TUN mode. A fake `tailscale` on `PATH` makes `tailscaleConnected` an input rather than a fact about the host.

One assertion was **dropped for being vacuous**: `listenerLoopbackOnly` is false in an isolated root because no daemon runs, so asserting it proved nothing about withholding. Saying so beats keeping a green assertion that discriminates nothing.

## Measured

| | before | after |
|---|---|---|
| tests | 206 | **292** |
| assertions | 983 | **1439** |
| `doctor.ts` | 34.6% | **85.2%** |
| `config.ts` | 69.2% | 72.8% |
| `service.ts` | 30.8% | 41.6% |
| `cli.ts` | 16.8% | 27.4% |
| `tailnet.ts` | — | **100%** |
| `auth.ts` | — | 94.7% |
| overall | 67.4% | 69.5% |

`cli.ts` and `service.ts` gained least because most of what remains needs a real service manager or live daemon, which the new tests correctly decline to fake and say so.

The new suites are not string-matching: the service tests parse generated systemd units, plists, and task XML through consumer-shaped parsers and pin the #69 `RuntimeDirectory` boundary and the #90 `LogonTrigger`/`InteractiveToken` behaviour, including markup-injection payloads in program paths. The CLI tests drive the option table data-driven with a drift guard, so a command added without a table entry fails. The config tests were each mutation-proven against a scratch copy.

## Threat-model impact

Net positive and no new exposure. One production source change removes a footgun (a module that published into a live registry on import); one adds a test-only injection seam whose default is the real probe. `codecov.yml` uploads only `coverage/lcov.info`, which contains file paths and hit counts — no config, tokens, or capabilities — and `coverage/` was already gitignored.

## Also

README's badge and status paragraph still said "pre-alpha, unqualified" after the alpha decision went GO; corrected to name the two qualified hosts, the one client, the TUN-mode precondition, and the two known limitations. Adds a coverage badge in the existing shields style.
