### PR TITLE
ci: add trusted gateway runner dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,36 @@
 name: CI
+run-name: >-
+  CI / ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'github-hosted' }} /
+  ${{ github.event_name == 'workflow_dispatch' && inputs.dispatch_id || github.sha }}
 
 on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: Execution pool; gateway-ci is for trusted manual runs only
+        required: true
+        default: github-hosted
+        type: choice
+        options:
+          - github-hosted
+          - gateway-ci
+      dispatch_id:
+        description: Optional controller correlation identifier
+        required: false
+        default: manual
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   implementation-checks:
-    runs-on: ubuntu-24.04
+    # Pushes and pull requests always resolve to GitHub-hosted. Only an explicit trusted
+    # workflow_dispatch can select the transient, repository-scoped runner appliance.
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && 'gateway-ci-linux-x64' || 'ubuntu-24.04' }}
     # Observed ~20s. A bound keeps a hung step from holding a required check for the 6h default.
     timeout-minutes: 15
     env:
@@ -19,9 +39,14 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - name: Set up Bun
+        if: ${{ runner.environment == 'github-hosted' }}
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
+      - name: Verify appliance Bun
+        if: ${{ runner.environment == 'self-hosted' }}
+        run: test "$(bun --version)" = 1.3.14
       - run: bun install --frozen-lockfile
         if: ${{ hashFiles('bun.lock', 'bun.lockb') != '' }}
       - run: bun run check
@@ -40,15 +65,22 @@ jobs:
           fail_ci_if_error: false
 
   browser-notifications:
-    runs-on: ubuntu-24.04
+    # Same routing invariant as implementation-checks: untrusted automatic events cannot
+    # select the self-hosted label.
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && 'gateway-ci-linux-x64' || 'ubuntu-24.04' }}
     # Observed 2-7 min. On 2026-08-19 an Ubuntu mirror stall inside `playwright install --with-deps`
     # hung this job for 38 minutes with no output before it was cancelled by hand.
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - name: Set up Bun
+        if: ${{ runner.environment == 'github-hosted' }}
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
+      - name: Verify appliance Bun
+        if: ${{ runner.environment == 'self-hosted' }}
+        run: test "$(bun --version)" = 1.3.14
       - run: bun install --frozen-lockfile
       # No --with-deps: the ubuntu-24.04 runner image already ships Chromium's shared libraries, and
       # apt was the only network dependency in this job. On 2026-08-19 an Ubuntu mirror stalled here
@@ -56,5 +88,6 @@ jobs:
       # below fired, both times immediately after `Get:5 noble-security InRelease`. If a library is
       # ever genuinely missing, `bun run test:browser` fails loudly on browser launch.
       - run: bunx playwright install chromium
+        if: ${{ runner.environment == 'github-hosted' }}
         timeout-minutes: 10
       - run: bun run test:browser


### PR DESCRIPTION
## Change
- keep push and pull-request jobs on `ubuntu-24.04`
- add a manual `gateway-ci` choice routed only to `gateway-ci-linux-x64`
- use the runner image's pinned Bun and Chromium for self-hosted jobs
- retain GitHub-hosted execution as the manual default

## Security boundary
The repository is public. Self-hosted routing is reachable only through an explicit trusted `workflow_dispatch`; automatic and fork pull-request events cannot select the label. The two runners are ephemeral, repository-scoped Linux containers with no host mounts, Docker socket, GPU, ingress, persistent workspace, or private/tailnet egress.

## Verification
- host appliance build completed from pinned images/toolchain
- appliance smoke passed tracked-file, container-isolation, public-egress, private-egress-denial, `local-5090` unchanged, and teardown checks
- an end-to-end manual dispatch will run after this trigger exists on the default branch