### PR TITLE
fix(release): refresh qualification candidate notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,21 +256,24 @@ jobs:
           EOF
           else
             cat > "$notes" <<EOF
-          ## Pre-alpha hardening candidate; qualification pending
+          ## Pre-release qualification candidate
 
-          This is the signed candidate for \`v0.1.0-alpha.1\`. It is not an advertised alpha or a production-qualified release.
+          This is a signed engineering candidate for the next advertised release. It is not an advertised alpha or beta, and it is not stable or production-qualified. Promotion requires the exact host/client evidence recorded at this source commit.
 
           ### Changes under qualification
 
-          - Atomic, monotonic registry/SSE admission with complete revocation despite observer faults.
-          - Compare-and-remove Web Push cleanup that preserves concurrent subscription renewal.
-          - Capability-safe collaboration-client restoration after Android back/forward-cache traversal.
-          - Fail-closed cross-install service ownership for install, stop, uninstall, and token rotation.
-          - Authenticated-identity launch rate windows and focused request-body/identity boundary tests.
+          - Exact OMP v17.4.1 source, patch, pi-wire, provenance, and license cutover.
+          - Closed beta tag/channel metadata that fails before artifact creation on unknown or stable channels.
+          - Windows-only bounded readiness correction while Windows remains unadvertised.
+          - Deterministic public media and documentation; no capability transport or persistence boundary changes.
 
           ### Security
 
-          Collaboration capabilities remain absent from list/SSE responses, push state and payloads, URLs, browser storage, service-worker caches, logs, diagnostics, screenshots, and release fixtures. Service ownership is checked from both the manager's rendered program and the shared definition file before destructive effects.
+          Collaboration capabilities remain absent from list/SSE responses, push state and payloads, URLs, browser storage, service-worker caches, logs, diagnostics, screenshots, and release fixtures. Release qualification is selected only from a validated tag shape.
+
+          ### Required OMP prerequisite
+
+          Run OMP $upstream_tag at \`$upstream_commit\` with the exact patch included in this archive. Stock OMP is not sufficient. Use [the versioned \`omp-gateway-patched\` route](https://github.com/$GITHUB_REPOSITORY/blob/$GITHUB_SHA/patches/oh-my-pi/README.md#supported-beta-prerequisite-route-linux-and-macos); upstreaming and paired packaging are not promotion gates.
 
           ### Install or upgrade
 
@@ -281,12 +284,12 @@ jobs:
           - Source commit: \`$GITHUB_SHA\`
           - Exact release baseline: OMP $upstream_tag at \`$upstream_commit\` with the included patch.
           - Runtime: Bun 1.3.14; registry protocol 1; Push API 2.
-          - Preview notification detail falls back to Session detail until the publisher protocol gains a bounded preview source.
-          - Advertised Debian, macOS, and physical Pixel lanes must pass against these exact signed bytes before alpha promotion.
+          - Advertised Debian, macOS, and physical Pixel lanes must pass against these exact signed bytes before beta promotion.
+          - Android network-change/reconnect remains a disclosed limitation; Windows and self-hosted/proxied relay modes remain unadvertised.
 
           ### Rollback
 
-          Run \`bun apps/gateway/src/cli.js rollback\` when the predecessor is present in managed installation history. Otherwise reinstall the signed \`v0.1.0-alpha\` archive with the deployment's existing origin and allowlist.
+          Run \`bun apps/gateway/src/cli.js rollback\` when the predecessor is present in managed installation history. Otherwise reinstall the signed \`v0.1.0-alpha.1\` archive with the deployment's existing origin and allowlist.
 
           Verification instructions: [docs/RELEASE.md](https://github.com/$GITHUB_REPOSITORY/blob/$GITHUB_SHA/docs/RELEASE.md).
           EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
   the patch rebase.
 - Bind `release-info.json` qualification to the workflow-validated release channel, so alpha tags
   no longer ship the pre-alpha claim and unknown future channels fail before producing artifacts.
+- Make pre-release candidate notes channel-neutral and bind them to the current OMP patch,
+  advertised beta lanes, limitations, and `v0.1.0-alpha.1` rollback predecessor instead of the
+  already-published alpha-point plan.
 - Give Windows managed-service startup a measured 60-second hard readiness deadline while
   retaining 15 seconds elsewhere, so cold per-path ACL verification no longer rolls back a
   progressing service before it can bind. A persistent Server 2025 source lane now passes install,


### PR DESCRIPTION
## Problem

The generic `v0.1.0-prealpha.<n>` release-notes branch still claimed every candidate was for the already-published `v0.1.0-alpha.1`, listed the old hardening delta, said “before alpha promotion,” and rolled back to `v0.1.0-alpha`.

That would make the next signed beta qualification candidate materially false even though the beta channel itself is closed and tested.

## Change

- make pre-release candidate notes channel-neutral and explicitly non-alpha/non-beta/stable;
- name the actual v17.4.1 patch/provenance, beta-channel, Windows-readiness, and documentation changes under qualification;
- require the exact `omp-gateway-patched` prerequisite route while keeping upstreaming/paired packaging non-blocking;
- require Debian/macOS/Pixel evidence before beta promotion and preserve Android/Windows/relay caveats;
- use `v0.1.0-alpha.1` as the fallback rollback predecessor.

## Verification

- `bun test scripts/build-release.test.ts`: 6 passed, 0 failed, 131 assertions.
- No tag or release created.
