### PR TITLE
fix: recover explicit rollback from systemd start limits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
           | Debian 13 (trixie) x86-64, systemd 257, kernel 6.12.94+deb13-amd64 | signed-candidate install, upgrade/rollback, readiness, identity isolation, reboot persistence, and uninstall lanes |
           | macOS 26.6.1 arm64 (Mac14,3) | signed-candidate install, active reinstall, token rotation, identity isolation, reboot persistence, and uninstall |
 
-          Client: Chrome 151.0.7922.171 on Android 17 (Pixel 10 Pro). The advertised hosts and client were qualified against signed candidate \`v0.1.0-prealpha.18\`; this release records its own exact source commit and provenance below.
+          Client: Chrome 151.0.7922.171 on Android 17 (Pixel 10 Pro). The advertised hosts and client were qualified against signed candidate \`v0.1.0-prealpha.19\`; this release records its own exact source commit and provenance below.
 
           ### Required deployment precondition
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
   an unavailable ownership probe now fails closed.
 - Scope launch rate windows to the authenticated identity and operation instead of caller-selected
   instance IDs, preventing one allowed identity from exhausting bucket capacity for another.
+- Clear systemd's start-rate counter before an explicit install or rollback restart, so several
+  successful version switches cannot deadlock the next operator-requested recovery.
 
 ### Testing
 

--- a/apps/gateway/src/service.ts
+++ b/apps/gateway/src/service.ts
@@ -372,6 +372,9 @@ export async function installUserService(
     await host.run(["systemctl", "--user", "daemon-reload"]);
     await host.run(["systemctl", "--user", "enable", "omp-session-gateway.service"]);
     if (activate) {
+      // An explicit install/rollback is an operator request to start now. Clear systemd's start-rate
+      // counter first so several successful version switches cannot deadlock the next rollback.
+      await host.run(["systemctl", "--user", "reset-failed", "omp-session-gateway.service"]);
       await host.run(["systemctl", "--user", wasActive ? "restart" : "start", "omp-session-gateway.service"]);
     }
   } else if (host.platform === "darwin") {

--- a/apps/gateway/test/service.test.ts
+++ b/apps/gateway/test/service.test.ts
@@ -629,7 +629,7 @@ interface FakeManager {
   /** Every command the flow issued, in order. */
   readonly commands: readonly (readonly string[])[];
   /** What the manager would execute for the label, and whether it is running it. */
-  readonly state: { program: string | undefined; running: boolean };
+  readonly state: { program: string | undefined; running: boolean; startLimited: boolean };
 }
 
 /** The manager verbs that change machine state; a refusal must have issued none of them. */
@@ -637,6 +637,7 @@ const mutatingVerbs = new Set([
   "daemon-reload",
   "enable",
   "disable",
+  "reset-failed",
   "start",
   "restart",
   "stop",
@@ -667,11 +668,16 @@ function fakeManager(
   initial: {
     readonly program?: string;
     readonly running?: boolean;
+    readonly startLimited?: boolean;
     readonly adopts?: string;
     readonly homeDirectory?: string;
   } = {},
 ): FakeManager {
-  const state = { program: initial.program, running: initial.running ?? false };
+  const state = {
+    program: initial.program,
+    running: initial.running ?? false,
+    startLimited: initial.startLimited ?? false,
+  };
   const commands: string[][] = [];
   const uid = process.getuid?.() ?? 0;
   const unit = "omp-session-gateway.service";
@@ -702,7 +708,12 @@ function fakeManager(
       return { ok: true };
     }
     if (is("systemctl", "--user", "enable", unit)) return { ok: state.program !== undefined };
+    if (is("systemctl", "--user", "reset-failed", unit)) {
+      state.startLimited = false;
+      return { ok: true };
+    }
     if (is("systemctl", "--user", "start", unit) || is("systemctl", "--user", "restart", unit)) {
+      if (state.startLimited) return { ok: false };
       state.running = state.program !== undefined;
       return { ok: state.program !== undefined };
     }
@@ -961,6 +972,7 @@ describe("service ownership across install roots", () => {
     expect(mutations(manager.commands)).toEqual([
       "systemctl --user daemon-reload",
       "systemctl --user enable omp-session-gateway.service",
+      "systemctl --user reset-failed omp-session-gateway.service",
       "systemctl --user start omp-session-gateway.service",
     ]);
     expect(manager.state.program).toBe(program);
@@ -983,6 +995,7 @@ describe("service ownership across install roots", () => {
     expect(mutations(manager.commands)).toEqual([
       "systemctl --user daemon-reload",
       "systemctl --user enable omp-session-gateway.service",
+      "systemctl --user reset-failed omp-session-gateway.service",
       "systemctl --user start omp-session-gateway.service",
     ]);
     expect(manager.state.program).toBe(next);
@@ -993,6 +1006,7 @@ describe("service ownership across install roots", () => {
     const target = rootedConfig(root);
     const next = stagedProgram(target.paths.stateDir, "0.1.0-222222222222");
     const manager = fakeManager("linux", {
+      startLimited: true,
       program: stagedProgram(target.paths.stateDir, "0.1.0-111111111111"),
       running: true,
       adopts: next,
@@ -1003,9 +1017,11 @@ describe("service ownership across install roots", () => {
     expect(mutations(manager.commands)).toEqual([
       "systemctl --user daemon-reload",
       "systemctl --user enable omp-session-gateway.service",
+      "systemctl --user reset-failed omp-session-gateway.service",
       "systemctl --user restart omp-session-gateway.service",
     ]);
     expect(manager.state.running).toBe(true);
+    expect(manager.state.startLimited).toBe(false);
   });
 
   test("creates and runs a task when nothing holds the task name", async () => {

--- a/apps/web/e2e/network-recovery.e2e.ts
+++ b/apps/web/e2e/network-recovery.e2e.ts
@@ -106,6 +106,9 @@ test("failure states keep stale sessions, exact copy, timestamps, and mobile fit
     await page.unroute("**/api/v1/sessions");
     await expect(page.locator("#status-banner")).toBeHidden({ timeout: 6_000 });
 
+    // Keep replacement EventSource connections down as well as the stream that is open now. Without
+    // this, the gateway banner can recover between the data-kind and copy assertions.
+    await page.route("**/api/v1/events", route => route.abort("connectionrefused"));
     fixture.disconnectEvents();
     await expect(page.locator("#status-banner")).toHaveAttribute("data-kind", "gateway", {
       timeout: 900,

--- a/scripts/provision-linux-qual.sh
+++ b/scripts/provision-linux-qual.sh
@@ -1549,6 +1549,28 @@ prev_root="$(find ~/runtime-prev -maxdepth 1 -mindepth 1 -type d 2>/dev/null | h
 # Every rollback here is driven by the candidate's CLI: it is the newer of the two artifacts, it is
 # what an operator on this box would reach for, and the predecessor may predate the command entirely.
 cli="$next_root/apps/gateway/src/cli.js"
+candidate_cli() {
+  "$bun" -e '
+const [, modulePath, ...args] = Bun.argv;
+const { main } = await import(modulePath);
+const describe = error => {
+  const message = error instanceof Error ? error.message : String(error);
+  const children =
+    error instanceof AggregateError
+      ? error.errors
+      : error instanceof Error && error.cause !== undefined
+        ? [error.cause]
+        : [];
+  return [message, ...children.flatMap(describe)];
+};
+try {
+  await main(args);
+} catch (error) {
+  console.error(describe(error).map((line, index) => `${index === 0 ? "" : "caused by: "}${line}`).join("\n"));
+  process.exitCode = 1;
+}
+' "$cli" "$@"
+}
 grep -q -a -F 'refusing to guess a rollback target' "$cli" || {
   echo "the candidate artifact carries no rollback target resolver, so it predates PR #78 and there is no command for this lane to exercise. Point OMP_QUAL_RELEASE_TAG at a candidate that has it." >&2
   exit 1
@@ -1639,7 +1661,7 @@ roll() {
   ROLL_PID_BEFORE="$(main_pid)"
   ROLL_HISTORY_BEFORE="$(history_count)"
   ROLL_HISTORY_LAST_BEFORE="$(history_last)"
-  ROLL_OUTPUT="$("$bun" "$cli" rollback "$@" | tr '\n' ' ')"
+  ROLL_OUTPUT="$(candidate_cli rollback "$@" | tr '\n' ' ')"
   ROLL_TO="$(pointer_version)"
   ROLL_UNIT_PATH="$(unit_exec_path)"
   ROLL_UNIT_VERSION="$(version_of_path "$ROLL_UNIT_PATH")"
@@ -1716,7 +1738,7 @@ show "active version directory" "$w0_active"
 show "activations recorded" "$(history_entries | tr '\n' ' ' | sed 's/ *$//' | grep . || printf 'none')"
 show "recorded predecessor, computed here" "$w0_expected"
 w0_rc=0
-"$bun" "$cli" rollback >"$work/w0.log" 2>&1 || w0_rc=$?
+candidate_cli rollback >"$work/w0.log" 2>&1 || w0_rc=$?
 show "exit code" "$w0_rc"
 show "output" "$(head -c 240 "$work/w0.log" | tr '\n' ' ')"
 show "current.json after" "$(pointer_version)"

--- a/scripts/qualify-macos-host.sh
+++ b/scripts/qualify-macos-host.sh
@@ -129,7 +129,9 @@ REMOTE
 S() { if [ -n "$PW" ]; then echo "$PW" | sudo -S -p '' "$@"; else sudo -n "$@"; fi; }
 if ! command -v tailscale >/dev/null 2>&1 && [ ! -x "$HOME/go/bin/tailscale" ]; then echo "no-tailscale"; exit 0; fi
 TS="$(command -v tailscale || echo "$HOME/go/bin/tailscale")"
-state="$(S "$TS" status --json 2>/dev/null | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("BackendState","?"), "tagged" if d.get("Self",{}).get("Tags") else "user-owned", d.get("Self",{}).get("DNSName","").rstrip("."))' 2>/dev/null || echo "? ? ?")"
+state="$("$TS" status --json 2>/dev/null || S "$TS" status --json 2>/dev/null)" &&
+  state="$(printf '%s' "$state" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("BackendState","?"), "tagged" if d.get("Self",{}).get("Tags") else "user-owned", d.get("Self",{}).get("DNSName","").rstrip("."))' 2>/dev/null || echo "? ? ?")" ||
+  state="? ? ?"
 # A tailnet address on a real interface is what distinguishes TUN mode from userspace networking, and
 # it is the same signal the gateway itself enforces.
 tun="userspace"
@@ -201,7 +203,9 @@ TS="\$(command -v tailscale || echo "\$HOME/go/bin/tailscale")"
 
 # The operator grant matters: doctor runs as this user and shells out to \`tailscale\`, so without it
 # the tailscale checks fail for a permission reason that looks like a gateway fault.
-S "\$TS" set --operator="\$(whoami)" >/dev/null 2>&1 || true
+"\$TS" set --operator="\$(whoami)" >/dev/null 2>&1 ||
+  S "\$TS" set --operator="\$(whoami)" >/dev/null 2>&1 ||
+  true
 
 bun "\$CLI" install --origin "https://$DNS_NAME" --allow "\$LOGIN" >/dev/null 2>&1 ||
   { echo "   install FAILED"; exit 1; }
@@ -217,7 +221,8 @@ show "launchagent state" "\$(launchctl print "gui/\$(id -u)/omp-session-gateway"
 # trap described in this script's header.
 \$TS serve reset >/dev/null 2>&1 || true
 \$TS serve --bg --https=443 "http://127.0.0.1:\$PORT" >/dev/null 2>&1 || true
-S "\$TS" cert --cert-file /tmp/omp-qual.crt --key-file /tmp/omp-qual.key "$DNS_NAME" >/dev/null 2>&1 &&
+("\$TS" cert --cert-file /tmp/omp-qual.crt --key-file /tmp/omp-qual.key "$DNS_NAME" >/dev/null 2>&1 ||
+  S "\$TS" cert --cert-file /tmp/omp-qual.crt --key-file /tmp/omp-qual.key "$DNS_NAME" >/dev/null 2>&1) &&
   show "tls certificate" "provisioned for $DNS_NAME" ||
   show "tls certificate" "NOT provisioned (check the ACME rate limit; do not retry by probing)"
 
@@ -258,7 +263,8 @@ lane_identity() {
   host_ip="$(remote <<'REMOTE'
 S() { if [ -n "$PW" ]; then echo "$PW" | sudo -S -p '' "$@"; else sudo -n "$@"; fi; }
 TS="$(command -v tailscale || echo "$HOME/go/bin/tailscale")"
-S "$TS" status --json 2>/dev/null | python3 -c 'import json,sys;print(json.load(sys.stdin)["Self"]["TailscaleIPs"][0])' 2>/dev/null
+("$TS" status --json 2>/dev/null || S "$TS" status --json 2>/dev/null) |
+  python3 -c 'import json,sys;print(json.load(sys.stdin)["Self"]["TailscaleIPs"][0])' 2>/dev/null
 REMOTE
 )"
   measure "host tailnet address" "${host_ip:-<unknown>}"


### PR DESCRIPTION
## Problem

Signed candidate `v0.1.0-prealpha.18` passed artifact, install, rotation, upgrade, first rollback, macOS identity, Pixel leak/BFCache, and real View/Control/interrupt checks. Its full Debian lane then reproduced a concrete rollback failure: after several successful explicit version switches, systemd's default start-rate counter refused W2 and the repair restart with `start of the service was attempted too often`.

The macOS harness also assumed the Tailscale CLI required sudo even after the user was already configured as operator; the leased host had a healthy user-accessible TUN client but preflight reported unknown state.

## Change

- reset only systemd's failed/start-rate state immediately before an explicit operator-requested install or rollback start/restart
- model a rate-limited manager in the stateful service test; the restart succeeds only if `reset-failed` occurs first
- preserve nested rollback causes in the Linux qualification output
- use the unprivileged Tailscale CLI first, with sudo only as a fallback
- point final alpha notes at replacement candidate `v0.1.0-prealpha.19`

## Threat-model impact

This does not change automatic restart policy. `Restart=on-failure` and systemd's ordinary loop containment remain intact. Only an explicit management operation clears the counter immediately before the start it already requested. No capability, config, protocol, token, or persisted-state format changes.

## Verification

- local state-faithful start-limited manager regression: green only with `reset-failed`
- `bun run check`: 382 passed, 0 failed; typecheck/build/handoff/leak scans green
- `v0.1.0-prealpha.18` diagnostic Debian run identified the exact two nested systemctl failures and tore the paid droplet down successfully
- updated macOS artifact/install/identity lanes passed the signed candidate: `doctor` 17/17, Serve 200, backend tailnet/public ports refused, rotation replaced PID, diagnostic bundle contained neither token nor login

`v0.1.0-prealpha.18` remains a failed qualification candidate and will not be promoted. After merge, `.19` will be built and every advertised exact-candidate lane rerun.