### PR TITLE
chore(deps): bump actions/attest-build-provenance to v4.2.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           (cd dist/release && sha256sum --check SHA256SUMS)
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             dist/release/omp-session-gateway-*-bun.tar


### PR DESCRIPTION
Applies what #19 proposed, on current `main` rather than by merging a branch that is a hundred files behind it.

The held reasoning on #19 stands and is exactly why this lands now rather than earlier: `release.yml` runs only on tag pushes, so **no pull request check exercises the attestation path** and a green check here proves nothing about it. The repository's own validation vehicle is the `provenance-test-*` tag series, and one is being cut immediately after this merges.

## Compatibility, checked rather than assumed

- v4.2.2 is a thin wrapper over `actions/attest@v4.2.1` and still accepts `subject-path`, the only input this workflow supplies.
- The job already grants `attestations: write` and `id-token: write`, which v4 needs unchanged.
- Upstream notes say new implementations should prefer `actions/attest` directly. Worth doing eventually, but a larger change than a pin bump and not something to fold into a validation run.

## Threat-model impact

This is the action that produces release provenance, so it is squarely supply-chain relevant, and two majors of upstream change land at once. The pin remains a full commit SHA with the version in a trailing comment, so what is actually trusted is immutable regardless of tag movement.

What closes this is **not this diff** — it is the tag run and its independent verification: downloaded checksums, all three GitHub attestations, all three Cosign bundles, and a byte-identical rebuild from the exact tag. If any of those fail, the pin gets reverted and #19 goes back to held.
