### PR TITLE
docs(release): point the ledger, changelog and readme at the published alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable project changes will be documented here.
 
 The format is based on Keep a Changelog, and the project intends to use Semantic Versioning once implementation releases begin.
 
-## [Unreleased]
+## [v0.1.0-alpha] — 2026-08-21
+
+First advertised release. Qualified for Debian 13 (trixie) x86-64 and macOS 26.6.1 arm64 as hosts,
+with Chrome `151.0.7922.139` on Android 17 as the client, and for nothing else. Both hosts were
+qualified from a signed candidate whose executable surface is byte-identical to this release: all 46
+files match, and the only differences are `sourceCommit`/`sourceCreated` in `release-info.json` and
+the same commit and timestamp inside `SBOM.spdx.json`.
+
+Requires Tailscale's **TUN-mode** client; the daemon refuses identity headers otherwise. Never enable
+Tailscale Funnel. Android network-change recovery is a known limitation, Windows is implemented but
+not advertised, and self-hosted or proxied relay modes remain unsupported.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 [license]: LICENSE
 [license-badge]: https://img.shields.io/github/license/alphastorm/omp-session-gateway?color=1C232B&labelColor=0B0E11
 [status]: docs/RELEASE_STATUS.md
-[status-badge]: https://img.shields.io/badge/status-alpha%2C%20two%20hosts%20qualified-C99B45?labelColor=0B0E11
+[status-badge]: https://img.shields.io/badge/status-alpha%20v0.1.0--alpha-C99B45?labelColor=0B0E11
 [omp-lock]: UPSTREAM.lock.json
 [omp-badge]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falphastorm%2Fomp-session-gateway%2Fmain%2FUPSTREAM.lock.json&query=%24.tag&label=OMP%20baseline&color=1C232B&labelColor=0B0E11
 [bun]: https://bun.sh
@@ -43,9 +43,10 @@
 
 </div>
 
-> **Project status: alpha, qualified for two host platforms and one client.** The alpha decision is
-> **GO** for Debian 13 (trixie) x86-64 and macOS 26.6.1 arm64 as hosts, with Chrome `151.0.7922.139`
-> on Android 17 as the client, against candidate `v0.1.0-prealpha.17`. Anything outside that
+> **Project status: alpha.** [`v0.1.0-alpha`](https://github.com/alphastorm/omp-session-gateway/releases/tag/v0.1.0-alpha)
+> is published and independently verified. It is qualified for Debian 13 (trixie) x86-64 and
+> macOS 26.6.1 arm64 as hosts, with Chrome `151.0.7922.139`
+> on Android 17 as the client. Anything outside that
 > combination is unqualified and must not be treated as a working deployment path: Windows is
 > implemented but **not advertised**, and self-hosted or proxied relay modes remain unsupported.
 > Tailscale must run its **TUN-mode** client — the gateway refuses identity headers otherwise, because

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -1,7 +1,7 @@
 # Release status
 
 **Updated:** 2026-08-21<br>
-**Repository version:** `0.1.0`, alpha candidate **`provenance-test-v0.1.0.11`** (published, independently verified)<br>
+**Repository version:** `0.1.0`, released as **`v0.1.0-alpha`** (published, independently verified)<br>
 **Classification:** qualified alpha<br>
 **Alpha decision:** **GO**, for the combinations named immediately below and for nothing else<br>
 
@@ -13,6 +13,19 @@
 | macOS 26.6.1 arm64 (`Mac14,3`, build `25G76`) | 2026-08-21, `doctor` **17/17**, reboot persistence, distinct-node probe refused | `provenance-test-v0.1.0.11` |
 
 **Advertised client:** Chrome `151.0.7922.139` on Android 17 (Pixel 10 Pro, build `CP2A.260805.005`, SDK 37).
+
+**`v0.1.0-alpha` is published, and its runtime is the qualified runtime.** Both host lanes ran
+against `provenance-test-v0.1.0.11`, built from commit `48485a7f`; the alpha is built from
+`6e9bf586`, which adds only this document and the release workflow's tag contract. That difference
+was checked rather than asserted: extracting both archives and comparing every file leaves exactly
+two differing, and both are provenance metadata — `release-info.json`'s `sourceCommit` and
+`sourceCreated`, and the same commit and timestamp inside `SBOM.spdx.json`. All **46** other files,
+the entire executable surface, are byte-identical, and `bunLockSha256` and `upstreamCommit` are
+unchanged. The alpha's own artifacts were then verified independently from a clean directory:
+`shasum -c` OK, three GitHub attestations verified, three Cosign bundles `Verified OK` against
+`.../release.yml@refs/tags/v0.1.0-alpha`, and a clean exact-tag rebuild byte-identical for the
+archive (`cc6ea478df050432…`), SPDX inventory (`5ffcfccd4626f405…`) and checksum manifest
+(`7a953b70cac146b8…`).
 
 **Both advertised hosts are now qualified against the candidate that contains the #98 identity-trust
 change**, so the GO above describes current code rather than the artifact it was first decided on.


### PR DESCRIPTION
[`v0.1.0-alpha`](https://github.com/alphastorm/omp-session-gateway/releases/tag/v0.1.0-alpha) is published and independently verified, so the documents name it rather than the candidate the decision was first recorded against.

## The one claim worth care

Both host lanes ran against `provenance-test-v0.1.0.11` at commit `48485a7f`. The alpha is built from `6e9bf586`, which adds only the ledger and the workflow's tag contract — so is the alpha's runtime the runtime that was qualified?

Checked, not assumed. Extracting both archives and comparing every file leaves **exactly two differing**, and both are provenance metadata:

| file | delta |
|---|---|
| `release-info.json` | `sourceCommit`, `sourceCreated` |
| `SBOM.spdx.json` | same commit and timestamp, in `documentNamespace`, `created`, `sourceInfo` |

All **46** other files — the entire executable surface — are byte-identical, and `bunLockSha256` and `upstreamCommit` are unchanged. So the qualification transfers, and the ledger says exactly why rather than implying it.

## The alpha's own artifacts

| check | result |
|---|---|
| `shasum -c SHA256SUMS` | OK |
| `gh attestation verify` ×3 | verified |
| `cosign verify-blob` ×3 | `Verified OK` against `…/release.yml@refs/tags/v0.1.0-alpha` |
| clean exact-tag rebuild | byte-identical: `cc6ea478df050432…` / `5ffcfccd4626f405…` / `7a953b70cac146b8…` |
| `release-info.json` source commit | `6e9bf586caa2ed09e12d295195da8c94950ff0a7`, the tagged commit |

## Threat-model impact

Documentation only. It removes the possibility of a reader treating the alpha as qualified by inheritance rather than by the measured equivalence above.

## Verification

`bun test scripts/ledger-structure.test.ts scripts/check-evidence.test.ts`: 25 pass / 0 fail.
