### PR TITLE
test: close browser fixture connections deterministically

### DIFF
--- a/apps/web/e2e/fixture-server.ts
+++ b/apps/web/e2e/fixture-server.ts
@@ -258,6 +258,10 @@ export async function startDashboardFixture(
           if (error === undefined) resolveClose();
           else rejectClose(error);
         });
+        // A browser may retain an idle keep-alive socket after the EventSource ends. `close()`
+        // stops new requests but waits for that socket indefinitely, so force only this fixture's
+        // remaining HTTP connections after closing admission.
+        server.closeAllConnections();
       });
     },
     upgradeServiceWorker(): void {


### PR DESCRIPTION
## Problem
The full browser suite deterministically exhausted the 60-second test timeout on the containerized Linux runner after all assertions had reached the final `Gateway unavailable` state. The fixture's `server.close()` was waiting on an idle Chromium keep-alive connection.

## Fix
Stop new requests with `server.close()`, then close only that fixture server's remaining HTTP connections with `server.closeAllConnections()`.

## Evidence
- exact self-hosted candidate reproduced the timeout in the full 22-test suite
- the isolated failing test passed, identifying teardown interaction rather than product behavior
- full 22-test suite passed in 1.1 minutes after the cleanup change
- workspace typecheck passed