### PR TITLE
fix(omp): stage exact native addon for beta build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
 - Make pre-release candidate notes channel-neutral and bind them to the current OMP patch,
   advertised beta lanes, limitations, and `v0.1.0-alpha.1` rollback predecessor instead of the
   already-published alpha-point plan.
+- Make the documented OMP binary route work on a fresh host without Rust/Cargo by staging the exact
+  official `@oh-my-pi/pi-natives@17.4.1` platform addon before the upstream binary build; retain
+  `bun setup` as the source-development alternative.
 - Give Windows managed-service startup a measured 60-second hard readiness deadline while
   retaining 15 seconds elsewhere, so cold per-path ACL verification no longer rolls back a
   progressing service before it can bind. A persistent Server 2025 source lane now passes install,

--- a/patches/oh-my-pi/README.md
+++ b/patches/oh-my-pi/README.md
@@ -109,7 +109,31 @@ test "$(git -C "$OMP_ROOT" rev-parse 'HEAD^{tree}')" = a5cfc80fcc0df1ca6e430c125
 (
   cd "$OMP_ROOT"
   test "$(bun --version)" = 1.3.14
-  bun setup
+  bun install --frozen-lockfile
+
+  # Fresh source workspaces shadow the npm package, so stage the exact official native addon.
+  native_fixture="$(mktemp -d)"
+  trap 'rm -rf "$native_fixture"' EXIT
+  printf '%s\n' '{"private":true,"dependencies":{"@oh-my-pi/pi-natives":"17.4.1"}}' \
+    > "$native_fixture/package.json"
+  (cd "$native_fixture" && bun install)
+  case "$(uname -s)-$(uname -m)" in
+    Darwin-arm64)
+      native_package=pi-natives-darwin-arm64
+      native_file=pi_natives.darwin-arm64.node
+      ;;
+    Linux-x86_64)
+      native_package=pi-natives-linux-x64
+      native_file=pi_natives.linux-x64-baseline.node
+      ;;
+    *)
+      echo "unsupported beta build host: $(uname -s)-$(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+  cp "$native_fixture/node_modules/@oh-my-pi/$native_package/$native_file" \
+    "packages/natives/native/$native_file"
+
   bun run ci:check:full
   bun --cwd=packages/coding-agent run build
   test "$(packages/coding-agent/dist/omp --version)" = omp/17.4.1
@@ -130,6 +154,12 @@ fi
 "$HOME/.local/bin/omp-gateway-patched" config get collab.autoStart --json
 "$HOME/.local/bin/omp-gateway-patched" config get collab.registryEndpoint --json
 ```
+
+The native step consumes OMP's exact official npm package and matching platform addon rather than
+requiring a local Rust toolchain. A fresh workspace shadows that package with `packages/natives`,
+which is why `bun install` alone does not place the `.node` file where the binary builder can embed
+it. `bun setup` remains upstream's source-development route when Rust/Cargo is installed; the beta
+route above is the bounded binary path tested on the advertised macOS architecture.
 
 Launch sessions that should publish with `omp-gateway-patched`, not stock `omp`. Keep the source
 checkout: its exact commit/tree plus a SHA-256 of the installed binary are the local provenance


### PR DESCRIPTION
## Problem

The new exact v17.4.1 patch route used upstream `bun setup`. On the clean macOS qualification host, that failed at `build:native` because Cargo was absent. `bun install` alone also cannot supply the addon: the source workspace shadows `@oh-my-pi/pi-natives`, so no platform `.node` file is available for `build-binary.ts` to embed.

## Fix

- install exact `@oh-my-pi/pi-natives@17.4.1` in a disposable fixture;
- select only the advertised `Darwin-arm64` or `Linux-x86_64` official platform package;
- copy its exact addon into the source workspace for the binary build;
- fail closed on every other host architecture;
- retain `bun setup` as the upstream source-development route when Rust/Cargo is present.

## Evidence

On the clean dedicated macOS 26.6.1 arm64 candidate host, the original route failed with `cargo metadata failed to run`. The corrected sequence then:

- installed the exact official native package;
- passed `bun run ci:check:full` across all OMP workspaces;
- built the patched binary;
- reported `omp/17.4.1`;
- reproduced patch tree `a5cfc80f…`;
- activated the separate `omp-gateway-patched` binary and persisted `collab.autoStart=control` / `registryEndpoint=auto`.

No gateway runtime code changes.
