### PR TITLE
docs(release): finalize alpha point publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 [license]: LICENSE
 [license-badge]: https://img.shields.io/github/license/alphastorm/omp-session-gateway?color=1C232B&labelColor=0B0E11
 [status]: docs/RELEASE_STATUS.md
-[status-badge]: https://img.shields.io/badge/status-alpha%20v0.1.0--alpha-C99B45?labelColor=0B0E11
+[status-badge]: https://img.shields.io/badge/status-alpha%20v0.1.0--alpha.1-C99B45?labelColor=0B0E11
 [omp-lock]: UPSTREAM.lock.json
 [omp-badge]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falphastorm%2Fomp-session-gateway%2Fmain%2FUPSTREAM.lock.json&query=%24.tag&label=OMP%20baseline&color=1C232B&labelColor=0B0E11
 [bun]: https://bun.sh
@@ -43,12 +43,11 @@
 
 </div>
 
-> **Project status: alpha.** [`v0.1.0-alpha`](https://github.com/alphastorm/omp-session-gateway/releases/tag/v0.1.0-alpha)
+> **Project status: alpha.** [`v0.1.0-alpha.1`](https://github.com/alphastorm/omp-session-gateway/releases/tag/v0.1.0-alpha.1)
 > is published and independently verified. It is qualified for Debian 13 (trixie) x86-64 and
-> macOS 26.6.1 arm64 as hosts, with Chrome `151.0.7922.139`
-> on Android 17 as the client. Anything outside that
-> combination is unqualified and must not be treated as a working deployment path: Windows is
-> implemented but **not advertised**, and self-hosted or proxied relay modes remain unsupported.
+> macOS 26.6.1 arm64 as hosts, with Chrome `151.0.7922.171` on Android 17 as the client. Anything
+> outside that combination is unqualified and must not be treated as a working deployment path:
+> Windows is implemented but **not advertised**, and self-hosted or proxied relay modes remain unsupported.
 > Tailscale must run its **TUN-mode** client — the gateway refuses identity headers otherwise, because
 > userspace-networking `tailscaled` makes the loopback listener reachable from the whole tailnet
 > ([#98](https://github.com/alphastorm/omp-session-gateway/issues/98)). Android recovery after an

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,4 +37,4 @@ The detailed threat model, trust boundaries, and release gates are in [`docs/SEC
 
 ## Supported versions
 
-`v0.1.0-alpha` is the current published qualified alpha; `v0.1.0-alpha.1` has passed exact-candidate qualification and is pending promotion. Neither is a stable-production support promise. Supported combinations, known limitations, and release-specific evidence are maintained in [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md) and [`docs/RELEASE_STATUS.md`](docs/RELEASE_STATUS.md).
+`v0.1.0-alpha.1` is the current published qualified alpha; `v0.1.0-alpha` is its supported rollback predecessor. Neither is a stable-production support promise. Supported combinations, known limitations, and release-specific evidence are maintained in [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md) and [`docs/RELEASE_STATUS.md`](docs/RELEASE_STATUS.md).

--- a/apps/web/e2e/network-recovery.e2e.ts
+++ b/apps/web/e2e/network-recovery.e2e.ts
@@ -49,6 +49,7 @@ test("dashboard reconnects after its live transport is interrupted", async ({ pa
 });
 
 test("failure states keep stale sessions, exact copy, timestamps, and mobile fit", async ({ context, page }) => {
+  test.setTimeout(60_000);
   const active = session();
   const fixture = await startDashboardFixture([active]);
   const assertFits = async (): Promise<void> => {

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -2,9 +2,9 @@
 
 ## Current claim
 
-**Current public release:** qualified alpha `v0.1.0-alpha`.<br>
-**Qualified successor:** `v0.1.0-alpha.1`, pending final tag/workflow promotion from signed candidate
-`v0.1.0-prealpha.19`.<br>
+**Current public release:** qualified alpha `v0.1.0-alpha.1`.<br>
+**Rollback predecessor:** qualified alpha `v0.1.0-alpha`.<br>
+**Qualification candidate:** signed `v0.1.0-prealpha.19`.<br>
 **Advertised combinations:** Debian 13 (trixie) x86-64 and macOS 26.6.1 arm64 hosts, with Chrome
 `151.0.7922.171` on Android 17 (Pixel 10 Pro). Nothing else is advertised.
 
@@ -64,7 +64,7 @@ The alpha targets one immutable upstream source revision:
 
 | Gateway line | OMP source | Nearest release baseline | OMP package baselines | Collab client | Registry protocol | Claim |
 |---|---|---|---|---|---:|---|
-| `0.1.0`, published as `v0.1.0-alpha` and qualified for `v0.1.0-alpha.1` | `can1357/oh-my-pi@858f7dd91fff9b84cf8a2c6a6bb85aa0e6d03a55` | `v17.3.8` | coding-agent `17.3.8`; wire `17.3.8` | collab-web `16.3.6` from the same source commit | 1 | Exact-commit alpha qualification only |
+| `0.1.0`, published as `v0.1.0-alpha.1` | `can1357/oh-my-pi@858f7dd91fff9b84cf8a2c6a6bb85aa0e6d03a55` | `v17.3.8` | coding-agent `17.3.8`; wire `17.3.8` | collab-web `16.3.6` from the same source commit | 1 | Exact-commit alpha qualification only |
 
 `v17.3.8` is the release tag and package baseline recorded on **2026-08-19**. It is
 not a claim that every checkout or package combination labeled `v17.3.8` is compatible.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,10 +2,10 @@
 
 ## Pre-alpha and alpha artifacts
 
-The repository can produce working Bun-runtime pre-alpha archives and advertised alpha releases
-(`v0.1.0-alpha` published; `v0.1.0-alpha.1` qualified and pending promotion in this stream). They
-must not be described as stable or production releases. Repository commits remain preferred outside
-the exact platform and Android combinations recorded in the release ledger.
+The repository can produce working Bun-runtime pre-alpha archives and advertised alpha releases.
+`v0.1.0-alpha.1` is the current published qualified alpha. It must not be described as stable or
+production-qualified, and repository commits remain preferred outside the exact platform and
+Android combinations recorded in the release ledger.
 
 ## Alpha release gates
 

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -1,12 +1,11 @@
 # Release status
 
 **Updated:** 2026-08-21<br>
-**Repository version:** `0.1.0`; current public release **`v0.1.0-alpha`**; qualified successor
-candidate **`v0.1.0-prealpha.19`** for planned **`v0.1.0-alpha.1`**<br>
+**Repository version:** `0.1.0`, released as **`v0.1.0-alpha.1`** (published and independently
+verified)<br>
 **Classification:** qualified alpha<br>
-**Alpha.1 decision:** **GO to promotion**, for the combinations named immediately below and for
-nothing else; the final tag still requires protected-main evidence updates, release-workflow
-success, and candidate/final executable-byte comparison<br>
+**Alpha.1 decision:** **GO, completed**, for the combinations named immediately below and for
+nothing else<br>
 
 **Advertised host platforms**
 
@@ -25,6 +24,22 @@ success, and candidate/final executable-byte comparison<br>
 `f6e01c4b96b5630fccbb3c79f0a0dae1677e316990d869db6e300ce96605a762`. From a clean directory,
 `SHA256SUMS` verified, all three GitHub attestations verified against the exact tag/workflow, and all
 three Cosign bundles returned `Verified OK`.
+
+**The final release is independently verified and executable-byte-equivalent to the candidate.**
+`v0.1.0-alpha.1` records source `5323303cdc3156854f7ede9267863b0148407357`; its archive, SPDX,
+and checksum-manifest digests are respectively
+`37f12c21975759bbc10fb2f7288149d3cdc5dc82caddcc0a1645d93be71b7506`,
+`5c83c333579fc948857255383e4003535c64c596e129444379c910da77a65f7b`, and
+`ce220ca82e4174f23da86e3f710b2fbc5020382adb5e966b506952a23ce28a27`. Checksums, all three
+GitHub attestations, and all three Cosign bundles verified against the final tag. Candidate and
+final archives contain the same 48 paths; 46 are byte-identical, and the only differences are
+`release-info.json` plus `SBOM.spdx.json`, where source commit/timestamp/namespace provenance names
+the final tag commit.
+
+The final `release-info.json` still carries the build script's conservative static
+`pre-alpha; cross-OS and real Android acceptance not yet completed` qualification string. It
+underclaims the independently verified release but does not alter executable bytes or the support
+matrix above. Make that field tag-aware before beta rather than rewriting this immutable release.
 
 **Candidate `.18` is retained as failed qualification evidence, not promoted.** It exposed a real
 operator-path defect: after several successful explicit version switches, systemd's start-rate


### PR DESCRIPTION
## Published release

[`v0.1.0-alpha.1`](https://github.com/alphastorm/omp-session-gateway/releases/tag/v0.1.0-alpha.1) is published from commit `5323303c` with six signed/attested assets.

## Independent verification

- `SHA256SUMS` verified
- all three GitHub attestations verified against the exact final tag/workflow
- all three Cosign bundles returned `Verified OK`
- archive: `37f12c21975759bbc10fb2f7288149d3cdc5dc82caddcc0a1645d93be71b7506`
- SPDX: `5c83c333579fc948857255383e4003535c64c596e129444379c910da77a65f7b`
- checksum manifest: `ce220ca82e4174f23da86e3f710b2fbc5020382adb5e966b506952a23ce28a27`

Candidate `.19` and final archives contain the same 48 paths. Forty-six files—the complete executable surface—are byte-identical. Only `release-info.json` and `SBOM.spdx.json` differ, solely in final source commit/time/namespace provenance.

## Documentation changes

- make README/status/compatibility/security identify alpha.1 as current and alpha as rollback predecessor
- record final digests and executable-byte comparison
- explicitly record the conservative static `release-info.json` qualification string as metadata debt to fix before beta rather than mutating this immutable release

No runtime or release artifact changes. `bun run check`: 382 passed; typecheck/build/handoff/leak scans green.