### PR TITLE
fix: harden alpha lifecycle boundaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,70 +147,84 @@ jobs:
           EOF
           elif [[ "$GITHUB_REF_NAME" == *-alpha* ]]; then
             cat > "$notes" <<EOF
-          ## Alpha, qualified for two hosts and one client
+          ## Alpha point release, qualified for two hosts and one client
 
-          First advertised release. Everything outside the combination below is unqualified and must not be treated as a working deployment path.
+          This point release supersedes \`v0.1.0-alpha\` with lifecycle, capability-revocation, notification, and cross-install service hardening. Everything outside the combinations below remains unqualified.
+
+          ### Fixed
+
+          - Registry/SSE admission is atomic and reentrant observer failures cannot interrupt capability revocation.
+          - A stale Web Push delivery cannot delete a concurrently renewed subscription.
+          - A disposed collaboration client restored from Android's back/forward cache returns to the live directory without reusing its capability.
+          - Install, stop, uninstall, and publisher-token rotation fail closed for foreign or unverifiable service ownership.
+          - Launch rate windows are isolated by authenticated identity rather than caller-selected session IDs.
 
           ### Qualified
 
           | host | evidence |
           |---|---|
-          | Debian 13 (trixie) x86-64, systemd 257, kernel 6.12.94+deb13-amd64 | six lanes, exit 0; \`doctor\` 13/17 with four expected-false on a tagged node; reboot persistence with and without lingering |
-          | macOS 26.6.1 arm64 (Mac14,3) | \`doctor\` **17/17**; reboot persistence with the token digest unchanged; active reinstall and token rotation |
+          | Debian 13 (trixie) x86-64, systemd 257, kernel 6.12.94+deb13-amd64 | signed-candidate install, upgrade/rollback, readiness, identity isolation, reboot persistence, and uninstall lanes |
+          | macOS 26.6.1 arm64 (Mac14,3) | signed-candidate install, active reinstall, token rotation, identity isolation, reboot persistence, and uninstall |
 
-          Client: Chrome 151.0.7922.139 on Android 17 (Pixel 10 Pro). Both hosts were qualified from a signed candidate built from this code, and on both the gateway port was refused from a **separate** tailnet node while Serve returned a metadata-only \`200\`.
+          Client: Chrome 151.0.7922.171 on Android 17 (Pixel 10 Pro). The advertised hosts and client were qualified against signed candidate \`v0.1.0-prealpha.18\`; this release records its own exact source commit and provenance below.
 
           ### Required deployment precondition
 
-          Run Tailscale's **TUN-mode** client. With \`tailscaled --tun=userspace-networking\` there is no tunnel device, so its netstack forwards inbound tailnet connections to localhost and any tailnet peer reaches the loopback listener as a loopback peer. The daemon detects that and returns \`403\` to every request rather than believing an identity header, \`doctor\` reports \`loopbackTrustSound: false\`, and the log carries one \`http.identity_trust_unsound\`. Never enable Tailscale Funnel.
+          Run Tailscale's **TUN-mode** client. Userspace-networking mode does not establish the listener-identity trust boundary and is refused. Never enable Tailscale Funnel.
 
           ### Known limitations
 
-          - Recovery after an abrupt radio transition on Android may require force-stopping Chrome; network-change and reconnect are **not** proven.
-          - Windows is implemented and partly qualified but **not advertised**.
+          - Recovery after an abrupt radio transition on Android may require force-stopping Chrome; network-change and reconnect are not proven.
+          - Preview notification detail currently falls back to Session detail because the OMP publisher carries no bounded preview field.
+          - Windows is implemented and tested but **not advertised**.
           - Self-hosted or proxied relay modes remain unsupported.
 
-          ### Install
+          ### Install or upgrade
 
-          Extract \`omp-session-gateway-${PACKAGE_VERSION}-bun.tar\`, then run \`bun apps/gateway/src/cli.js install --origin https://host.tailnet.ts.net --allow user@example.com\` from the extracted directory with the deployment's real values. Repeat \`--allow\` for additional identities; active reinstall with the same values preserves the publisher token.
+          Extract \`omp-session-gateway-${PACKAGE_VERSION}-bun.tar\`, then run \`bun apps/gateway/src/cli.js install --origin https://host.tailnet.ts.net --allow user@example.com\` with the deployment's real values. Repeat \`--allow\` for additional identities. Active reinstall preserves configuration and the publisher token.
+
+          ### Rollback
+
+          Run \`bun apps/gateway/src/cli.js rollback\` when the predecessor is present in managed installation history. Otherwise reinstall the signed \`v0.1.0-alpha\` archive with the deployment's existing origin and allowlist.
 
           - Source commit: \`$GITHUB_SHA\`
           - OMP baseline: \`858f7dd91fff9b84cf8a2c6a6bb85aa0e6d03a55\` (tag v17.3.8) with the included patch
-          - Runtime: Bun 1.3.14 or newer; registry protocol 1; Push API 2
+          - Runtime: Bun 1.3.14; registry protocol 1; Push API 2
           - Verification: [docs/RELEASE.md](https://github.com/$GITHUB_REPOSITORY/blob/$GITHUB_SHA/docs/RELEASE.md)
           EOF
           else
             cat > "$notes" <<EOF
-          ## Pre-alpha; physical Couch Flow qualification pending
+          ## Pre-alpha hardening candidate; qualification pending
 
-          This release completes the approved mobile Couch Flow handoff. It is not an alpha or production-qualified release.
+          This is the signed candidate for \`v0.1.0-alpha.1\`. It is not an advertised alpha or a production-qualified release.
 
-          ### User-visible changes
+          ### Changes under qualification
 
-          - The directory now switches wholly between a FIFO **Needs you** queue and an **All clear** working-session view, without a prominent manual Refresh control.
-          - The collaboration shell reports connection state, advances through authoritative asks, and restores exact directory order and scroll on Back.
-          - Each device can choose Private, Session, or Preview notification detail; alert taps revalidate the exact current request before opening Control.
-          - Phone, tailnet, desktop, and relay outages retain the last authenticated list with distinct timestamped recovery guidance.
+          - Atomic, monotonic registry/SSE admission with complete revocation despite observer faults.
+          - Compare-and-remove Web Push cleanup that preserves concurrent subscription renewal.
+          - Capability-safe collaboration-client restoration after Android back/forward-cache traversal.
+          - Fail-closed cross-install service ownership for install, stop, uninstall, and token rotation.
+          - Authenticated-identity launch rate windows and focused request-body/identity boundary tests.
 
           ### Security
 
-          The gateway derives opaque request identities in volatile registry memory without changing OMP's capability-bearing publisher contract. Request routes are synchronously scrubbed and revalidated before the unchanged generation-bound launch. Collaboration capabilities remain absent from push state and payloads, notification data, URLs, history, browser storage, caches, logs, and diagnostics. Optional notification text is server-built only at the detail level selected for that browser endpoint.
+          Collaboration capabilities remain absent from list/SSE responses, push state and payloads, URLs, browser storage, service-worker caches, logs, diagnostics, screenshots, and release fixtures. Service ownership is checked from both the manager's rendered program and the shared definition file before destructive effects.
 
           ### Install or upgrade
 
-          Extract \`omp-session-gateway-${PACKAGE_VERSION}-bun.tar\`, then run \`bun apps/gateway/src/cli.js install --origin https://host.tailnet.ts.net --allow user@example.com\` from the extracted directory, replacing both values with the existing canonical origin and allowed identity. Repeat \`--allow\` for additional identities. Active reinstall with the same values preserves the publisher token. The installed PWA activates the changed client automatically when idle; active collaboration adopts it after ordinary Back or Leave.
+          Extract \`omp-session-gateway-${PACKAGE_VERSION}-bun.tar\`, then run \`bun apps/gateway/src/cli.js install --origin https://host.tailnet.ts.net --allow user@example.com\` with the deployment's real values. Repeat \`--allow\` for additional identities. Active reinstall preserves configuration and the publisher token.
 
-          ### Compatibility and known issues
+          ### Compatibility and open qualification
 
           - Source commit: \`$GITHUB_SHA\`
           - Exact release baseline: OMP v17.3.8 at \`858f7dd91fff9b84cf8a2c6a6bb85aa0e6d03a55\` with the included patch.
-          - Runtime: Bun 1.3.14 or newer; registry protocol 1; Push API 2.
-          - The unchanged OMP publisher exposes boolean attention only, so Preview currently falls back to Session detail until a bounded preview source is qualified.
-          - Automated unit, protocol, gateway, service-worker, leak, and Android-sized browser checks pass. The new request-specific lock-screen, force-stop, stale-request, roaming, and forbidden-sink matrix remains to be repeated on the physical Android candidate.
+          - Runtime: Bun 1.3.14; registry protocol 1; Push API 2.
+          - Preview notification detail falls back to Session detail until the publisher protocol gains a bounded preview source.
+          - Advertised Debian, macOS, and physical Pixel lanes must pass against these exact signed bytes before alpha promotion.
 
           ### Rollback
 
-          Reinstall the signed \`v0.1.0-prealpha.9\` archive with \`bun apps/gateway/src/cli.js install --origin https://host.tailnet.ts.net --allow user@example.com\`, using the deployment's real values. Existing publisher credentials remain valid.
+          Run \`bun apps/gateway/src/cli.js rollback\` when the predecessor is present in managed installation history. Otherwise reinstall the signed \`v0.1.0-alpha\` archive with the deployment's existing origin and allowlist.
 
           Verification instructions: [docs/RELEASE.md](https://github.com/$GITHUB_REPOSITORY/blob/$GITHUB_SHA/docs/RELEASE.md).
           EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable project changes will be documented here.
 
 The format is based on Keep a Changelog, and the project intends to use Semantic Versioning once implementation releases begin.
 
+## [Unreleased]
+
+### Fixed
+
+- Admit SSE consumers through an atomic registry snapshot/subscription handshake and serialize
+  reentrant registry mutations, so every consumer observes one snapshot followed by strictly
+  increasing revisions without an admission gap.
+- Preserve a renewed Web Push subscription when an older in-flight delivery for the same endpoint
+  fails permanently; stale cleanup now removes only the exact failed transport target.
+- Return a collaboration page restored from the browser back/forward cache to the live session
+  directory after its capability-bearing client has been disposed, rather than leaving an inert
+  client shell or attempting to reuse the capability.
+- Refuse install and uninstall before touching files or service-manager state when the global
+  systemd, launchd, or Task Scheduler identity belongs to another gateway installation root.
+
+### Testing
+
+- Cover launch rate-window boundaries, declared and streamed request-body ceilings, identity-scoped
+  push deletion, reentrant registry ordering, push-renewal races, cross-install service ownership,
+  and capability-safe back/forward-cache restoration.
+
+### Documentation
+
+- Align the release and rollback guides with the published `v0.1.0-alpha` tag contract and the
+  implemented `omp-gateway rollback [--to <version>]` command.
+
 ## [v0.1.0-alpha] — 2026-08-21
 
 First advertised release. Qualified for Debian 13 (trixie) x86-64 and macOS 26.6.1 arm64 as hosts,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,26 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
 
 ### Fixed
 
-- Admit SSE consumers through an atomic registry snapshot/subscription handshake and serialize
-  reentrant registry mutations, so every consumer observes one snapshot followed by strictly
-  increasing revisions without an admission gap.
+- Admit SSE consumers through an atomic registry snapshot/subscription handshake, serialize
+  reentrant registry mutations, and isolate observer failures, so healthy consumers receive one
+  snapshot followed by every later revision in strictly increasing order.
 - Preserve a renewed Web Push subscription when an older in-flight delivery for the same endpoint
   fails permanently; stale cleanup now removes only the exact failed transport target.
 - Return a collaboration page restored from the browser back/forward cache to the live session
   directory after its capability-bearing client has been disposed, rather than leaving an inert
   client shell or attempting to reuse the capability.
-- Refuse install and uninstall before touching files or service-manager state when the global
-  systemd, launchd, or Task Scheduler identity belongs to another gateway installation root.
+- Refuse install, stop, and uninstall before touching files or service-manager state when either a
+  loaded manager identity or an unloaded definition belongs to another gateway installation root;
+  an unavailable ownership probe now fails closed.
+- Scope launch rate windows to the authenticated identity and operation instead of caller-selected
+  instance IDs, preventing one allowed identity from exhausting bucket capacity for another.
 
 ### Testing
 
-- Cover launch rate-window boundaries, declared and streamed request-body ceilings, identity-scoped
-  push deletion, reentrant registry ordering, push-renewal races, cross-install service ownership,
-  and capability-safe back/forward-cache restoration.
+- Cover identity-isolated launch rate windows, declared and streamed request-body ceilings,
+  identity-scoped push deletion, reentrant registry ordering and observer failure, push-renewal
+  races, file-only and manager-loaded service ownership, and capability-safe back/forward-cache
+  restoration.
 
 ### Documentation
 

--- a/apps/gateway/src/cli.ts
+++ b/apps/gateway/src/cli.ts
@@ -31,6 +31,7 @@ import { PushService } from "./push.ts";
 import { SessionRegistry } from "./registry.ts";
 import {
   assertServiceInstallPreflight,
+  assertUserServiceOwnership,
   installUserService,
   serviceDefinition,
   uninstallUserService,
@@ -137,7 +138,11 @@ async function runServe(arguments_: ParsedArguments): Promise<void> {
   const webRoot = resolve(fileURLToPath(new URL("../../web/dist/", import.meta.url)));
   const staticAssets = await StaticAssetStore.load(webRoot);
   const logger = new SafeLogger();
-  const registry = new SessionRegistry({ ttlSeconds: config.registry.ttlSeconds, maxSessions: config.registry.maxSessions });
+  const registry = new SessionRegistry({
+    ttlSeconds: config.registry.ttlSeconds,
+    maxSessions: config.registry.maxSessions,
+    onListenerError: () => logger.event("warn", "registry.listener_failed"),
+  });
   const pushService = await PushService.open({ config, registry, logger });
   const ipc = await startRegistryIpcServer({ config, token, registry, logger });
   let stopping = false;
@@ -441,6 +446,7 @@ async function runDoctor(arguments_: ParsedArguments): Promise<void> {
 
 async function runRotateToken(): Promise<void> {
   const config = await loadGatewayConfig();
+  await assertUserServiceOwnership(config);
   const service = await userServiceStatus(config);
   if (service.active && !service.installed) {
     throw new Error("refusing token rotation while an unmanaged gateway service is active");

--- a/apps/gateway/src/http.ts
+++ b/apps/gateway/src/http.ts
@@ -262,7 +262,10 @@ export function createHttpHandler(options: {
 }): (request: Request, peer?: RequestPeer) => Promise<Response> {
   const { config, registry, staticAssets } = options;
   const logger = options.logger ?? new SafeLogger();
-  const limiter = new LaunchRateLimiter();
+  const identityCapacity = config.auth.mode === "dev-localhost" ? 1 : config.auth.allowedLogins.length;
+  // Each admitted identity can own exactly two keys (`launch` and `push`), so configured identities
+  // can never deny one another merely by filling the bounded map.
+  const limiter = new LaunchRateLimiter(20, 60_000, Math.max(2, identityCapacity * 2));
   const now = options.now ?? Date.now;
   const tailnetPresent = options.tailnetPresent ?? createTailnetPresenceProbe();
   // `tailscale-serve` mode trusts an identity header from any loopback peer, which is only sound

--- a/apps/gateway/src/http.ts
+++ b/apps/gateway/src/http.ts
@@ -153,6 +153,10 @@ const SSE_KEEPALIVE_MS = 5_000;
  * be evaluated once and never again, so a stream admitted while identity trust was sound would keep
  * delivering the session directory after the topology stopped justifying it. The keepalive is
  * already the stream's liveness tick, so this adds a predicate read rather than a timer.
+ *
+ * Admission goes through `subscribeWithSnapshot` so the snapshot and the live subscription are one
+ * step: a revision landing mid-handshake is replayed in order rather than lost, and teardown is
+ * reachable from the first frame onward instead of only after the subscription is assigned.
  */
 function eventStream(
   registry: SessionRegistry,
@@ -162,26 +166,39 @@ function eventStream(
   const encoder = new TextEncoder();
   let unsubscribe: (() => void) | undefined;
   let keepalive: ReturnType<typeof setInterval> | undefined;
+  let closed = false;
+  const release = (): void => {
+    closed = true;
+    unsubscribe?.();
+    unsubscribe = undefined;
+    clearInterval(keepalive);
+    keepalive = undefined;
+  };
   const stream = new ReadableStream<Uint8Array>(
     {
       start(controller) {
         const send = (event: SessionEvent): void => {
+          if (closed) return;
           if ((controller.desiredSize ?? 1) < -32) {
+            release();
             controller.close();
-            unsubscribe?.();
-            clearInterval(keepalive);
             return;
           }
           controller.enqueue(encoder.encode(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`));
         };
-        const snapshot = registry.snapshot();
-        send({ type: "snapshot", revision: snapshot.revision, sessions: snapshot.sessions });
-        unsubscribe = registry.subscribe(send);
+        const dispose = registry.subscribeWithSnapshot(send);
+        // A stream abandoned during admission has no subscription handle to revoke yet, so revoke the
+        // one admission just returned instead of leaving the listener attached to the registry.
+        if (closed) {
+          dispose();
+          return;
+        }
+        unsubscribe = dispose;
         keepalive = setInterval(() => {
+          if (closed) return;
           if (!stillAuthorized()) {
+            release();
             controller.close();
-            unsubscribe?.();
-            clearInterval(keepalive);
             return;
           }
           if ((controller.desiredSize ?? 1) >= -32) {
@@ -190,8 +207,7 @@ function eventStream(
         }, keepaliveMs);
       },
       cancel() {
-        unsubscribe?.();
-        clearInterval(keepalive);
+        release();
       },
     },
     { highWaterMark: 32 },
@@ -216,6 +232,8 @@ export function createHttpHandler(options: {
   readonly readinessToken?: string;
   readonly readinessInstance?: string;
   readonly sseKeepaliveMs?: number;
+  /** Supplies wall-clock time for deterministic rate-window enforcement. */
+  readonly now?: () => number;
   /**
    * Reports whether the registry rendezvous point is still reachable by publishers. A daemon whose
    * socket path was removed underneath it keeps serving HTTP while no session can ever register, so
@@ -231,6 +249,7 @@ export function createHttpHandler(options: {
   const { config, registry, staticAssets } = options;
   const logger = options.logger ?? new SafeLogger();
   const limiter = new LaunchRateLimiter();
+  const now = options.now ?? Date.now;
   const tailnetPresent = options.tailnetPresent ?? createTailnetPresenceProbe();
   // `tailscale-serve` mode trusts an identity header from any loopback peer, which is only sound
   // while Serve is the sole way in. Configuration may declare that no tailnet reaches this host at
@@ -329,7 +348,7 @@ export function createHttpHandler(options: {
       if (request.headers.get("Content-Type")?.toLowerCase() !== "application/json") {
         return problem(415, "unsupported_media_type", "Expected application/json");
       }
-      if (!limiter.allow(`${authorization.identityKey}\0push`)) {
+      if (!limiter.allow(`${authorization.identityKey}\0push`, now())) {
         return problem(429, "rate_limited", "Too many requests");
       }
       let body: unknown;
@@ -393,7 +412,7 @@ export function createHttpHandler(options: {
       } catch {
         return problem(400, "bad_request", "Invalid request");
       }
-      if (!limiter.allow(`${authorization.identityKey}\0${instanceId}`)) {
+      if (!limiter.allow(`${authorization.identityKey}\0${instanceId}`, now())) {
         return problem(429, "rate_limited", "Too many requests");
       }
       const lookup = registry.lookupCapability(

--- a/apps/gateway/src/http.ts
+++ b/apps/gateway/src/http.ts
@@ -177,14 +177,25 @@ function eventStream(
   const stream = new ReadableStream<Uint8Array>(
     {
       start(controller) {
+        const close = (): void => {
+          release();
+          try {
+            controller.close();
+          } catch {
+            // The peer may have errored the stream before Bun delivered cancel().
+          }
+        };
         const send = (event: SessionEvent): void => {
           if (closed) return;
           if ((controller.desiredSize ?? 1) < -32) {
-            release();
-            controller.close();
+            close();
             return;
           }
-          controller.enqueue(encoder.encode(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`));
+          try {
+            controller.enqueue(encoder.encode(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`));
+          } catch {
+            release();
+          }
         };
         const dispose = registry.subscribeWithSnapshot(send);
         // A stream abandoned during admission has no subscription handle to revoke yet, so revoke the
@@ -197,12 +208,15 @@ function eventStream(
         keepalive = setInterval(() => {
           if (closed) return;
           if (!stillAuthorized()) {
-            release();
-            controller.close();
+            close();
             return;
           }
           if ((controller.desiredSize ?? 1) >= -32) {
-            controller.enqueue(encoder.encode("event: keepalive\ndata: {}\n\n"));
+            try {
+              controller.enqueue(encoder.encode("event: keepalive\ndata: {}\n\n"));
+            } catch {
+              release();
+            }
           }
         }, keepaliveMs);
       },
@@ -412,7 +426,7 @@ export function createHttpHandler(options: {
       } catch {
         return problem(400, "bad_request", "Invalid request");
       }
-      if (!limiter.allow(`${authorization.identityKey}\0${instanceId}`, now())) {
+      if (!limiter.allow(`${authorization.identityKey}\0launch`, now())) {
         return problem(429, "rate_limited", "Too many requests");
       }
       const lookup = registry.lookupCapability(

--- a/apps/gateway/src/push.ts
+++ b/apps/gateway/src/push.ts
@@ -178,6 +178,24 @@ function statusCode(error: unknown): number | undefined {
   return typeof value === "number" && Number.isInteger(value) ? value : undefined;
 }
 
+/**
+ * A 404/410 condemns exactly the subscription that was sent, so stale cleanup compares the whole
+ * delivery target — owner identity, endpoint, expiry, and both transport keys — instead of the endpoint
+ * alone. A browser may renew a subscription while a delivery is still in flight, and that renewal reuses
+ * the endpoint with fresh keys; matching on the endpoint alone would let the obsolete failure delete the
+ * live record. `detailLevel` is a presentation preference rather than part of the target, so changing it
+ * never shields a dead endpoint from cleanup.
+ */
+function isSameDeliveryTarget(subscription: StoredPushSubscription, other: StoredPushSubscription): boolean {
+  return (
+    subscription.identityKey === other.identityKey &&
+    subscription.endpoint === other.endpoint &&
+    subscription.expirationTime === other.expirationTime &&
+    subscription.keys.p256dh === other.keys.p256dh &&
+    subscription.keys.auth === other.keys.auth
+  );
+}
+
 function sessionNotificationBody(session: SessionMetadata, detailLevel: PushDetailLevel): string | undefined {
   if (detailLevel === "private") return undefined;
   const labels = [session.title, session.cwdLabel].filter(
@@ -222,14 +240,7 @@ export class PushService {
     this.#subscriptions = options.state.subscriptions.filter(subscription =>
       subscription.expirationTime === null || subscription.expirationTime > Date.now(),
     );
-    for (const session of this.#registry.snapshot().sessions) {
-      this.#attention.set(session.instanceId, {
-        generation: session.generation,
-        ...(session.ask === undefined ? {} : { requestId: session.ask.requestId }),
-        active: session.inputRequired && session.canControl && session.ask !== undefined,
-      });
-    }
-    this.#unsubscribeRegistry = this.#registry.subscribe(event => this.#acceptRegistryEvent(event));
+    this.#unsubscribeRegistry = this.#registry.subscribeWithSnapshot(event => this.#acceptRegistryEvent(event));
   }
 
   static async open(options: {
@@ -312,7 +323,18 @@ export class PushService {
   }
 
   #acceptRegistryEvent(event: SessionEvent): void {
-    if (this.#stopped || event.type === "snapshot") return;
+    if (this.#stopped) return;
+    if (event.type === "snapshot") {
+      this.#attention.clear();
+      for (const session of event.sessions) {
+        this.#attention.set(session.instanceId, {
+          generation: session.generation,
+          ...(session.ask === undefined ? {} : { requestId: session.ask.requestId }),
+          active: session.inputRequired && session.canControl && session.ask !== undefined,
+        });
+      }
+      return;
+    }
     if (event.type === "session_remove") {
       const previous = this.#attention.get(event.instanceId);
       if (previous?.generation !== event.generation) return;
@@ -411,7 +433,7 @@ export class PushService {
     );
     if (subscriptions.length === 0) return;
     const topic = createHash("sha256").update(instanceId).digest("base64url").slice(0, 32);
-    const stale = new Set<string>();
+    const stale: StoredPushSubscription[] = [];
     await Promise.all(
       subscriptions.map(async subscription => {
         try {
@@ -424,13 +446,17 @@ export class PushService {
           });
         } catch (error) {
           const code = statusCode(error);
-          if (code === 404 || code === 410) stale.add(subscription.endpoint);
+          if (code === 404 || code === 410) stale.push(subscription);
           else this.#logger.event("warn", "push.delivery_failed", { ...(code === undefined ? {} : { status: code }) });
         }
       }),
     );
-    if (stale.size > 0) {
-      await this.#mutateSubscriptions(current => current.filter(subscription => !stale.has(subscription.endpoint)));
+    if (stale.length > 0) {
+      await this.#mutateSubscriptions(current =>
+        current.filter(
+          subscription => !stale.some(failed => isSameDeliveryTarget(subscription, failed)),
+        ),
+      );
     }
   }
 

--- a/apps/gateway/src/registry.ts
+++ b/apps/gateway/src/registry.ts
@@ -20,6 +20,7 @@ export interface RegistryOptions {
   readonly maxSessions: number;
   readonly clock?: RegistryClock;
   readonly requestIdFactory?: () => string;
+  readonly onListenerError?: (error: unknown) => void;
 }
 
 interface InternalMetadataRecord {
@@ -55,6 +56,7 @@ export class SessionRegistry {
   readonly #maxSessions: number;
   readonly #clock: RegistryClock;
   readonly #requestIdFactory: () => string;
+  readonly #onListenerError: (error: unknown) => void;
   #pendingHead = 0;
   #dispatching = false;
   #revision = 0;
@@ -66,6 +68,7 @@ export class SessionRegistry {
     this.#maxSessions = options.maxSessions;
     this.#clock = options.clock ?? systemClock;
     this.#requestIdFactory = options.requestIdFactory ?? randomUUID;
+    this.#onListenerError = options.onListenerError ?? (() => undefined);
   }
 
   get revision(): number {
@@ -253,8 +256,6 @@ export class SessionRegistry {
     this.#pending.push(event);
     if (this.#dispatching) return;
     this.#dispatching = true;
-    let failed = false;
-    let firstError: unknown;
     try {
       while (this.#pendingHead < this.#pending.length) {
         const next = this.#pending[this.#pendingHead] as SessionEvent;
@@ -263,8 +264,13 @@ export class SessionRegistry {
           try {
             listener(next);
           } catch (error) {
-            if (!failed) firstError = error;
-            failed = true;
+            // Observers do not own registry state. Report the fault without letting one callback
+            // interrupt capability revocation or starve the remaining observers.
+            try {
+              this.#onListenerError(error);
+            } catch {
+              // Error reporting is an observer too and must not become a mutation dependency.
+            }
           }
         }
       }
@@ -273,8 +279,5 @@ export class SessionRegistry {
       this.#pendingHead = 0;
       this.#dispatching = false;
     }
-    // One faulty observer cannot make later observers miss committed revisions, but the caller still
-    // receives the first failure after the ordered queue is drained rather than having it hidden.
-    if (failed) throw firstError;
   }
 }

--- a/apps/gateway/src/registry.ts
+++ b/apps/gateway/src/registry.ts
@@ -253,17 +253,28 @@ export class SessionRegistry {
     this.#pending.push(event);
     if (this.#dispatching) return;
     this.#dispatching = true;
+    let failed = false;
+    let firstError: unknown;
     try {
       while (this.#pendingHead < this.#pending.length) {
         const next = this.#pending[this.#pendingHead] as SessionEvent;
         this.#pendingHead += 1;
-        for (const listener of this.#listeners) listener(next);
+        for (const listener of this.#listeners) {
+          try {
+            listener(next);
+          } catch (error) {
+            if (!failed) firstError = error;
+            failed = true;
+          }
+        }
       }
     } finally {
-      // Compacted, not truncated: a throwing listener must not silently drop the revisions behind it.
       this.#pending.splice(0, this.#pendingHead);
       this.#pendingHead = 0;
       this.#dispatching = false;
     }
+    // One faulty observer cannot make later observers miss committed revisions, but the caller still
+    // receives the first failure after the ordered queue is drained rather than having it hidden.
+    if (failed) throw firstError;
   }
 }

--- a/apps/gateway/src/registry.ts
+++ b/apps/gateway/src/registry.ts
@@ -50,10 +50,13 @@ export class SessionRegistry {
   readonly #metadata = new Map<string, InternalMetadataRecord>();
   readonly #secrets = new Map<string, SecretSessionRecord>();
   readonly #listeners = new Set<(event: SessionEvent) => void>();
+  readonly #pending: SessionEvent[] = [];
   readonly #ttlMs: number;
   readonly #maxSessions: number;
   readonly #clock: RegistryClock;
   readonly #requestIdFactory: () => string;
+  #pendingHead = 0;
+  #dispatching = false;
   #revision = 0;
 
   constructor(options: RegistryOptions) {
@@ -88,6 +91,50 @@ export class SessionRegistry {
     return () => {
       this.#listeners.delete(listener);
     };
+  }
+
+  /**
+   * Atomic admission: the listener is registered before the snapshot is observed, so a mutation that
+   * races the handshake — including one the listener itself causes while reading the snapshot — is
+   * buffered instead of falling into the gap between reading the directory and subscribing to it.
+   * Buffered revisions at or below the snapshot revision are already represented by the snapshot and
+   * are dropped; every newer one is replayed in order before the subscription goes live, so the
+   * listener observes exactly one snapshot followed by strictly increasing revisions.
+   */
+  subscribeWithSnapshot(listener: (event: SessionEvent) => void): () => void {
+    const buffered: SessionEvent[] = [];
+    let snapshotRevision = -1;
+    let live = false;
+    const gate = (event: SessionEvent): void => {
+      if (!live) {
+        buffered.push(event);
+        return;
+      }
+      // Still filtered once live: admission can complete inside an in-flight dispatch that has yet to
+      // reach this listener, and that event is already folded into the snapshot.
+      if (event.revision > snapshotRevision) listener(event);
+    };
+    this.#listeners.add(gate);
+    const unsubscribe = (): void => {
+      this.#listeners.delete(gate);
+    };
+    try {
+      const snapshot = this.snapshot();
+      snapshotRevision = snapshot.revision;
+      listener({ type: "snapshot", revision: snapshot.revision, sessions: snapshot.sessions });
+      // Indexed rather than shifted: the gate keeps appending while this drains, and those late
+      // arrivals belong at the tail of the same ordered replay.
+      for (let index = 0; index < buffered.length; index += 1) {
+        const event = buffered[index] as SessionEvent;
+        if (event.revision > snapshotRevision) listener(event);
+      }
+      live = true;
+    } catch (error) {
+      // A throwing listener must not leave its admission wrapper registered on the registry.
+      unsubscribe();
+      throw error;
+    }
+    return unsubscribe;
   }
 
   upsert(ownerId: string, input: PublishedSessionInput): UpsertResult {
@@ -196,7 +243,27 @@ export class SessionRegistry {
     this.#emit({ type: "session_remove", revision: this.#revision, instanceId, generation });
   }
 
+  /**
+   * Dispatch is serialized. A listener is free to mutate the registry — `PushService` does so
+   * indirectly by sweeping through `snapshot()` — and delivering that nested revision inline would
+   * hand it to every listener the outer loop has not reached yet, ahead of the older revision they
+   * are still owed. Queueing keeps delivery in strictly increasing revision order for all listeners.
+   */
   #emit(event: SessionEvent): void {
-    for (const listener of this.#listeners) listener(event);
+    this.#pending.push(event);
+    if (this.#dispatching) return;
+    this.#dispatching = true;
+    try {
+      while (this.#pendingHead < this.#pending.length) {
+        const next = this.#pending[this.#pendingHead] as SessionEvent;
+        this.#pendingHead += 1;
+        for (const listener of this.#listeners) listener(next);
+      }
+    } finally {
+      // Compacted, not truncated: a throwing listener must not silently drop the revisions behind it.
+      this.#pending.splice(0, this.#pendingHead);
+      this.#pendingHead = 0;
+      this.#dispatching = false;
+    }
   }
 }

--- a/apps/gateway/src/service.ts
+++ b/apps/gateway/src/service.ts
@@ -255,6 +255,14 @@ async function assertNoForeignServiceLabel(config: ServicePathConfig, host: Serv
   if (lookup.status === "found" && !serviceProgramBelongsTo(lookup.rendered, config.paths.stateDir)) foreign();
 }
 
+/** Fail-closed preflight for callers that mutate service-adjacent state before invoking a verb. */
+export async function assertUserServiceOwnership(
+  config: ServicePathConfig,
+  host: ServiceHost = systemServiceHost,
+): Promise<void> {
+  await assertNoForeignServiceLabel(config, host);
+}
+
 
 async function bootstrapLaunchAgent(domain: string, path: string, host: ServiceHost): Promise<void> {
   let lastError: unknown;
@@ -339,6 +347,9 @@ export async function installUserService(
   await assertNoForeignServiceLabel(config, host);
   await assertServiceInstallPreflight(activate, host);
   const definition = serviceDefinition(config, host.platform, installedCli, readinessInstance, host.homeDirectory);
+  if (!serviceProgramBelongsTo(definition.content, config.paths.stateDir)) {
+    throw new Error("gateway service program must be staged under the configured state directory");
+  }
   await mkdir(dirname(definition.path), { recursive: true, mode: 0o700 });
   const serialized =
     host.platform === "win32"
@@ -367,11 +378,15 @@ export async function installUserService(
       await assertNoForeignServiceLabel(config, host);
       await host.run(["launchctl", "bootout", target]);
     }
+    await assertNoForeignServiceLabel(config, host);
     await bootstrapLaunchAgent(`gui/${process.getuid?.() ?? 0}`, definition.path, host);
   } else {
     const status = await userServiceStatus(config, host);
     await assertNoForeignServiceLabel(config, host);
-    if (status.active) await stopWindowsTask(host);
+    if (status.active) {
+      await stopWindowsTask(host);
+      await assertNoForeignServiceLabel(config, host);
+    }
     await host.run(["schtasks.exe", "/Create", "/TN", "OMP Session Gateway", "/XML", definition.path, "/F"]);
     if (activate) await host.run(["schtasks.exe", "/Run", "/TN", "OMP Session Gateway"]);
   }
@@ -379,6 +394,7 @@ export async function installUserService(
 }
 
 export async function stopUserService(config: ServicePathConfig, host: ServiceHost = systemServiceHost): Promise<void> {
+  await assertNoForeignServiceLabel(config, host);
   const status = await userServiceStatus(config, host);
   // `active` is ownership-scoped, so a foreign holder of the label leaves nothing here to stop.
   if (!status.active) return;
@@ -428,9 +444,13 @@ export async function uninstallUserService(
       await host.run(["launchctl", "bootout", `gui/${process.getuid?.() ?? 0}/omp-session-gateway`]);
     }
   } else if (status.installed) {
-    if (deactivate && status.active) await stopWindowsTask(host);
+    if (deactivate && status.active) {
+      await stopWindowsTask(host);
+      await assertNoForeignServiceLabel(config, host);
+    }
     await host.run(["schtasks.exe", "/Delete", "/TN", "OMP Session Gateway", "/F"]);
   }
+  await assertNoForeignServiceLabel(config, host);
   await rm(definition.path, { force: true });
   if (host.platform === "linux") await host.run(["systemctl", "--user", "daemon-reload"]);
 }

--- a/apps/gateway/src/service.ts
+++ b/apps/gateway/src/service.ts
@@ -114,6 +114,31 @@ async function commandOutput(command: readonly string[]): Promise<string | undef
 }
 
 /**
+ * The OS surface the service verbs read and mutate: the running platform and the service-manager
+ * commands.
+ *
+ * Injectable because the ownership rules below cannot be exercised any other way. A service manager
+ * keys its registry on identity no filesystem override can scope, so producing a *foreign* holder of
+ * the label on the machine running the suite would mean loading a real unit there — and the refusals
+ * have to be proven to fire before the first byte is written and before the first mutating command.
+ */
+export interface ServiceHost {
+  readonly platform: typeof process.platform;
+  /** Stdout of a command that exited zero; undefined when it failed or could not be spawned. */
+  readonly output: (command: readonly string[]) => Promise<string | undefined>;
+  readonly succeeds: (command: readonly string[]) => Promise<boolean>;
+  /** Runs a command that must succeed, surfacing its stderr otherwise. */
+  readonly run: (command: readonly string[]) => Promise<void>;
+}
+
+const systemServiceHost: ServiceHost = {
+  platform: process.platform,
+  output: commandOutput,
+  succeeds: commandSucceeds,
+  run,
+};
+
+/**
  * Whether a service manager's rendering of a loaded unit names a program under `stateDir`.
  *
  * Installed runtimes live at `<stateDir>/installation/versions/<id>/...`, so the install root is a
@@ -123,6 +148,31 @@ async function commandOutput(command: readonly string[]): Promise<string | undef
  */
 export function serviceProgramBelongsTo(programText: string | undefined, stateDir: string): boolean {
   return programText !== undefined && programText.includes(stateDir + sep);
+}
+
+/**
+ * What the service manager would execute for the gateway's label, running or not.
+ *
+ * Registration, not activity: systemd answers for a unit it has loaded but never started, Task
+ * Scheduler for a task sitting idle, launchd for any loaded job. Installing and uninstalling are
+ * destructive to all of those, so ownership is read from the manager's own metadata rather than from
+ * an activity probe. Undefined means nothing holds the label, which is also what a machine with no
+ * user service manager reports; the mutating command surfaces that on its own.
+ */
+async function loadedServiceProgram(host: ServiceHost): Promise<string | undefined> {
+  // `systemctl show` prints an empty value for a unit it does not know, so a loaded-but-inactive
+  // foreign unit — the one `is-active` hides — still reports its ExecStart here. `launchctl print`
+  // and `schtasks /Query /XML` render a registered service in any state and exit non-zero when
+  // nothing holds the label.
+  const query =
+    host.platform === "linux"
+      ? ["systemctl", "--user", "show", "-p", "ExecStart", "--value", "omp-session-gateway.service"]
+      : host.platform === "darwin"
+        ? ["launchctl", "print", `gui/${process.getuid?.() ?? 0}/omp-session-gateway`]
+        : ["schtasks.exe", "/Query", "/TN", "OMP Session Gateway", "/XML"];
+  const rendered = await host.output(query);
+  // A rendering with nothing in it names no program, so nothing holds the label.
+  return rendered?.trim() === "" ? undefined : rendered;
 }
 
 /**
@@ -138,27 +188,42 @@ export function serviceProgramBelongsTo(programText: string | undefined, stateDi
  * The loaded service's own program path is the one piece of identity that does carry the root, so
  * compare against it rather than trusting the label. Returns false when nothing is loaded.
  */
-async function loadedServiceIsOurs(config: ServicePathConfig): Promise<boolean> {
-  const owns = (text: string | undefined): boolean => serviceProgramBelongsTo(text, config.paths.stateDir);
-  if (process.platform === "linux") {
-    if (!(await commandSucceeds(["systemctl", "--user", "is-active", "omp-session-gateway.service"]))) return false;
-    return owns(
-      await commandOutput(["systemctl", "--user", "show", "-p", "ExecStart", "--value", "omp-session-gateway.service"]),
-    );
-  }
-  if (process.platform === "darwin") {
-    return owns(await commandOutput(["launchctl", "print", `gui/${process.getuid?.() ?? 0}/omp-session-gateway`]));
-  }
-  if (!(await windowsTaskActive())) return false;
-  return owns(await commandOutput(["schtasks.exe", "/Query", "/TN", "OMP Session Gateway", "/XML"]));
+async function loadedServiceIsOurs(config: ServicePathConfig, host: ServiceHost): Promise<boolean> {
+  // launchd has no activity gate: a job it has loaded is a job it is keeping alive.
+  if (host.platform === "linux") {
+    if (!(await host.succeeds(["systemctl", "--user", "is-active", "omp-session-gateway.service"]))) return false;
+  } else if (host.platform !== "darwin" && !(await windowsTaskActive(host))) return false;
+  return serviceProgramBelongsTo(await loadedServiceProgram(host), config.paths.stateDir);
+}
+
+/**
+ * Refuses when the label is held by an install root other than this one.
+ *
+ * Called before every step that destroys what the label resolves to — the definition write, the
+ * manager mutation that adopts it, the boot-out that precedes it — because a sandbox reaches the
+ * real machine's service through the label alone and each of those steps is enough to break it.
+ */
+async function assertNoForeignServiceLabel(config: ServicePathConfig, host: ServiceHost): Promise<void> {
+  const program = await loadedServiceProgram(host);
+  if (program === undefined || serviceProgramBelongsTo(program, config.paths.stateDir)) return;
+  const registry =
+    host.platform === "linux"
+      ? "systemd user unit name"
+      : host.platform === "darwin"
+        ? "launchd label"
+        : "scheduled task name";
+  throw new Error(
+    `another gateway service already holds this ${registry} from a different install root; ` +
+      "uninstall it from that root first",
+  );
 }
 
 
-async function bootstrapLaunchAgent(domain: string, path: string): Promise<void> {
+async function bootstrapLaunchAgent(domain: string, path: string, host: ServiceHost): Promise<void> {
   let lastError: unknown;
   for (let attempt = 0; attempt < 20; attempt += 1) {
     try {
-      await run(["launchctl", "bootstrap", domain, path]);
+      await host.run(["launchctl", "bootstrap", domain, path]);
       return;
     } catch (error) {
       lastError = error;
@@ -176,8 +241,8 @@ async function fileExists(path: string): Promise<boolean> {
     return false;
   }
 }
-async function windowsTaskActive(): Promise<boolean> {
-  return commandSucceeds([
+async function windowsTaskActive(host: ServiceHost): Promise<boolean> {
+  return host.succeeds([
     "powershell.exe",
     "-NoProfile",
     "-NonInteractive",
@@ -186,35 +251,41 @@ async function windowsTaskActive(): Promise<boolean> {
   ]);
 }
 
-export async function assertServiceInstallPreflight(activate: boolean): Promise<void> {
-  if (process.platform === "win32" && !activate && (await windowsTaskActive())) {
+export async function assertServiceInstallPreflight(
+  activate: boolean,
+  host: ServiceHost = systemServiceHost,
+): Promise<void> {
+  if (host.platform === "win32" && !activate && (await windowsTaskActive(host))) {
     throw new Error("cannot replace an active Windows service with --no-start");
   }
 }
 
-async function stopWindowsTask(): Promise<void> {
-  await commandSucceeds(["schtasks.exe", "/End", "/TN", "OMP Session Gateway"]);
+async function stopWindowsTask(host: ServiceHost): Promise<void> {
+  await host.succeeds(["schtasks.exe", "/End", "/TN", "OMP Session Gateway"]);
   const deadline = Date.now() + 7_500;
   while (Date.now() < deadline) {
-    if (!(await windowsTaskActive())) return;
+    if (!(await windowsTaskActive(host))) return;
     await Bun.sleep(100);
   }
   throw new Error("running gateway task did not stop");
 }
 
-export async function userServiceStatus(config: ServicePathConfig): Promise<UserServiceStatus> {
-  const definition = serviceDefinition(config);
+export async function userServiceStatus(
+  config: ServicePathConfig,
+  host: ServiceHost = systemServiceHost,
+): Promise<UserServiceStatus> {
+  const definition = serviceDefinition(config, host.platform);
   const definitionExists = await fileExists(definition.path);
   // `active` means "a service this install owns is running", never "some service holds our label".
   // Everything downstream acts on it: rotation restarts, stop boots out, uninstall refuses.
-  const active = await loadedServiceIsOurs(config);
-  if (process.platform === "linux") {
+  const active = await loadedServiceIsOurs(config, host);
+  if (host.platform === "linux") {
     const installed =
-      definitionExists && (await commandSucceeds(["systemctl", "--user", "is-enabled", "omp-session-gateway.service"]));
+      definitionExists && (await host.succeeds(["systemctl", "--user", "is-enabled", "omp-session-gateway.service"]));
     return { installed, active };
   }
-  if (process.platform === "darwin") return { installed: definitionExists, active };
-  const installed = await commandSucceeds(["schtasks.exe", "/Query", "/TN", "OMP Session Gateway"]);
+  if (host.platform === "darwin") return { installed: definitionExists, active };
+  const installed = await host.succeeds(["schtasks.exe", "/Query", "/TN", "OMP Session Gateway"]);
   return { installed, active };
 }
 
@@ -223,69 +294,91 @@ export async function installUserService(
   activate = true,
   installedCli?: string,
   readinessInstance?: string,
+  host: ServiceHost = systemServiceHost,
 ): Promise<ServiceDefinition> {
-  await assertServiceInstallPreflight(activate);
-  const definition = serviceDefinition(config, process.platform, installedCli, readinessInstance);
+  // Ownership first, before `mkdir` and before the definition write. Two roots that share a HOME
+  // compute the same definition path, so the write alone replaces the other root's service, and on
+  // Linux and Windows the manager mutations that follow act on a label a sandbox cannot scope.
+  await assertNoForeignServiceLabel(config, host);
+  await assertServiceInstallPreflight(activate, host);
+  const definition = serviceDefinition(config, host.platform, installedCli, readinessInstance);
   await mkdir(dirname(definition.path), { recursive: true, mode: 0o700 });
   const serialized =
-    process.platform === "win32"
+    host.platform === "win32"
       ? Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(definition.content, "utf16le")])
       : definition.content;
   await writeFile(definition.path, serialized, { mode: 0o600 });
-  if (process.platform !== "win32") await chmod(definition.path, 0o600);
-  if (process.platform === "linux") {
-    const wasActive = await commandSucceeds(["systemctl", "--user", "is-active", "omp-session-gateway.service"]);
-    await run(["systemctl", "--user", "daemon-reload"]);
-    await run(["systemctl", "--user", "enable", "omp-session-gateway.service"]);
-    if (activate) await run(["systemctl", "--user", wasActive ? "restart" : "start", "omp-session-gateway.service"]);
-  } else if (process.platform === "darwin") {
+  if (host.platform !== "win32") await chmod(definition.path, 0o600);
+  if (host.platform === "linux") {
+    const wasActive = await host.succeeds(["systemctl", "--user", "is-active", "omp-session-gateway.service"]);
+    // Re-read ownership immediately before the manager is touched. Nothing has reloaded yet, so the
+    // manager still reports the unit it holds, and an install that landed from another root while
+    // this one was writing must not be reloaded, enabled or restarted out from under it.
+    await assertNoForeignServiceLabel(config, host);
+    await host.run(["systemctl", "--user", "daemon-reload"]);
+    await host.run(["systemctl", "--user", "enable", "omp-session-gateway.service"]);
+    if (activate) {
+      await host.run(["systemctl", "--user", wasActive ? "restart" : "start", "omp-session-gateway.service"]);
+    }
+  } else if (host.platform === "darwin") {
     if (!activate) return definition;
     const target = `gui/${process.getuid?.() ?? 0}/omp-session-gateway`;
-    if (await commandSucceeds(["launchctl", "print", target])) {
+    if (await host.succeeds(["launchctl", "print", target])) {
       // Replacing our own running instance is the ordinary upgrade path. Booting out a service that
       // belongs to a different install root is how a sandboxed run kills the real daemon, so refuse
       // instead: launchd keys the label on uid alone and cannot tell the two apart for us.
-      if (!(await loadedServiceIsOurs(config))) {
-        throw new Error(
-          "another gateway service already holds this launchd label from a different install root; " +
-            "uninstall it from that root before installing here",
-        );
-      }
-      await run(["launchctl", "bootout", target]);
+      await assertNoForeignServiceLabel(config, host);
+      await host.run(["launchctl", "bootout", target]);
     }
-    await bootstrapLaunchAgent(`gui/${process.getuid?.() ?? 0}`, definition.path);
+    await bootstrapLaunchAgent(`gui/${process.getuid?.() ?? 0}`, definition.path, host);
   } else {
-    const status = await userServiceStatus(config);
-    if (status.active) await stopWindowsTask();
-    await run(["schtasks.exe", "/Create", "/TN", "OMP Session Gateway", "/XML", definition.path, "/F"]);
-    if (activate) await run(["schtasks.exe", "/Run", "/TN", "OMP Session Gateway"]);
+    const status = await userServiceStatus(config, host);
+    await assertNoForeignServiceLabel(config, host);
+    if (status.active) await stopWindowsTask(host);
+    await host.run(["schtasks.exe", "/Create", "/TN", "OMP Session Gateway", "/XML", definition.path, "/F"]);
+    if (activate) await host.run(["schtasks.exe", "/Run", "/TN", "OMP Session Gateway"]);
   }
   return definition;
 }
 
-export async function stopUserService(config: ServicePathConfig): Promise<void> {
-  const status = await userServiceStatus(config);
+export async function stopUserService(config: ServicePathConfig, host: ServiceHost = systemServiceHost): Promise<void> {
+  const status = await userServiceStatus(config, host);
+  // `active` is ownership-scoped, so a foreign holder of the label leaves nothing here to stop.
   if (!status.active) return;
-  if (process.platform === "linux") {
-    await run(["systemctl", "--user", "stop", "omp-session-gateway.service"]);
-  } else if (process.platform === "darwin") {
+  // The label can be replaced after the status probe; re-read immediately before stopping it.
+  await assertNoForeignServiceLabel(config, host);
+  if (host.platform === "linux") {
+    await host.run(["systemctl", "--user", "stop", "omp-session-gateway.service"]);
+  } else if (host.platform === "darwin") {
     const target = `gui/${process.getuid?.() ?? 0}/omp-session-gateway`;
-    await run(["launchctl", "bootout", target]);
+    await host.run(["launchctl", "bootout", target]);
   } else {
-    await stopWindowsTask();
+    await stopWindowsTask(host);
   }
-  if ((await userServiceStatus(config)).active) throw new Error("gateway service remained active after stop");
+  if ((await userServiceStatus(config, host)).active) throw new Error("gateway service remained active after stop");
 }
 
-export async function uninstallUserService(config: ServicePathConfig, deactivate = true): Promise<void> {
-  const definition = serviceDefinition(config);
-  const status = await userServiceStatus(config);
+export async function uninstallUserService(
+  config: ServicePathConfig,
+  deactivate = true,
+  host: ServiceHost = systemServiceHost,
+): Promise<void> {
+  // `installed` answers for the label, not for the root that owns it: `schtasks /Query` finds any
+  // task carrying our name and `systemctl is-enabled` any unit carrying our unit name. Every branch
+  // below acts on that — `disable --now`, `/End`, `/Delete` — and the closing `rm` targets a path
+  // two roots sharing a HOME compute identically. Refuse first, so an uninstall run from one root
+  // cannot stop, delete or unfile another root's service.
+  await assertNoForeignServiceLabel(config, host);
+  const definition = serviceDefinition(config, host.platform);
+  const status = await userServiceStatus(config, host);
   if (!deactivate && status.active) {
     throw new Error("cannot uninstall an active gateway with --no-stop");
   }
-  if (process.platform === "linux") {
+  // The status probes are read-only but not atomic with manager mutation; close that interleaving.
+  await assertNoForeignServiceLabel(config, host);
+  if (host.platform === "linux") {
     if (status.installed || status.active) {
-      await run([
+      await host.run([
         "systemctl",
         "--user",
         "disable",
@@ -293,14 +386,14 @@ export async function uninstallUserService(config: ServicePathConfig, deactivate
         "omp-session-gateway.service",
       ]);
     }
-  } else if (process.platform === "darwin") {
+  } else if (host.platform === "darwin") {
     if (deactivate && status.active) {
-      await run(["launchctl", "bootout", `gui/${process.getuid?.() ?? 0}/omp-session-gateway`]);
+      await host.run(["launchctl", "bootout", `gui/${process.getuid?.() ?? 0}/omp-session-gateway`]);
     }
   } else if (status.installed) {
-    if (deactivate && status.active) await stopWindowsTask();
-    await run(["schtasks.exe", "/Delete", "/TN", "OMP Session Gateway", "/F"]);
+    if (deactivate && status.active) await stopWindowsTask(host);
+    await host.run(["schtasks.exe", "/Delete", "/TN", "OMP Session Gateway", "/F"]);
   }
   await rm(definition.path, { force: true });
-  if (process.platform === "linux") await run(["systemctl", "--user", "daemon-reload"]);
+  if (host.platform === "linux") await host.run(["systemctl", "--user", "daemon-reload"]);
 }

--- a/apps/gateway/src/service.ts
+++ b/apps/gateway/src/service.ts
@@ -151,7 +151,13 @@ const systemServiceHost: ServiceHost = {
  * `/tmp/x/state/omp-session-gateway-2`.
  */
 export function serviceProgramBelongsTo(programText: string | undefined, stateDir: string): boolean {
-  return programText !== undefined && programText.includes(stateDir + sep);
+  if (programText === undefined) return false;
+  return ["/", "\\"].some(separator => {
+    const prefix = `${stateDir}${separator}`;
+    const jsonEncoded = JSON.stringify(prefix).slice(1, -1);
+    const xmlEncoded = xmlEscape(prefix);
+    return programText.includes(prefix) || programText.includes(jsonEncoded) || programText.includes(xmlEncoded);
+  });
 }
 
 type ServiceProgramLookup =

--- a/apps/gateway/src/service.ts
+++ b/apps/gateway/src/service.ts
@@ -1,4 +1,4 @@
-import { access, chmod, mkdir, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -35,6 +35,7 @@ export function serviceDefinition(
   platform = process.platform,
   installedCli?: string,
   readinessInstance?: string,
+  homeDirectory = homedir(),
 ): ServiceDefinition {
   if (readinessInstance !== undefined && !/^[A-Za-z0-9_-]{43}$/u.test(readinessInstance)) {
     throw new Error("invalid service readiness instance");
@@ -67,7 +68,7 @@ export function serviceDefinition(
     const argumentsXml = argv.map(value => `      <string>${xmlEscape(value)}</string>`).join("\n");
     return {
       identifier: "omp-session-gateway",
-      path: join(homedir(), "Library", "LaunchAgents", "omp-session-gateway.plist"),
+      path: join(homeDirectory, "Library", "LaunchAgents", "omp-session-gateway.plist"),
       content: `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key><string>omp-session-gateway</string>\n    <key>ProgramArguments</key>\n    <array>\n${argumentsXml}\n    </array>\n    <key>RunAtLoad</key><true/>\n    <key>KeepAlive</key><dict><key>SuccessfulExit</key><false/></dict>\n    <key>ProcessType</key><string>Background</string>\n    <key>StandardOutPath</key><string>/dev/null</string>\n    <key>StandardErrorPath</key><string>/dev/null</string>\n  </dict>\n</plist>\n`,
     };
   }
@@ -124,6 +125,8 @@ async function commandOutput(command: readonly string[]): Promise<string | undef
  */
 export interface ServiceHost {
   readonly platform: typeof process.platform;
+  /** Injectable only so macOS file-only ownership can be exercised outside the real home. */
+  readonly homeDirectory?: string;
   /** Stdout of a command that exited zero; undefined when it failed or could not be spawned. */
   readonly output: (command: readonly string[]) => Promise<string | undefined>;
   readonly succeeds: (command: readonly string[]) => Promise<boolean>;
@@ -133,6 +136,7 @@ export interface ServiceHost {
 
 const systemServiceHost: ServiceHost = {
   platform: process.platform,
+  homeDirectory: homedir(),
   output: commandOutput,
   succeeds: commandSucceeds,
   run,
@@ -150,20 +154,22 @@ export function serviceProgramBelongsTo(programText: string | undefined, stateDi
   return programText !== undefined && programText.includes(stateDir + sep);
 }
 
+type ServiceProgramLookup =
+  | { readonly status: "found"; readonly rendered: string }
+  | { readonly status: "absent" }
+  | { readonly status: "unavailable" };
+
 /**
  * What the service manager would execute for the gateway's label, running or not.
  *
  * Registration, not activity: systemd answers for a unit it has loaded but never started, Task
  * Scheduler for a task sitting idle, launchd for any loaded job. Installing and uninstalling are
  * destructive to all of those, so ownership is read from the manager's own metadata rather than from
- * an activity probe. Undefined means nothing holds the label, which is also what a machine with no
- * user service manager reports; the mutating command surfaces that on its own.
+ * an activity probe. A failed Linux query is distinct from an absent unit because systemctl reports
+ * an unknown unit successfully with an empty ExecStart; failing open on an unavailable user manager
+ * would permit a definition write before the later mutation reports the real error.
  */
-async function loadedServiceProgram(host: ServiceHost): Promise<string | undefined> {
-  // `systemctl show` prints an empty value for a unit it does not know, so a loaded-but-inactive
-  // foreign unit — the one `is-active` hides — still reports its ExecStart here. `launchctl print`
-  // and `schtasks /Query /XML` render a registered service in any state and exit non-zero when
-  // nothing holds the label.
+async function loadedServiceProgram(host: ServiceHost): Promise<ServiceProgramLookup> {
   const query =
     host.platform === "linux"
       ? ["systemctl", "--user", "show", "-p", "ExecStart", "--value", "omp-session-gateway.service"]
@@ -171,8 +177,15 @@ async function loadedServiceProgram(host: ServiceHost): Promise<string | undefin
         ? ["launchctl", "print", `gui/${process.getuid?.() ?? 0}/omp-session-gateway`]
         : ["schtasks.exe", "/Query", "/TN", "OMP Session Gateway", "/XML"];
   const rendered = await host.output(query);
-  // A rendering with nothing in it names no program, so nothing holds the label.
-  return rendered?.trim() === "" ? undefined : rendered;
+  if (rendered === undefined) {
+    if (host.platform === "linux") return { status: "unavailable" };
+    const managerAvailable =
+      host.platform === "darwin"
+        ? await host.succeeds(["launchctl", "print", `gui/${process.getuid?.() ?? 0}`])
+        : await host.succeeds(["schtasks.exe", "/Query"]);
+    return managerAvailable ? { status: "absent" } : { status: "unavailable" };
+  }
+  return rendered.trim() === "" ? { status: "absent" } : { status: "found", rendered };
 }
 
 /**
@@ -193,29 +206,53 @@ async function loadedServiceIsOurs(config: ServicePathConfig, host: ServiceHost)
   if (host.platform === "linux") {
     if (!(await host.succeeds(["systemctl", "--user", "is-active", "omp-session-gateway.service"]))) return false;
   } else if (host.platform !== "darwin" && !(await windowsTaskActive(host))) return false;
-  return serviceProgramBelongsTo(await loadedServiceProgram(host), config.paths.stateDir);
+  const lookup = await loadedServiceProgram(host);
+  return lookup.status === "found" && serviceProgramBelongsTo(lookup.rendered, config.paths.stateDir);
+}
+
+function serviceRegistryName(host: ServiceHost): string {
+  return host.platform === "linux"
+    ? "systemd user unit name"
+    : host.platform === "darwin"
+      ? "launchd label"
+      : "scheduled task name";
+}
+
+async function existingServiceDefinition(config: ServicePathConfig, host: ServiceHost): Promise<string | undefined> {
+  const path = serviceDefinition(config, host.platform, undefined, undefined, host.homeDirectory).path;
+  try {
+    const bytes = await readFile(path);
+    if (host.platform !== "win32") return bytes.toString("utf8");
+    const offset = bytes[0] === 0xff && bytes[1] === 0xfe ? 2 : 0;
+    return bytes.subarray(offset).toString("utf16le");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
 }
 
 /**
- * Refuses when the label is held by an install root other than this one.
+ * Refuses when either the manager identity or its shared definition path belongs to another root.
  *
- * Called before every step that destroys what the label resolves to — the definition write, the
- * manager mutation that adopts it, the boot-out that precedes it — because a sandbox reaches the
- * real machine's service through the label alone and each of those steps is enough to break it.
+ * The file check covers an install staged with `--no-start`, which has no manager registration yet.
+ * The manager check covers loaded definitions whose source file moved or disappeared.
  */
 async function assertNoForeignServiceLabel(config: ServicePathConfig, host: ServiceHost): Promise<void> {
-  const program = await loadedServiceProgram(host);
-  if (program === undefined || serviceProgramBelongsTo(program, config.paths.stateDir)) return;
-  const registry =
-    host.platform === "linux"
-      ? "systemd user unit name"
-      : host.platform === "darwin"
-        ? "launchd label"
-        : "scheduled task name";
-  throw new Error(
-    `another gateway service already holds this ${registry} from a different install root; ` +
-      "uninstall it from that root first",
-  );
+  const registry = serviceRegistryName(host);
+  const foreign = (): never => {
+    throw new Error(
+      `another gateway service already holds this ${registry} from a different install root; ` +
+        "uninstall it from that root first",
+    );
+  };
+  const definition = await existingServiceDefinition(config, host);
+  if (definition !== undefined && !serviceProgramBelongsTo(definition, config.paths.stateDir)) foreign();
+
+  const lookup = await loadedServiceProgram(host);
+  if (lookup.status === "unavailable") {
+    throw new Error(`cannot verify ${registry} ownership; refusing to modify gateway service state`);
+  }
+  if (lookup.status === "found" && !serviceProgramBelongsTo(lookup.rendered, config.paths.stateDir)) foreign();
 }
 
 
@@ -274,7 +311,7 @@ export async function userServiceStatus(
   config: ServicePathConfig,
   host: ServiceHost = systemServiceHost,
 ): Promise<UserServiceStatus> {
-  const definition = serviceDefinition(config, host.platform);
+  const definition = serviceDefinition(config, host.platform, undefined, undefined, host.homeDirectory);
   const definitionExists = await fileExists(definition.path);
   // `active` means "a service this install owns is running", never "some service holds our label".
   // Everything downstream acts on it: rotation restarts, stop boots out, uninstall refuses.
@@ -301,7 +338,7 @@ export async function installUserService(
   // Linux and Windows the manager mutations that follow act on a label a sandbox cannot scope.
   await assertNoForeignServiceLabel(config, host);
   await assertServiceInstallPreflight(activate, host);
-  const definition = serviceDefinition(config, host.platform, installedCli, readinessInstance);
+  const definition = serviceDefinition(config, host.platform, installedCli, readinessInstance, host.homeDirectory);
   await mkdir(dirname(definition.path), { recursive: true, mode: 0o700 });
   const serialized =
     host.platform === "win32"
@@ -369,7 +406,7 @@ export async function uninstallUserService(
   // two roots sharing a HOME compute identically. Refuse first, so an uninstall run from one root
   // cannot stop, delete or unfile another root's service.
   await assertNoForeignServiceLabel(config, host);
-  const definition = serviceDefinition(config, host.platform);
+  const definition = serviceDefinition(config, host.platform, undefined, undefined, host.homeDirectory);
   const status = await userServiceStatus(config, host);
   if (!deactivate && status.active) {
     throw new Error("cannot uninstall an active gateway with --no-stop");

--- a/apps/gateway/test/http.test.ts
+++ b/apps/gateway/test/http.test.ts
@@ -438,6 +438,44 @@ describe("HTTP boundary", () => {
     await reader.cancel();
   });
 
+  test("admits an SSE stream with one snapshot and no repeated or reordered revision", async () => {
+    let monotonic = 1_000;
+    const registry = new SessionRegistry({
+      ttlSeconds: 35,
+      maxSessions: 10,
+      clock: { monotonicNowMs: () => monotonic, wallNowIso: () => "2026-07-19T00:00:00.000Z" },
+    });
+    registry.upsert("owner", publishedSession("http-instance-000001"));
+    monotonic += 35_000;
+    const handler = createHttpHandler({ config: config(), registry, staticAssets: assets, sseKeepaliveMs: 60_000 });
+    const sse = await handler(request("/api/v1/events"), peer);
+    const reader = sse.body?.getReader();
+    if (reader === undefined) throw new Error("missing SSE body");
+    const framed = (text: string): [string, unknown] => {
+      const data: unknown = JSON.parse(text.slice(text.indexOf("data: ") + "data: ".length));
+      if (typeof data !== "object" || data === null || !("revision" in data)) {
+        throw new Error("SSE frame carries no revision");
+      }
+      return [text.slice("event: ".length, text.indexOf("\n")), data.revision];
+    };
+
+    // Admission sweeps the expired record, so that removal is already inside the snapshot revision and
+    // must not also be framed; the two later upserts must each arrive once, in revision order.
+    const snapshot = await readSseEvent(reader);
+    registry.upsert("owner", publishedSession("http-instance-000002"));
+    registry.upsert("owner", publishedSession("http-instance-000003"));
+    const frames = [snapshot, await readSseEvent(reader), await readSseEvent(reader)];
+
+    expect(frames.map(text => framed(text))).toEqual([
+      ["snapshot", 2],
+      ["session_upsert", 3],
+      ["session_upsert", 4],
+    ]);
+    expect(snapshot).toContain('"sessions":[]');
+    expect(frames.join("")).not.toContain(viewCapability);
+    await reader.cancel();
+  });
+
   test("releases exactly one requested capability with no-store", async () => {
     const handler = createHttpHandler({ config: config(), registry: populatedRegistry(), staticAssets: assets });
     const response = await handler(launchRequest(), peer);
@@ -446,6 +484,78 @@ describe("HTTP boundary", () => {
     expect(response.headers.get("Cache-Control")).toContain("no-store");
     expect(payload.capability).toBe(viewCapability);
     expect(JSON.stringify(payload)).not.toContain(controlCapability);
+  });
+
+  test("enforces the launch rate-limit boundary and resets it at the window edge", async () => {
+    let now = 1_000;
+    const handler = createHttpHandler({
+      config: config(),
+      registry: populatedRegistry(),
+      staticAssets: assets,
+      now: () => now,
+    });
+
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      expect((await handler(launchRequest(), peer)).status).toBe(200);
+    }
+    const limited = await handler(launchRequest(), peer);
+    expect(limited.status).toBe(429);
+    expect(await limited.json()).toEqual({ code: "rate_limited", message: "Too many requests" });
+
+    now += 60_000;
+    const reset = await handler(launchRequest(), peer);
+    expect(reset.status).toBe(200);
+    expect(await reset.json()).toMatchObject({ mode: "view", generation: 3, capability: expect.any(String) });
+  });
+
+  test("rejects a launch body declared over the endpoint maximum", async () => {
+    const handler = createHttpHandler({ config: config(), registry: populatedRegistry(), staticAssets: assets });
+    const response = await handler(
+      request("/api/v1/sessions/http-instance-000001/launch", {
+        method: "POST",
+        headers: {
+          Origin: origin,
+          "Sec-Fetch-Site": "same-origin",
+          "Content-Type": "application/json",
+          "Content-Length": "4097",
+        },
+        body: JSON.stringify({ mode: "view", generation: 3 }),
+      }),
+      peer,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ code: "bad_request", message: "Invalid request" });
+  });
+
+  test("rejects streamed launch bodies that cross the maximum with an acceptable or absent declaration", async () => {
+    const handler = createHttpHandler({ config: config(), registry: populatedRegistry(), staticAssets: assets });
+    const json = JSON.stringify({ mode: "view", generation: 3 });
+    const firstChunk = new TextEncoder().encode(json + " ".repeat(4_096 - json.length));
+    const finalChunk = new TextEncoder().encode(" ");
+    const streamedRequest = (declaredLength?: string): Request =>
+      request("/api/v1/sessions/http-instance-000001/launch", {
+        method: "POST",
+        headers: {
+          Origin: origin,
+          "Sec-Fetch-Site": "same-origin",
+          "Content-Type": "application/json",
+          ...(declaredLength === undefined ? {} : { "Content-Length": declaredLength }),
+        },
+        body: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(firstChunk);
+            controller.enqueue(finalChunk);
+            controller.close();
+          },
+        }),
+      });
+
+    for (const declaredLength of ["4096", undefined]) {
+      const response = await handler(streamedRequest(declaredLength), peer);
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ code: "bad_request", message: "Invalid request" });
+    }
   });
 
   test("revalidates request-bound control launches at capability release", async () => {
@@ -609,6 +719,84 @@ describe("HTTP boundary", () => {
     const state = await Bun.file(join(root, "state", "push-state.json")).text();
     expect(state).toContain(body.subscription.endpoint);
     expect(state).not.toContain("PROMPT_CONTENT_CANARY");
+    await pushService.stop();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("isolates push DELETE mutations by authenticated identity for same and other endpoints", async () => {
+    const root = await mkdtemp(join(tmpdir(), "gateway-http-push-isolation-"));
+    const base = config();
+    const gatewayConfig: GatewayConfig = {
+      ...base,
+      auth: { ...base.auth, allowedLogins: ["allowed@example.com", "other@example.com"] },
+      paths: {
+        configDir: join(root, "config"),
+        stateDir: join(root, "state"),
+        runtimeDir: join(root, "run"),
+        socketPath: join(root, "run", "registry.sock"),
+        tokenPath: join(root, "config", "publisher-token"),
+        configPath: join(root, "config", "config.json"),
+      },
+    };
+    const registry = populatedRegistry();
+    const pushService = await PushService.open({
+      config: gatewayConfig,
+      registry,
+      transport: { async send(): Promise<void> {} },
+    });
+    const handler = createHttpHandler({ config: gatewayConfig, registry, staticAssets: assets, pushService });
+    const sharedEndpoint = "https://push.example.test/send/shared-device";
+    const otherEndpoint = "https://push.example.test/send/other-device";
+    const mutate = (method: "POST" | "DELETE", identity: string, value: unknown): Request =>
+      request(
+        "/api/v1/push/subscription",
+        {
+          method,
+          headers: {
+            Origin: origin,
+            "Sec-Fetch-Site": "same-origin",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(value),
+        },
+        identity,
+      );
+    const subscription = (endpoint: string) => ({
+      version: 2,
+      subscription: {
+        endpoint,
+        expirationTime: null,
+        keys: { p256dh: "P".repeat(88), auth: "A".repeat(22) },
+      },
+    });
+
+    expect((await handler(mutate("POST", "allowed@example.com", subscription(sharedEndpoint)), peer)).status).toBe(200);
+    expect((await handler(mutate("POST", "other@example.com", subscription(sharedEndpoint)), peer)).status).toBe(200);
+    expect((await handler(mutate("POST", "other@example.com", subscription(otherEndpoint)), peer)).status).toBe(200);
+    const statePath = join(root, "state", "push-state.json");
+    const beforeDeniedDeletes = await Bun.file(statePath).text();
+    expect(beforeDeniedDeletes).toContain(sharedEndpoint);
+    expect(beforeDeniedDeletes).toContain(otherEndpoint);
+
+    for (const endpoint of [sharedEndpoint, otherEndpoint]) {
+      const deniedDelete = await handler(
+        mutate("DELETE", "allowed@example.com", { version: 2, endpoint }),
+        peer,
+      );
+      expect(deniedDelete.status).toBe(204);
+      expect(await deniedDelete.text()).toBe("");
+    }
+    expect(await Bun.file(statePath).text()).toBe(beforeDeniedDeletes);
+
+    const ownDelete = await handler(
+      mutate("DELETE", "other@example.com", { version: 2, endpoint: otherEndpoint }),
+      peer,
+    );
+    expect(ownDelete.status).toBe(204);
+    expect(await ownDelete.text()).toBe("");
+    const afterOwnDelete = await Bun.file(statePath).text();
+    expect(afterOwnDelete).toContain(sharedEndpoint);
+    expect(afterOwnDelete).not.toContain(otherEndpoint);
     await pushService.stop();
     await rm(root, { recursive: true, force: true });
   });

--- a/apps/gateway/test/http.test.ts
+++ b/apps/gateway/test/http.test.ts
@@ -78,12 +78,17 @@ function launchRequest(
   mode: "view" | "control" = "view",
   instanceId = "http-instance-000001",
   requestId?: string,
+  identity = "allowed@example.com",
 ): Request {
-  return request(`/api/v1/sessions/${encodeURIComponent(instanceId)}/launch`, {
-    method: "POST",
-    headers: { Origin: origin, "Sec-Fetch-Site": "same-origin", "Content-Type": "application/json" },
-    body: JSON.stringify({ mode, generation, ...(requestId === undefined ? {} : { requestId }) }),
-  });
+  return request(
+    `/api/v1/sessions/${encodeURIComponent(instanceId)}/launch`,
+    {
+      method: "POST",
+      headers: { Origin: origin, "Sec-Fetch-Site": "same-origin", "Content-Type": "application/json" },
+      body: JSON.stringify({ mode, generation, ...(requestId === undefined ? {} : { requestId }) }),
+    },
+    identity,
+  );
 }
 
 async function readSseEvent(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<string> {
@@ -506,6 +511,30 @@ describe("HTTP boundary", () => {
     const reset = await handler(launchRequest(), peer);
     expect(reset.status).toBe(200);
     expect(await reset.json()).toMatchObject({ mode: "view", generation: 3, capability: expect.any(String) });
+  });
+
+  test("shares the launch window within one identity without coupling another allowed identity", async () => {
+    const base = config();
+    const gatewayConfig: GatewayConfig = {
+      ...base,
+      auth: { ...base.auth, allowedLogins: ["allowed@example.com", "other@example.com"] },
+    };
+    const handler = createHttpHandler({
+      config: gatewayConfig,
+      registry: populatedRegistry(),
+      staticAssets: assets,
+      now: () => 1_000,
+    });
+
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      expect((await handler(launchRequest(), peer)).status).toBe(200);
+    }
+    expect(
+      (await handler(launchRequest(3, "view", "http-instance-999999"), peer)).status,
+    ).toBe(429);
+    expect(
+      (await handler(launchRequest(3, "view", "http-instance-000001", undefined, "other@example.com"), peer)).status,
+    ).toBe(200);
   });
 
   test("rejects a launch body declared over the endpoint maximum", async () => {

--- a/apps/gateway/test/push.test.ts
+++ b/apps/gateway/test/push.test.ts
@@ -6,6 +6,7 @@ import {
   PUSH_API_VERSION,
   type BrowserPushSubscription,
   type PublishedSessionInput,
+  type PushSubscriptionKeys,
   parseAttentionPushMessage,
   parsePushSubscriptionRequest,
 } from "@omp-session-gateway/protocol";
@@ -15,11 +16,28 @@ import { PushService, type PushTransport } from "../src/push.ts";
 import { SessionRegistry } from "../src/registry.ts";
 
 const endpoint = "https://push.example.test/send/device-subscription";
+const previousKeys: PushSubscriptionKeys = { p256dh: "P".repeat(88), auth: "A".repeat(22) };
+const renewedKeys: PushSubscriptionKeys = { p256dh: "Q".repeat(88), auth: "B".repeat(22) };
 const subscription: BrowserPushSubscription = {
   endpoint,
   expirationTime: null,
-  keys: { p256dh: "P".repeat(88), auth: "A".repeat(22) },
+  keys: previousKeys,
 };
+
+/** Names a device by its key pair so a failed expectation never prints transport key material. */
+function keyLabel(keys: PushSubscriptionKeys): string {
+  if (keys.p256dh === previousKeys.p256dh && keys.auth === previousKeys.auth) return "previous";
+  if (keys.p256dh === renewedKeys.p256dh && keys.auth === renewedKeys.auth) return "renewed";
+  return "unrecognized";
+}
+
+function pushError(status: number): Error {
+  const error = new Error("push service rejected request");
+  Object.defineProperty(error, "statusCode", { value: status });
+  return error;
+}
+
+type SettleSend = (error?: unknown) => void;
 
 function config(root: string): GatewayConfig {
   return {
@@ -66,6 +84,18 @@ class RecordingTransport implements PushTransport {
     };
   }> = [];
   statusCode: number | undefined;
+  blockWhen: ((subscription: BrowserPushSubscription) => boolean) | undefined;
+  readonly #gates: SettleSend[] = [];
+  readonly #waiters: Array<(settle: SettleSend) => void> = [];
+
+  /** Resolves with the gate of the next blocked send, awaiting that signal instead of a timer. */
+  nextBlockedSend(): Promise<SettleSend> {
+    const ready = this.#gates.shift();
+    if (ready !== undefined) return Promise.resolve(ready);
+    const { promise, resolve } = Promise.withResolvers<SettleSend>();
+    this.#waiters.push(resolve);
+    return promise;
+  }
 
   async send(
     pushSubscription: BrowserPushSubscription,
@@ -79,11 +109,19 @@ class RecordingTransport implements PushTransport {
     },
   ): Promise<void> {
     this.calls.push({ subscription: pushSubscription, payload, options });
-    if (this.statusCode !== undefined) {
-      const error = new Error("push service rejected request");
-      Object.defineProperty(error, "statusCode", { value: this.statusCode });
-      throw error;
+    if (this.blockWhen?.(pushSubscription) === true) {
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      const settle: SettleSend = error => {
+        if (error === undefined) resolve();
+        else reject(error);
+      };
+      const waiter = this.#waiters.shift();
+      if (waiter === undefined) this.#gates.push(settle);
+      else waiter(settle);
+      await promise;
+      return;
     }
+    if (this.statusCode !== undefined) throw pushError(this.statusCode);
   }
 }
 
@@ -211,5 +249,70 @@ describe("Web Push service", () => {
     expect(lines.join("\n")).not.toContain(endpoint);
     expect(lines.join("\n")).not.toContain("CONTENT_CANARY");
     expect(lines.join("\n")).not.toContain("CAPABILITY_CANARY");
+  });
+
+  test("keeps a renewed subscription when the in-flight send for the replaced keys is gone", async () => {
+    const root = await createRoot();
+    const gatewayConfig = config(root);
+    const statePath = join(gatewayConfig.paths.stateDir, "push-state.json");
+    const registry = new SessionRegistry({ ttlSeconds: 35, maxSessions: 10 });
+    const transport = new RecordingTransport();
+    const lines: string[] = [];
+    const logger = new SafeLogger({ write(line): void { lines.push(line); } });
+    const service = await PushService.open({ config: gatewayConfig, registry, transport, logger });
+    const subscribeWith = async (keys: PushSubscriptionKeys): Promise<void> => {
+      await service.subscribe(
+        "dev-localhost",
+        parsePushSubscriptionRequest({
+          version: PUSH_API_VERSION,
+          detailLevel: "private",
+          subscription: { endpoint, expirationTime: null, keys: { ...keys } },
+        }),
+      );
+    };
+    const storedLabels = async (): Promise<readonly string[]> => {
+      const state = JSON.parse(await readFile(statePath, "utf8")) as {
+        readonly subscriptions: readonly { readonly keys: PushSubscriptionKeys }[];
+      };
+      return state.subscriptions.map(entry => keyLabel(entry.keys));
+    };
+
+    await subscribeWith(previousKeys);
+    transport.blockWhen = candidate => keyLabel(candidate.keys) === "previous";
+
+    const blockedSend = transport.nextBlockedSend();
+    registry.upsert("owner", published(true));
+    const settleBlockedSend = await blockedSend;
+    expect(transport.calls.map(call => keyLabel(call.subscription.keys))).toEqual(["previous"]);
+
+    await subscribeWith(renewedKeys);
+    expect(await storedLabels()).toEqual(["renewed"]);
+    expect(transport.calls).toHaveLength(1);
+
+    transport.blockWhen = undefined;
+    settleBlockedSend(pushError(410));
+    await service.flush();
+
+    expect(await storedLabels()).toEqual(["renewed"]);
+
+    const deliveredBeforeClear = transport.calls.length;
+    registry.upsert("owner", published(false));
+    await service.flush();
+    const afterRenewal = transport.calls.slice(deliveredBeforeClear);
+    expect(afterRenewal.map(call => keyLabel(call.subscription.keys))).toEqual(["renewed"]);
+    expect(afterRenewal.map(call => parseAttentionPushMessage(JSON.parse(call.payload)).type)).toEqual(["clear"]);
+
+    transport.statusCode = 410;
+    registry.upsert("owner", published(true));
+    await service.flush();
+    expect(await storedLabels()).toEqual([]);
+
+    await service.stop();
+    const log = lines.join("\n");
+    expect(log).not.toContain(endpoint);
+    expect(log).not.toContain(previousKeys.auth);
+    expect(log).not.toContain(renewedKeys.auth);
+    expect(log).not.toContain(previousKeys.p256dh);
+    expect(log).not.toContain(renewedKeys.p256dh);
   });
 });

--- a/apps/gateway/test/registry.test.ts
+++ b/apps/gateway/test/registry.test.ts
@@ -237,4 +237,23 @@ describe("SessionRegistry", () => {
       ["session_remove", 3],
     ]);
   });
+
+  test("delivers queued revisions to every healthy listener before surfacing an observer failure", () => {
+    const registry = new SessionRegistry({ ttlSeconds: 35, maxSessions: 10 });
+    const first: number[] = [];
+    const third: number[] = [];
+    registry.subscribe(event => first.push(event.revision));
+    registry.subscribe(event => {
+      if (event.type !== "session_upsert" || event.revision !== 1) return;
+      registry.upsert("owner-a", published(2));
+      throw new Error("observer failed");
+    });
+    registry.subscribe(event => third.push(event.revision));
+
+    expect(() => registry.upsert("owner-a", published(1))).toThrow("observer failed");
+
+    expect(first).toEqual([1, 2]);
+    expect(third).toEqual([1, 2]);
+    expect(registry.snapshot().sessions[0]?.generation).toBe(2);
+  });
 });

--- a/apps/gateway/test/registry.test.ts
+++ b/apps/gateway/test/registry.test.ts
@@ -238,8 +238,13 @@ describe("SessionRegistry", () => {
     ]);
   });
 
-  test("delivers queued revisions to every healthy listener before surfacing an observer failure", () => {
-    const registry = new SessionRegistry({ ttlSeconds: 35, maxSessions: 10 });
+  test("reports observer failure after delivering queued revisions to every healthy listener", () => {
+    const errors: unknown[] = [];
+    const registry = new SessionRegistry({
+      ttlSeconds: 35,
+      maxSessions: 10,
+      onListenerError: error => errors.push(error),
+    });
     const first: number[] = [];
     const third: number[] = [];
     registry.subscribe(event => first.push(event.revision));
@@ -250,10 +255,34 @@ describe("SessionRegistry", () => {
     });
     registry.subscribe(event => third.push(event.revision));
 
-    expect(() => registry.upsert("owner-a", published(1))).toThrow("observer failed");
+    registry.upsert("owner-a", published(1));
 
     expect(first).toEqual([1, 2]);
     expect(third).toEqual([1, 2]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+    expect((errors[0] as Error).message).toBe("observer failed");
     expect(registry.snapshot().sessions[0]?.generation).toBe(2);
+  });
+
+  test("revokes every owned capability when a removal observer fails", () => {
+    const errors: unknown[] = [];
+    const registry = new SessionRegistry({
+      ttlSeconds: 35,
+      maxSessions: 10,
+      onListenerError: error => errors.push(error),
+    });
+    registry.subscribe(event => {
+      if (event.type === "session_remove") throw new Error("remove observer failed");
+    });
+    registry.upsert("owner-a", published(1, { instanceId: "registry-instance-0001" }));
+    registry.upsert("owner-a", published(1, { instanceId: "registry-instance-0002" }));
+
+    expect(registry.removeOwner("owner-a")).toBe(2);
+
+    expect(registry.size).toBe(0);
+    expect(registry.lookupCapability("registry-instance-0001", 1, "control").status).toBe("missing");
+    expect(registry.lookupCapability("registry-instance-0002", 1, "control").status).toBe("missing");
+    expect(errors).toHaveLength(2);
   });
 });

--- a/apps/gateway/test/registry.test.ts
+++ b/apps/gateway/test/registry.test.ts
@@ -171,4 +171,70 @@ describe("SessionRegistry", () => {
     registry.upsert("owner-a", published());
     expect(() => registry.upsert("owner-a", published(1, { sessionId: "different" }))).toThrow("identity conflict");
   });
+
+  test("admits a subscriber atomically when snapshot delivery mutates the registry", () => {
+    const registry = new SessionRegistry({ ttlSeconds: 35, maxSessions: 10 });
+    registry.upsert("owner-a", published(1));
+    const observed: SessionEvent[] = [];
+    let reentered = false;
+    const unsubscribe = registry.subscribeWithSnapshot(event => {
+      observed.push(event);
+      if (event.type !== "snapshot" || reentered) return;
+      reentered = true;
+      // Lands after the snapshot was read but before admission completes: exactly the window a
+      // snapshot-then-subscribe handshake drops a revision into.
+      registry.upsert("owner-a", published(2));
+    });
+    registry.upsert("owner-a", published(3));
+    unsubscribe();
+    registry.upsert("owner-a", published(4));
+
+    expect(observed.map(event => [event.type, event.revision])).toEqual([
+      ["snapshot", 1],
+      ["session_upsert", 2],
+      ["session_upsert", 3],
+    ]);
+    expect(observed[0]).toMatchObject({ sessions: [{ generation: 1 }] });
+    expect(registry.snapshot().sessions[0]?.generation).toBe(4);
+  });
+
+  test("drops admission-buffered revisions the snapshot already represents", () => {
+    const clock = new FakeClock();
+    const registry = new SessionRegistry({ ttlSeconds: 35, maxSessions: 10, clock });
+    registry.upsert("owner-a", published(1));
+    clock.advance(35_000);
+
+    const observed: SessionEvent[] = [];
+    // Admission sweeps the expired record while the listener is already registered, yet that removal
+    // is folded into the snapshot revision; replaying it would repeat revision 2.
+    registry.subscribeWithSnapshot(event => observed.push(event));
+    registry.upsert("owner-a", published(1));
+
+    expect(observed.map(event => [event.type, event.revision])).toEqual([
+      ["snapshot", 2],
+      ["session_upsert", 3],
+    ]);
+    expect(observed[0]).toMatchObject({ sessions: [] });
+  });
+
+  test("keeps revisions increasing for every listener when one mutates during dispatch", () => {
+    const clock = new FakeClock();
+    const registry = new SessionRegistry({ ttlSeconds: 35, maxSessions: 10, clock });
+    registry.upsert("owner-a", published(1, { instanceId: "registry-instance-0002" }));
+    clock.advance(35_000);
+
+    // Mirrors the push service: a listener that reads the directory sweeps it, producing a newer
+    // revision from inside the dispatch of an older one.
+    registry.subscribe(() => {
+      registry.snapshot();
+    });
+    const observed: SessionEvent[] = [];
+    registry.subscribe(event => observed.push(event));
+    registry.upsert("owner-a", published(1));
+
+    expect(observed.map(event => [event.type, event.revision])).toEqual([
+      ["session_upsert", 2],
+      ["session_remove", 3],
+    ]);
+  });
 });

--- a/apps/gateway/test/service.test.ts
+++ b/apps/gateway/test/service.test.ts
@@ -656,7 +656,12 @@ function mutations(commands: readonly (readonly string[])[]): readonly string[] 
  */
 function fakeManager(
   platform: ServiceHost["platform"],
-  initial: { readonly program?: string; readonly running?: boolean; readonly adopts?: string } = {},
+  initial: {
+    readonly program?: string;
+    readonly running?: boolean;
+    readonly adopts?: string;
+    readonly homeDirectory?: string;
+  } = {},
 ): FakeManager {
   const state = { program: initial.program, running: initial.running ?? false };
   const commands: string[][] = [];
@@ -702,6 +707,7 @@ function fakeManager(
       state.program = undefined;
       return { ok: true };
     }
+    if (is("launchctl", "print", `gui/${uid}`)) return { ok: true };
     if (is("launchctl", "print", target)) {
       return state.program === undefined ? { ok: false } : { ok: true, stdout: rendered(state.program) };
     }
@@ -717,6 +723,7 @@ function fakeManager(
     }
     // `Get-ScheduledTask -ErrorAction Stop` fails outright when no task carries the name.
     if (command[0] === "powershell.exe") return { ok: state.program !== undefined && state.running };
+    if (is("schtasks.exe", "/Query")) return { ok: true };
     if (is("schtasks.exe", "/Query", "/TN", task, "/XML")) {
       return state.program === undefined ? { ok: false } : { ok: true, stdout: rendered(state.program) };
     }
@@ -749,6 +756,7 @@ function fakeManager(
     commands,
     host: {
       platform,
+      ...(initial.homeDirectory === undefined ? {} : { homeDirectory: initial.homeDirectory }),
       output: async command => {
         const result = record(command);
         return result.ok ? (result.stdout ?? "") : undefined;
@@ -823,6 +831,59 @@ describe("service ownership across install roots", () => {
   function foreignProgram(root: string): string {
     return stagedProgram(join(root, "other", "omp-session-gateway"), "0.1.0-f0f0f0f0f0f0");
   }
+
+  test("refuses an unloaded foreign LaunchAgent definition before install or uninstall", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const homeDirectory = join(root, "home");
+    const foreign = foreignProgram(root);
+    const manager = fakeManager("darwin", { homeDirectory });
+    const definition = serviceDefinition(target, "darwin", foreign, undefined, homeDirectory);
+    await mkdir(dirname(definition.path), { recursive: true, mode: 0o700 });
+    await writeFile(definition.path, definition.content);
+
+    await expect(
+      installUserService(target, false, stagedProgram(target.paths.stateDir, "0.1.0-111111111111"), boundInstance, manager.host),
+    ).rejects.toThrow("another gateway service already holds this launchd label from a different install root");
+    await expect(uninstallUserService(target, true, manager.host)).rejects.toThrow(
+      "another gateway service already holds this launchd label from a different install root",
+    );
+
+    expect(mutations(manager.commands)).toEqual([]);
+    expect(await readFile(definition.path, "utf8")).toBe(definition.content);
+    expect(manager.state.program).toBeUndefined();
+  });
+
+  test("fails closed before file mutation when the systemd ownership query is unavailable", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const manager = fakeManager("linux");
+    const host: ServiceHost = {
+      ...manager.host,
+      output: async command => {
+        await manager.host.output(command);
+        return undefined;
+      },
+    };
+    const definition = serviceDefinition(
+      target,
+      "linux",
+      stagedProgram(target.paths.stateDir, "0.1.0-111111111111"),
+    );
+
+    await expect(
+      installUserService(target, true, stagedProgram(target.paths.stateDir, "0.1.0-111111111111"), boundInstance, host),
+    ).rejects.toThrow("cannot verify systemd user unit name ownership");
+    expect(existsSync(dirname(definition.path))).toBe(false);
+
+    await mkdir(dirname(definition.path), { recursive: true, mode: 0o700 });
+    await writeFile(definition.path, definition.content);
+    await expect(uninstallUserService(target, true, host)).rejects.toThrow(
+      "cannot verify systemd user unit name ownership",
+    );
+    expect(await readFile(definition.path, "utf8")).toBe(definition.content);
+    expect(mutations(manager.commands)).toEqual([]);
+  });
 
   test("refuses a loaded but idle foreign systemd unit before writing or reloading anything", async () => {
     const root = await isolatedRoot();

--- a/apps/gateway/test/service.test.ts
+++ b/apps/gateway/test/service.test.ts
@@ -870,6 +870,9 @@ describe("service ownership across install roots", () => {
       "linux",
       stagedProgram(target.paths.stateDir, "0.1.0-111111111111"),
     );
+    await expect(stopUserService(target, host)).rejects.toThrow(
+      "cannot verify systemd user unit name ownership",
+    );
 
     await expect(
       installUserService(target, true, stagedProgram(target.paths.stateDir, "0.1.0-111111111111"), boundInstance, host),
@@ -882,6 +885,20 @@ describe("service ownership across install roots", () => {
       "cannot verify systemd user unit name ownership",
     );
     expect(await readFile(definition.path, "utf8")).toBe(definition.content);
+    expect(mutations(manager.commands)).toEqual([]);
+  });
+
+  test("refuses to install a definition that does not identify this state root", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const manager = fakeManager("linux");
+    const definitionPath = serviceDefinition(target, "linux").path;
+
+    await expect(installUserService(target, false, undefined, undefined, manager.host)).rejects.toThrow(
+      "gateway service program must be staged under the configured state directory",
+    );
+
+    expect(existsSync(definitionPath)).toBe(false);
     expect(mutations(manager.commands)).toEqual([]);
   });
 
@@ -1080,13 +1097,40 @@ describe("service ownership across install roots", () => {
     expect(manager.state.running).toBe(false);
   });
 
+  test("preserves a definition another root writes after the manager mutation", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const program = stagedProgram(target.paths.stateDir, "0.1.0-111111111111");
+    const foreignDefinition = serviceDefinition(target, "linux", foreignProgram(root));
+    const definition = serviceDefinition(target, "linux", program);
+    await mkdir(dirname(definition.path), { recursive: true, mode: 0o700 });
+    await writeFile(definition.path, definition.content);
+    const manager = fakeManager("linux", { program, running: true });
+    const host: ServiceHost = {
+      ...manager.host,
+      run: async command => {
+        await manager.host.run(command);
+        if (command.includes("disable")) await writeFile(definition.path, foreignDefinition.content);
+      },
+    };
+
+    await expect(uninstallUserService(target, true, host)).rejects.toThrow(
+      "another gateway service already holds this systemd user unit name from a different install root",
+    );
+
+    expect(await readFile(definition.path, "utf8")).toBe(foreignDefinition.content);
+    expect(mutations(manager.commands)).toEqual(["systemctl --user disable --now omp-session-gateway.service"]);
+  });
+
   test("leaves a running foreign task alone when asked to stop", async () => {
     const root = await isolatedRoot();
     const target = rootedConfig(root);
     const foreign = foreignProgram(root);
     const manager = fakeManager("win32", { program: foreign, running: true });
 
-    await stopUserService(target, manager.host);
+    await expect(stopUserService(target, manager.host)).rejects.toThrow(
+      "another gateway service already holds this scheduled task name from a different install root",
+    );
 
     expect(mutations(manager.commands)).toEqual([]);
     expect(manager.state.running).toBe(true);
@@ -1107,7 +1151,7 @@ describe("service ownership across install roots", () => {
         const rendered = await manager.host.output(command);
         if (command[0] === "schtasks.exe" && command.includes("/XML")) {
           ownershipReads += 1;
-          if (ownershipReads === 1) manager.state.program = foreign;
+          if (ownershipReads === 2) manager.state.program = foreign;
         }
         return rendered;
       },
@@ -1117,7 +1161,7 @@ describe("service ownership across install roots", () => {
       "another gateway service already holds this scheduled task name from a different install root",
     );
 
-    expect(ownershipReads).toBe(2);
+    expect(ownershipReads).toBe(3);
     expect(mutations(manager.commands)).toEqual([]);
     expect(manager.state.program).toBe(foreign);
     expect(manager.state.running).toBe(true);

--- a/apps/gateway/test/service.test.ts
+++ b/apps/gateway/test/service.test.ts
@@ -242,8 +242,8 @@ describe("service packaging", () => {
  * which took the active branch and booted out the production daemon.
  */
 describe("loaded service ownership", () => {
-  // Build fixtures with the host separator: the predicate compares against `stateDir + sep`, so a
-  // hard-coded POSIX fixture would vacuously fail on Windows and pass for the wrong reason on macOS.
+  // Use the host separator for ordinary manager output. A separate fixture below proves serialized
+  // definitions remain recognizable when their path syntax differs from the runner's.
   const stateDir = join(sep, "Users", "example", ".local", "state", "omp-session-gateway");
   const installedCli = join(stateDir, "installation", "versions", "0.1.0-77e3a6914cea", "apps", "gateway", "src", "cli.js");
   const otherRoot = join(sep, "tmp", "smoke.abc123", "state", "omp-session-gateway");
@@ -278,6 +278,14 @@ describe("loaded service ownership", () => {
     const execStart = `{ path=/usr/bin/bun ; argv[]=/usr/bin/bun ${installedCli} serve ; ignore_errors=no }`;
     expect(serviceProgramBelongsTo(execStart, stateDir)).toBe(true);
     expect(serviceProgramBelongsTo(execStart, otherRoot)).toBe(false);
+  });
+
+  test("recognizes a JSON-escaped Windows path in a systemd definition on every runner", () => {
+    const windowsState = String.raw`C:\Users\example\AppData\Local\omp-session-gateway`;
+    const windowsCli = String.raw`${windowsState}\installation\versions\0.1.0-test\apps\gateway\src\cli.js`;
+    const definition = `ExecStart=${JSON.stringify(windowsCli)}`;
+    expect(serviceProgramBelongsTo(definition, windowsState)).toBe(true);
+    expect(serviceProgramBelongsTo(definition, `${windowsState}-2`)).toBe(false);
   });
 
   test("disclaims a root whose name is a prefix of an unrelated directory's name", () => {

--- a/apps/gateway/test/service.test.ts
+++ b/apps/gateway/test/service.test.ts
@@ -955,7 +955,9 @@ describe("service ownership across install roots", () => {
     const definition = await installUserService(target, true, program, boundInstance, manager.host);
 
     expect(await readFile(definition.path, "utf8")).toBe(definition.content);
-    expect(statSync(definition.path).mode & 0o777).toBe(0o600);
+    // A fake Linux manager does not give the Windows filesystem POSIX mode semantics; the native
+    // Linux job owns this permission assertion.
+    if (process.platform !== "win32") expect(statSync(definition.path).mode & 0o777).toBe(0o600);
     expect(mutations(manager.commands)).toEqual([
       "systemctl --user daemon-reload",
       "systemctl --user enable omp-session-gateway.service",

--- a/apps/gateway/test/service.test.ts
+++ b/apps/gateway/test/service.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, test } from "bun:test";
-import { statSync } from "node:fs";
-import { homedir } from "node:os";
-import { basename, isAbsolute, join, resolve, sep } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, statSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
 import type { GatewayConfig } from "../src/config.ts";
-import { serviceDefinition, serviceProgramBelongsTo } from "../src/service.ts";
+import {
+  installUserService,
+  serviceDefinition,
+  type ServiceHost,
+  serviceProgramBelongsTo,
+  stopUserService,
+  uninstallUserService,
+} from "../src/service.ts";
 
 const config: GatewayConfig = {
   http: { hostname: "127.0.0.1", port: 4317, publicOrigin: "https://gateway.example.ts.net" },
@@ -600,5 +608,471 @@ describe("unsupported platforms", () => {
     expect(() => serviceDefinition(config, "sunos", installedCliPath, "short")).toThrow(
       "invalid service readiness instance",
     );
+  });
+});
+
+interface FakeCommandResult {
+  readonly ok: boolean;
+  readonly stdout?: string;
+}
+
+interface FakeManager {
+  readonly host: ServiceHost;
+  /** Every command the flow issued, in order. */
+  readonly commands: readonly (readonly string[])[];
+  /** What the manager would execute for the label, and whether it is running it. */
+  readonly state: { program: string | undefined; running: boolean };
+}
+
+/** The manager verbs that change machine state; a refusal must have issued none of them. */
+const mutatingVerbs = new Set([
+  "daemon-reload",
+  "enable",
+  "disable",
+  "start",
+  "restart",
+  "stop",
+  "bootout",
+  "bootstrap",
+  "/Create",
+  "/Run",
+  "/End",
+  "/Delete",
+]);
+
+function mutations(commands: readonly (readonly string[])[]): readonly string[] {
+  return commands.filter(command => command.some(token => mutatingVerbs.has(token))).map(command => command.join(" "));
+}
+
+/**
+ * A service manager that answers from state instead of from the machine running the suite.
+ *
+ * `program` is what it would execute for the gateway's label — the one piece of a manager's identity
+ * that carries the install root — and undefined means nothing holds the label. `running` is separate
+ * on purpose: systemd loads units it never started and Task Scheduler holds idle tasks, and both are
+ * as destructible as a running one. Queries are answered from that state and mutations apply to it,
+ * `adopts` being the program the definition under installation names. An unmodelled command throws
+ * rather than reporting a plausible success.
+ */
+function fakeManager(
+  platform: ServiceHost["platform"],
+  initial: { readonly program?: string; readonly running?: boolean; readonly adopts?: string } = {},
+): FakeManager {
+  const state = { program: initial.program, running: initial.running ?? false };
+  const commands: string[][] = [];
+  const uid = process.getuid?.() ?? 0;
+  const unit = "omp-session-gateway.service";
+  const task = "OMP Session Gateway";
+  const target = `gui/${uid}/omp-session-gateway`;
+  /** The manager's own rendering of the program it holds, in the shape the real one prints. */
+  const rendered = (program: string): string => {
+    if (platform === "linux") {
+      return `{ path=${process.execPath} ; argv[]=${process.execPath} ${program} serve ; ignore_errors=no }\n`;
+    }
+    if (platform === "darwin") {
+      return `${target} = {\n\tprogram = ${process.execPath}\n\targuments = {\n\t\t${process.execPath}\n\t\t${program}\n\t\tserve\n\t}\n}\n`;
+    }
+    return `<Task version="1.4">\n  <Actions Context="Author"><Exec><Command>${process.execPath}</Command><Arguments>&quot;${program}&quot; &quot;serve&quot;</Arguments></Exec></Actions>\n</Task>\n`;
+  };
+  const answer = (command: readonly string[]): FakeCommandResult => {
+    const is = (...tokens: readonly string[]): boolean =>
+      command.length === tokens.length && tokens.every((token, index) => command[index] === token);
+    if (is("systemctl", "--user", "show", "-p", "ExecStart", "--value", unit)) {
+      // systemctl exits zero for a unit it does not know and prints an empty value for it.
+      return { ok: true, stdout: state.program === undefined ? "\n" : rendered(state.program) };
+    }
+    if (is("systemctl", "--user", "is-active", unit)) return { ok: state.running };
+    if (is("systemctl", "--user", "is-enabled", unit)) return { ok: state.program !== undefined };
+    if (is("systemctl", "--user", "daemon-reload")) {
+      // Reloading is where the manager adopts the unit file the caller just wrote.
+      if (initial.adopts !== undefined) state.program = initial.adopts;
+      return { ok: true };
+    }
+    if (is("systemctl", "--user", "enable", unit)) return { ok: state.program !== undefined };
+    if (is("systemctl", "--user", "start", unit) || is("systemctl", "--user", "restart", unit)) {
+      state.running = state.program !== undefined;
+      return { ok: state.program !== undefined };
+    }
+    if (is("systemctl", "--user", "stop", unit)) {
+      state.running = false;
+      return { ok: true };
+    }
+    if (is("systemctl", "--user", "disable", "--now", unit) || is("systemctl", "--user", "disable", unit)) {
+      if (command.includes("--now")) state.running = false;
+      state.program = undefined;
+      return { ok: true };
+    }
+    if (is("launchctl", "print", target)) {
+      return state.program === undefined ? { ok: false } : { ok: true, stdout: rendered(state.program) };
+    }
+    if (is("launchctl", "bootout", target)) {
+      state.program = undefined;
+      state.running = false;
+      return { ok: true };
+    }
+    if (command[0] === "launchctl" && command[1] === "bootstrap") {
+      state.program = initial.adopts;
+      state.running = initial.adopts !== undefined;
+      return { ok: true };
+    }
+    // `Get-ScheduledTask -ErrorAction Stop` fails outright when no task carries the name.
+    if (command[0] === "powershell.exe") return { ok: state.program !== undefined && state.running };
+    if (is("schtasks.exe", "/Query", "/TN", task, "/XML")) {
+      return state.program === undefined ? { ok: false } : { ok: true, stdout: rendered(state.program) };
+    }
+    if (is("schtasks.exe", "/Query", "/TN", task)) return { ok: state.program !== undefined };
+    if (is("schtasks.exe", "/End", "/TN", task)) {
+      state.running = false;
+      return { ok: true };
+    }
+    if (command[0] === "schtasks.exe" && command[1] === "/Create") {
+      state.program = initial.adopts;
+      return { ok: true };
+    }
+    if (is("schtasks.exe", "/Run", "/TN", task)) {
+      state.running = state.program !== undefined;
+      return { ok: state.program !== undefined };
+    }
+    if (is("schtasks.exe", "/Delete", "/TN", task, "/F")) {
+      state.program = undefined;
+      state.running = false;
+      return { ok: true };
+    }
+    throw new Error(`fake service manager received an unmodelled command: ${command.join(" ")}`);
+  };
+  const record = (command: readonly string[]): FakeCommandResult => {
+    commands.push([...command]);
+    return answer(command);
+  };
+  return {
+    state,
+    commands,
+    host: {
+      platform,
+      output: async command => {
+        const result = record(command);
+        return result.ok ? (result.stdout ?? "") : undefined;
+      },
+      succeeds: async command => record(command).ok,
+      run: async command => {
+        if (!record(command).ok) throw new Error(`${command[0] ?? "service command"} failed`);
+      },
+    },
+  };
+}
+
+/** The staged program a definition names: `install` always roots it under the state directory. */
+function stagedProgram(stateDir: string, version: string): string {
+  return join(stateDir, "installation", "versions", version, "apps", "gateway", "src", "cli.js");
+}
+
+/**
+ * Regression for the rest of the 2026-08-19 outage class: the predicate above was wired into one
+ * platform and one moment.
+ *
+ * Ownership was consulted on macOS only, after the plist had already been written, and only when the
+ * install was activating. Linux gated it behind `is-active`, so a foreign unit systemd had loaded but
+ * never started was invisible and got reloaded, enabled and restarted; Windows gated it behind
+ * `State -eq 'Running'`, so an idle foreign task was invisible and got recreated. `installed` is
+ * label-scoped on both — `systemctl is-enabled`, `schtasks /Query` — so uninstall disabled, stopped
+ * and deleted a foreign service as well, and its closing `rm` removed a definition path two roots
+ * sharing a HOME compute identically.
+ *
+ * Producing a foreign holder for real means loading a service on the machine running the suite,
+ * which is the accident under test, so these drive the injected `ServiceHost` instead.
+ */
+describe("service ownership across install roots", () => {
+  const saved = { ...process.env };
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    for (const key of Object.keys(process.env)) if (!(key in saved)) delete process.env[key];
+    Object.assign(process.env, saved);
+    await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })));
+  });
+
+  /**
+   * A throwaway install root with the XDG variables pointed into it, so the systemd definition path
+   * — which comes from `XDG_CONFIG_HOME` rather than from the config — lands inside it too.
+   */
+  async function isolatedRoot(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "gateway-service-"));
+    roots.push(root);
+    process.env.XDG_CONFIG_HOME = join(root, "config");
+    process.env.XDG_STATE_HOME = join(root, "state");
+    process.env.XDG_RUNTIME_DIR = join(root, "run");
+    return root;
+  }
+
+  function rootedConfig(root: string): GatewayConfig {
+    const configDir = join(root, "config", "omp-session-gateway");
+    return {
+      ...config,
+      paths: {
+        configDir,
+        stateDir: join(root, "state", "omp-session-gateway"),
+        runtimeDir: join(root, "run", "omp-session-gateway"),
+        socketPath: join(root, "run", "omp-session-gateway", "registry.sock"),
+        tokenPath: join(configDir, "publisher-token"),
+        configPath: join(configDir, "config.json"),
+      },
+    };
+  }
+
+  /** A program staged under a second install root on the same machine. */
+  function foreignProgram(root: string): string {
+    return stagedProgram(join(root, "other", "omp-session-gateway"), "0.1.0-f0f0f0f0f0f0");
+  }
+
+  test("refuses a loaded but idle foreign systemd unit before writing or reloading anything", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const foreign = foreignProgram(root);
+    // Never started, so `is-active` reports nothing holds the label and `show` reports otherwise.
+    const manager = fakeManager("linux", { program: foreign, running: false });
+    const definitionPath = serviceDefinition(target, "linux").path;
+
+    await expect(
+      installUserService(target, true, stagedProgram(target.paths.stateDir, "0.1.0-111111111111"), boundInstance, manager.host),
+    ).rejects.toThrow("another gateway service already holds this systemd user unit name from a different install root");
+
+    expect(mutations(manager.commands)).toEqual([]);
+    expect(existsSync(definitionPath)).toBe(false);
+    // Not even the directory: the refusal precedes the `mkdir`.
+    expect(existsSync(dirname(definitionPath))).toBe(false);
+    expect(manager.state.program).toBe(foreign);
+  });
+
+  test("refuses an idle foreign scheduled task before writing the definition or recreating it", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const foreign = foreignProgram(root);
+    const manager = fakeManager("win32", { program: foreign, running: false });
+    const definitionPath = serviceDefinition(target, "win32").path;
+
+    await expect(
+      installUserService(target, true, stagedProgram(target.paths.stateDir, "0.1.0-111111111111"), boundInstance, manager.host),
+    ).rejects.toThrow("another gateway service already holds this scheduled task name from a different install root");
+
+    expect(mutations(manager.commands)).toEqual([]);
+    expect(existsSync(definitionPath)).toBe(false);
+    expect(existsSync(target.paths.configDir)).toBe(false);
+    expect(manager.state.program).toBe(foreign);
+  });
+
+  test("installs when nothing holds the systemd unit name", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const program = stagedProgram(target.paths.stateDir, "0.1.0-111111111111");
+    const manager = fakeManager("linux", { adopts: program });
+
+    const definition = await installUserService(target, true, program, boundInstance, manager.host);
+
+    expect(await readFile(definition.path, "utf8")).toBe(definition.content);
+    expect(statSync(definition.path).mode & 0o777).toBe(0o600);
+    expect(mutations(manager.commands)).toEqual([
+      "systemctl --user daemon-reload",
+      "systemctl --user enable omp-session-gateway.service",
+      "systemctl --user start omp-session-gateway.service",
+    ]);
+    expect(manager.state.program).toBe(program);
+    expect(manager.state.running).toBe(true);
+  });
+
+  test("upgrades a unit this root already owns, starting it when systemd had it stopped", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const next = stagedProgram(target.paths.stateDir, "0.1.0-222222222222");
+    const manager = fakeManager("linux", {
+      program: stagedProgram(target.paths.stateDir, "0.1.0-111111111111"),
+      running: false,
+      adopts: next,
+    });
+
+    const definition = await installUserService(target, true, next, boundInstance, manager.host);
+
+    expect(await readFile(definition.path, "utf8")).toBe(definition.content);
+    expect(mutations(manager.commands)).toEqual([
+      "systemctl --user daemon-reload",
+      "systemctl --user enable omp-session-gateway.service",
+      "systemctl --user start omp-session-gateway.service",
+    ]);
+    expect(manager.state.program).toBe(next);
+  });
+
+  test("restarts instead of starting when the unit it replaces was already running", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const next = stagedProgram(target.paths.stateDir, "0.1.0-222222222222");
+    const manager = fakeManager("linux", {
+      program: stagedProgram(target.paths.stateDir, "0.1.0-111111111111"),
+      running: true,
+      adopts: next,
+    });
+
+    await installUserService(target, true, next, boundInstance, manager.host);
+
+    expect(mutations(manager.commands)).toEqual([
+      "systemctl --user daemon-reload",
+      "systemctl --user enable omp-session-gateway.service",
+      "systemctl --user restart omp-session-gateway.service",
+    ]);
+    expect(manager.state.running).toBe(true);
+  });
+
+  test("creates and runs a task when nothing holds the task name", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const program = stagedProgram(target.paths.stateDir, "0.1.0-111111111111");
+    const manager = fakeManager("win32", { adopts: program });
+
+    const definition = await installUserService(target, true, program, boundInstance, manager.host);
+
+    // UTF-16LE behind a hand-written BOM, which is the only encoding Task Scheduler loads.
+    const written = await readFile(definition.path);
+    expect([...written.subarray(0, 2)]).toEqual([0xff, 0xfe]);
+    expect(written.subarray(2).toString("utf16le")).toBe(definition.content);
+    expect(mutations(manager.commands)).toEqual([
+      `schtasks.exe /Create /TN OMP Session Gateway /XML ${definition.path} /F`,
+      "schtasks.exe /Run /TN OMP Session Gateway",
+    ]);
+  });
+
+  test("stops, recreates and runs a task this root already owns", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const next = stagedProgram(target.paths.stateDir, "0.1.0-222222222222");
+    const manager = fakeManager("win32", {
+      program: stagedProgram(target.paths.stateDir, "0.1.0-111111111111"),
+      running: true,
+      adopts: next,
+    });
+
+    const definition = await installUserService(target, true, next, boundInstance, manager.host);
+
+    expect(mutations(manager.commands)).toEqual([
+      "schtasks.exe /End /TN OMP Session Gateway",
+      `schtasks.exe /Create /TN OMP Session Gateway /XML ${definition.path} /F`,
+      "schtasks.exe /Run /TN OMP Session Gateway",
+    ]);
+    expect(manager.state.program).toBe(next);
+    expect(manager.state.running).toBe(true);
+  });
+
+  test("refuses to uninstall a foreign task, leaving its registration and definition alone", async () => {
+    // `installed` is the task *name*, so this branch reached `/End` and `/Delete` on a task another
+    // root owns, and the closing `rm` removed the definition both roots resolve to.
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const foreign = foreignProgram(root);
+    const manager = fakeManager("win32", { program: foreign, running: true });
+    const definitionPath = serviceDefinition(target, "win32").path;
+    await mkdir(dirname(definitionPath), { recursive: true, mode: 0o700 });
+    await writeFile(definitionPath, "definition owned by the other root\n");
+
+    await expect(uninstallUserService(target, true, manager.host)).rejects.toThrow(
+      "another gateway service already holds this scheduled task name from a different install root",
+    );
+
+    expect(mutations(manager.commands)).toEqual([]);
+    expect(await readFile(definitionPath, "utf8")).toBe("definition owned by the other root\n");
+    expect(manager.state.program).toBe(foreign);
+    expect(manager.state.running).toBe(true);
+  });
+
+  test("refuses to uninstall a foreign unit, leaving it enabled and its definition in place", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const foreign = foreignProgram(root);
+    const manager = fakeManager("linux", { program: foreign, running: true });
+    const definitionPath = serviceDefinition(target, "linux").path;
+    await mkdir(dirname(definitionPath), { recursive: true, mode: 0o700 });
+    await writeFile(definitionPath, "definition owned by the other root\n");
+
+    await expect(uninstallUserService(target, true, manager.host)).rejects.toThrow(
+      "another gateway service already holds this systemd user unit name from a different install root",
+    );
+
+    expect(mutations(manager.commands)).toEqual([]);
+    expect(await readFile(definitionPath, "utf8")).toBe("definition owned by the other root\n");
+    expect(manager.state.program).toBe(foreign);
+    expect(manager.state.running).toBe(true);
+  });
+
+  test("uninstalls a unit this root owns", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const program = stagedProgram(target.paths.stateDir, "0.1.0-111111111111");
+    const manager = fakeManager("linux", { program, running: true });
+    const definition = serviceDefinition(target, "linux", program);
+    await mkdir(dirname(definition.path), { recursive: true, mode: 0o700 });
+    await writeFile(definition.path, definition.content);
+
+    await uninstallUserService(target, true, manager.host);
+
+    expect(mutations(manager.commands)).toEqual([
+      "systemctl --user disable --now omp-session-gateway.service",
+      "systemctl --user daemon-reload",
+    ]);
+    expect(existsSync(definition.path)).toBe(false);
+    expect(manager.state.program).toBeUndefined();
+    expect(manager.state.running).toBe(false);
+  });
+
+  test("leaves a running foreign task alone when asked to stop", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const foreign = foreignProgram(root);
+    const manager = fakeManager("win32", { program: foreign, running: true });
+
+    await stopUserService(target, manager.host);
+
+    expect(mutations(manager.commands)).toEqual([]);
+    expect(manager.state.running).toBe(true);
+  });
+
+  test("rechecks ownership when a task is replaced after the active-status probe", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const manager = fakeManager("win32", {
+      program: stagedProgram(target.paths.stateDir, "0.1.0-111111111111"),
+      running: true,
+    });
+    const foreign = foreignProgram(root);
+    let ownershipReads = 0;
+    const host: ServiceHost = {
+      ...manager.host,
+      output: async command => {
+        const rendered = await manager.host.output(command);
+        if (command[0] === "schtasks.exe" && command.includes("/XML")) {
+          ownershipReads += 1;
+          if (ownershipReads === 1) manager.state.program = foreign;
+        }
+        return rendered;
+      },
+    };
+
+    await expect(stopUserService(target, host)).rejects.toThrow(
+      "another gateway service already holds this scheduled task name from a different install root",
+    );
+
+    expect(ownershipReads).toBe(2);
+    expect(mutations(manager.commands)).toEqual([]);
+    expect(manager.state.program).toBe(foreign);
+    expect(manager.state.running).toBe(true);
+  });
+
+  test("stops a running task this root owns", async () => {
+    const root = await isolatedRoot();
+    const target = rootedConfig(root);
+    const manager = fakeManager("win32", {
+      program: stagedProgram(target.paths.stateDir, "0.1.0-111111111111"),
+      running: true,
+    });
+
+    await stopUserService(target, manager.host);
+
+    expect(mutations(manager.commands)).toEqual(["schtasks.exe /End /TN OMP Session Gateway"]);
+    expect(manager.state.running).toBe(false);
   });
 });

--- a/apps/web/e2e/launch.e2e.ts
+++ b/apps/web/e2e/launch.e2e.ts
@@ -41,6 +41,8 @@ function workingSession(index: number): SessionMetadata {
 
 async function installSilentWebSocket(page: Page): Promise<void> {
   await page.addInitScript(() => {
+    const socketCounter = globalThis as typeof globalThis & { __ompRelaySocketCount?: number };
+    socketCounter.__ompRelaySocketCount = 0;
     Object.defineProperty(globalThis, "WebSocket", {
       configurable: true,
       value: class {
@@ -48,12 +50,18 @@ async function installSilentWebSocket(page: Page): Promise<void> {
         static readonly OPEN = 1;
         static readonly CLOSING = 2;
         static readonly CLOSED = 3;
+        readonly url: string;
         readyState = 0;
         binaryType = "blob";
         onopen: ((event: Event) => void) | null = null;
         onmessage: ((event: MessageEvent) => void) | null = null;
         onerror: ((event: Event) => void) | null = null;
         onclose: ((event: CloseEvent) => void) | null = null;
+
+        constructor(url: string) {
+          this.url = url;
+          socketCounter.__ompRelaySocketCount = (socketCounter.__ompRelaySocketCount ?? 0) + 1;
+        }
 
         close(): void {
           this.readyState = 3;
@@ -63,6 +71,12 @@ async function installSilentWebSocket(page: Page): Promise<void> {
       },
     });
   });
+}
+
+function relaySocketCount(page: Page): Promise<number> {
+  return page.evaluate(
+    () => (globalThis as typeof globalThis & { __ompRelaySocketCount?: number }).__ompRelaySocketCount ?? 0,
+  );
 }
 
 test("installed-PWA View and Control mount in the current window without losing the handoff", async ({ context, page }) => {
@@ -766,6 +780,78 @@ test("answer feedback dismisses by tap-out, swipe, and the eight-second timeout"
     await expect(page.locator(".triage-bar")).toHaveAttribute("data-kind", "clear");
     await page.clock.fastForward(8_100);
     await expect(page.locator(".triage-bar")).toBeHidden();
+  } finally {
+    await fixture.stop();
+  }
+});
+
+test("a bfcache restore of a client disposed on pagehide returns to the live directory", async ({ page }) => {
+  const active = session();
+  const fixture = await startDashboardFixture([
+    active,
+    ...Array.from({ length: 12 }, (_, index) => workingSession(index)),
+  ]);
+
+  try {
+    await installSilentWebSocket(page);
+    await page.goto(fixture.origin);
+    await expect(page.locator(".queue-hero")).toHaveCount(1);
+    await expect(page.locator(".working-row")).toHaveCount(12);
+    await page.evaluate(() => window.scrollTo(0, 360));
+    const directoryScroll = await page.evaluate(() => window.scrollY);
+    expect(directoryScroll).toBeGreaterThan(0);
+
+    await page.locator(".queue-hero").getByRole("button", { name: "Open request" }).evaluate(
+      button => (button as HTMLButtonElement).click(),
+    );
+    await expect(page).toHaveURL(`${fixture.origin}/client/`);
+    await expect(page.locator("#root > .sh-app")).toHaveCount(1);
+    expect(fixture.launchRequests).toHaveLength(1);
+
+    // Count the bearer's transports and freeze the page in the same task, so no relay attempt can
+    // slip between the reading and the teardown. Never return the capability-bearing URLs to the
+    // test runner, where a failed assertion could print them into CI output.
+    const bootstrapSocketCount = await page.evaluate(() => {
+      const count =
+        (globalThis as typeof globalThis & { __ompRelaySocketCount?: number }).__ompRelaySocketCount ?? 0;
+      window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true }));
+      return count;
+    });
+    expect(bootstrapSocketCount).toBeGreaterThanOrEqual(1);
+    await expect(page.locator("#root > .sh-app")).toHaveCount(0);
+    await expect(page.locator(".gateway-shell")).toHaveCount(1);
+    await expect(page).toHaveURL(`${fixture.origin}/client/`);
+
+    await page.evaluate(() =>
+      window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true })),
+    );
+    await expect(page).toHaveURL(`${fixture.origin}/`);
+    await expect(page.locator(".gateway-shell")).toHaveCount(0);
+    await expect(page.locator("#session-list")).toBeVisible();
+    await expect(page.locator(".queue-hero")).toHaveCount(1);
+    expect(await page.evaluate(() => window.scrollY)).toBe(directoryScroll);
+
+    fixture.upsert(answeredSession(active));
+    await expect(page.locator(".all-clear-title")).toHaveText("All clear");
+    await expect(page.locator(".working-row")).toHaveCount(13);
+    expect(fixture.launchRequests).toHaveLength(1);
+    expect(await relaySocketCount(page)).toBe(bootstrapSocketCount);
+
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.locator('.working-row[data-instance-id="working-session-0000"]').click();
+    await expect(page).toHaveURL(`${fixture.origin}/client/`);
+    await expect(page.locator("#root > .sh-app")).toHaveCount(1);
+    expect(fixture.launchRequests[1]).toEqual({
+      instanceId: "working-session-0000",
+      generation: 1,
+      mode: "view",
+    });
+    expect(await relaySocketCount(page)).toBeGreaterThan(bootstrapSocketCount);
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${fixture.origin}/`);
+    await expect(page.locator(".all-clear-title")).toHaveText("All clear");
+    await expect(page.locator(".working-row")).toHaveCount(13);
   } finally {
     await fixture.stop();
   }

--- a/apps/web/src/app.ts
+++ b/apps/web/src/app.ts
@@ -133,6 +133,13 @@ interface ActiveCollabShell {
 let dashboardSnapshot: DashboardSnapshot | undefined;
 let activeCollabShell: ActiveCollabShell | undefined;
 let disposeActiveCollab: (() => void) | undefined;
+/**
+ * `pagehide` disposes the collab client and drops its capability with it, but the shell DOM, the
+ * `/client/` URL, and the document itself all survive into the bfcache. A restore of that entry is
+ * an inert shell, so it has to be handed back to the directory instead of reconnected behind dead
+ * DOM — and never by restarting a client whose capability is gone.
+ */
+let collabShellDisposedOnPageHide = false;
 let currentNotificationDetail: PushDetailLevel = "session";
 
 const notificationLabels: Readonly<Record<NotificationControlState, string>> = {
@@ -946,6 +953,7 @@ function renderConnectionState(shell: ActiveCollabShell): void {
 }
 
 function returnToDirectory(historyValue?: unknown): void {
+  collabShellDisposedOnPageHide = false;
   const snapshot = dashboardSnapshot;
   if (snapshot === undefined) {
     location.replace("/");
@@ -1141,6 +1149,8 @@ function enterCollabClient(
     hasBeenLive: false,
   };
   activeCollabShell = shellState;
+  // A live shell supersedes any disposed predecessor, so the bfcache restore path must not fire.
+  collabShellDisposedOnPageHide = false;
 
   const updateConnection = (state: CollabEmbedState): void => {
     shellState.latestEmbedState = state;
@@ -1160,8 +1170,10 @@ function enterCollabClient(
     disposeClient();
     disposeClient = (): void => undefined;
     if (activeCollabShell === shellState) activeCollabShell = undefined;
+    if (disposeActiveCollab === dispose) disposeActiveCollab = undefined;
   };
   const handlePageHide = (): void => {
+    collabShellDisposedOnPageHide = true;
     dispose();
   };
   const handlePopState = (event: PopStateEvent): void => {
@@ -1438,7 +1450,12 @@ for (const input of notificationDetailInputs) {
   });
 }
 window.addEventListener("pageshow", event => {
-  if (event.persisted) void refreshAndConnect();
+  if (!event.persisted) return;
+  if (collabShellDisposedOnPageHide) {
+    returnToDirectory();
+    return;
+  }
+  void refreshAndConnect();
 });
 window.addEventListener("online", () => void refreshAndConnect());
 window.addEventListener("offline", () => {

--- a/apps/web/src/app.ts
+++ b/apps/web/src/app.ts
@@ -1186,9 +1186,10 @@ function enterCollabClient(
       container,
       capability,
       () => {
+        // The client has already unmounted itself. Restore the cached directory synchronously so a
+        // failed location.replace() cannot strand an inert shell without lifecycle listeners.
         disposeClient = (): void => undefined;
-        clearConnectionTimers(shellState);
-        removeLifecycleListeners();
+        returnToDirectory();
       },
       {
         focusPendingRequest: requestId !== undefined,

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,15 +1,17 @@
 # Release process
 
-## Pre-alpha
+## Pre-alpha and alpha artifacts
 
-The repository can produce a working Bun-runtime pre-alpha archive, but it must not be described as an alpha or production release until the gates below pass. Repository commits remain preferred while platform and Android qualification is incomplete.
+The repository can produce a working Bun-runtime pre-alpha archive and the advertised alpha release
+(`v0.1.0-alpha` in this stream). It must not be described as a production release until the gates
+below pass. Repository commits remain preferred while platform and Android qualification is incomplete.
+
+## Alpha release gates
 
 The current release decision, evidence, and open gates are maintained in
 [`RELEASE_STATUS.md`](RELEASE_STATUS.md). Exact OMP, protocol, platform, browser, and deployment
 claims are maintained separately in [`COMPATIBILITY.md`](COMPATIBILITY.md). A generated archive
 does not change either status.
-
-## Alpha release gates
 
 Before publishing an alpha binary:
 
@@ -48,13 +50,13 @@ required before claiming bounded memory growth.
 
 The release workflow accepts only tags matching the current `package.json` version:
 
-- `v<version>-prealpha.<n>` for a pre-alpha build;
-- `provenance-test-v<version>.<n>` for a provenance exercise; and
+- `v<version>-prealpha.<n>` for an internal pre-alpha artifact;
+- `v<version>-alpha[.<n>]` for the advertised alpha shape; and
+- `provenance-test-v<version>.<n>` for a provenance exercise.
 - `<n>` must be a positive decimal integer.
 
-Alpha, beta, release-candidate, and stable tags are intentionally rejected while the
-platform, Android, and security gates remain open. The tagged commit must be reachable
-from `main`.
+`beta`, `release-candidate`, and stable tags are intentionally rejected while the platform, Android, and
+security gates remain open. The tagged commit must be reachable from `main`.
 
 `.github/workflows/release.yml` runs `bun run check`, builds the deterministic archive,
 checks its SHA-256 digest, and then uses GitHub Actions OIDC for both provenance systems:
@@ -161,8 +163,8 @@ done
 ```
 
 Successful checksum, build-attestation, Cosign, and immutable-release checks establish
-integrity and origin. They do not qualify the pre-alpha for supported use; the alpha gates
-above still apply.
+integrity and origin. They do not by themselves satisfy any additional deployment or
+support claim; the alpha gates above still apply.
 
 ## Versioning
 

--- a/docs/UPGRADE_ROLLBACK.md
+++ b/docs/UPGRADE_ROLLBACK.md
@@ -15,7 +15,13 @@ The forward upgrade is already measured: the ledger records the live macOS servi
 publisher token preserved. Rollback is the half that was never executed, and it is named in the
 "Required to close" column of four **PARTIAL** rows.
 
-Rollback is not a command. There is no `omp-gateway rollback`. The installer keeps every runtime
+`rollback` is now a first-class CLI command in this codebase (`omp-gateway rollback [--to <version>]`).
+That command resolves an installed predecessor by default, or a requested version directory, and
+rejects malformed targets, unmanaged active services, missing rollback history, and uninstalled rollback
+destinations. This lane still validates by installing the predecessor archive again so the measured
+on-disk transition is anchored to how the historical pre-alpha artifacts are exercised.
+
+The installer keeps every runtime
 side by side:
 
 ```
@@ -23,8 +29,7 @@ side by side:
 <stateDir>/installation/current.json      {"versionDirectory":"0.1.0-8773d783ca96"}
 ```
 
-so rolling back means **installing the predecessor archive again**. That makes three questions
-worth answering with measurements rather than reasoning:
+so this historical path still requires three explicit checks:
 
 1. does the predecessor's version directory actually survive the upgrade, which is the only reason
    rollback is possible at all;
@@ -59,9 +64,9 @@ namespace, so an isolated install still *sees* the production daemon under its o
 2026-08-19 that cost a live daemon four minutes: an "isolated" archive smoke read `active: true` off
 the production service and booted it out.
 
-The fix in the working tree compares the loaded service's **program path** against `stateDir + sep`,
-so `active` means "a service this install root owns is running". `v0.1.0-prealpha.14` carries that
-fix. **`v0.1.0-prealpha.13` does not** — see [section 5](#5-findings). The lane therefore drives one
+`v0.1.0-prealpha.14` compares the loaded service's **program path** against `stateDir + sep`, so
+`active` means "a service this install root owns is running". **`v0.1.0-prealpha.13` does not** —
+see [section 5](#5-findings). The lane therefore drives one
 artifact that will try to bootout the production daemon and one that will not, and has to survive
 both.
 


### PR DESCRIPTION
## Summary

- make registry/SSE admission atomic and keep revocation complete under reentrant or failing observers
- preserve renewed Web Push subscriptions when stale in-flight deliveries fail
- restore disposed collaboration pages safely across Android BFCache without capability reuse
- fail closed across install roots for service install, stop, uninstall, and publisher-token rotation
- isolate launch rate windows by authenticated identity and add focused HTTP boundary coverage
- correct alpha/rollback documentation and prepare truthful `v0.1.0-prealpha.18` / `v0.1.0-alpha.1` release notes

## Threat-model impact

This tightens four existing boundaries without adding a new trust path:

- capabilities remain memory-only and metadata APIs remain capability-free
- stale push transport failures cannot delete a replacement or cross identity ownership
- a second current-user install root cannot overwrite, stop, delete, or rotate state for a foreign globally named service
- authenticated users no longer share launch bucket capacity through caller-selected instance IDs

No HTTP, IPC, push-state, service-definition, configuration, or capability format changes. No migration. Existing `v0.1.0-alpha` remains a valid rollback target.

## Verification

- `bun run check`: 381 passed, 0 failed; typecheck/build/handoff/leak scans green
- `bun run test:browser`: 22 passed at 411×816 and 390×844
- physical Pixel 10 Pro / Chrome 151.0.7922.171: real `pagehide.persisted=true` → `pageshow.persisted=true`, restored to the directory with no collab shell or capability re-bootstrap
- `bun audit`: no vulnerabilities
- two resolver-bound cross-family focused reviews: no P0/P1; all selected service/listener/rate/lifecycle findings closed with executable regressions

## Release follow-through

After merge and required checks, `v0.1.0-prealpha.18` will be the signed qualification candidate. The advertised Debian/macOS and physical Pixel lanes must pass on those exact bytes before `v0.1.0-alpha.1` is tagged. Windows remains unadvertised; unchanged long-relay soak evidence will be reused rather than disturbed.