### PR TITLE
perf(ci): select stable two-worker browser topology

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ on:
         required: false
         type: string
       playwright_workers:
-        description: Playwright workers for the browser suite; benchmark sweep values only
+        description: Playwright workers for the browser suite; 2 is the qualified default
         required: false
-        default: "1"
+        default: "2"
         type: choice
         options:
           - "1"
@@ -105,9 +105,9 @@ jobs:
     # hung this job for 38 minutes with no output before it was cancelled by hand.
     timeout-minutes: 20
     env:
-      # Benchmark knob. Automatic events pin the single-worker baseline so push and pull_request
-      # timings stay comparable across runs; only a manual dispatch sweeps 2 or 4.
-      PLAYWRIGHT_WORKERS: ${{ github.event_name == 'workflow_dispatch' && inputs.playwright_workers || '1' }}
+      # Two workers is the qualified default for automatic and manual runs. A manual dispatch can
+      # still select 1 or 4 for a bounded benchmark.
+      PLAYWRIGHT_WORKERS: ${{ github.event_name == 'workflow_dispatch' && inputs.playwright_workers || '2' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Bun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,49 @@ on:
         description: Controller-supplied one-time label; leave blank in the GitHub UI
         required: false
         type: string
+      playwright_workers:
+        description: Playwright workers for the browser suite; benchmark sweep values only
+        required: false
+        default: "1"
+        type: choice
+        options:
+          - "1"
+          - "2"
+          - "4"
 
 permissions:
   contents: read
 
 jobs:
   implementation-checks:
-    # Pushes and pull requests always resolve to GitHub-hosted. A trusted controller must
-    # supply the unpredictable one-time label exposed by its two ephemeral runners.
+    # Pushes and pull requests always resolve to GitHub-hosted. A trusted controller must supply
+    # the unpredictable one-time label shared by the ephemeral runners it registers for this
+    # invocation. The jobs here are independent, so a parallel self-hosted run needs one free
+    # runner per job.
     runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.routing_label || 'ubuntu-24.04' }}
     # Observed ~20s. A bound keeps a hung step from holding a required check for the 6h default.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Bun
+        if: ${{ runner.environment == 'github-hosted' }}
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - name: Verify appliance Bun
+        if: ${{ runner.environment == 'self-hosted' }}
+        run: test "$(bun --version)" = 1.3.14
+      - run: bun install --frozen-lockfile
+        if: ${{ hashFiles('bun.lock', 'bun.lockb') != '' }}
+      - run: bun run check
+
+  coverage:
+    # Its own job rather than a second run inside implementation-checks: a coverage or upload
+    # problem can never turn the required gate red, and the seconds it costs overlap that job
+    # instead of extending it.
+    # Same one-time-label invariant as implementation-checks.
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.routing_label || 'ubuntu-24.04' }}
+    # Observed ~20s of tests plus the upload round trip; same bound as implementation-checks.
     timeout-minutes: 15
     env:
       # Referenced by the upload step's `if`, which cannot read `secrets` directly. Absent on
@@ -53,10 +86,6 @@ jobs:
         run: test "$(bun --version)" = 1.3.14
       - run: bun install --frozen-lockfile
         if: ${{ hashFiles('bun.lock', 'bun.lockb') != '' }}
-      - run: bun run check
-      # A second run rather than folding `--coverage` into `bun run check`, so a coverage or upload
-      # problem can never turn the required gate red. The suite is a few seconds, so the duplication
-      # costs less than the coupling would.
       - run: bun run test:coverage
       - name: Upload coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
@@ -75,6 +104,10 @@ jobs:
     # Observed 2-7 min. On 2026-08-19 an Ubuntu mirror stall inside `playwright install --with-deps`
     # hung this job for 38 minutes with no output before it was cancelled by hand.
     timeout-minutes: 20
+    env:
+      # Benchmark knob. Automatic events pin the single-worker baseline so push and pull_request
+      # timings stay comparable across runs; only a manual dispatch sweeps 2 or 4.
+      PLAYWRIGHT_WORKERS: ${{ github.event_name == 'workflow_dispatch' && inputs.playwright_workers || '1' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Bun

--- a/apps/web/e2e/network-recovery.e2e.ts
+++ b/apps/web/e2e/network-recovery.e2e.ts
@@ -105,10 +105,9 @@ test("failure states keep stale sessions, exact copy, timestamps, and mobile fit
     await expect(page.locator("#status-banner .status-detail")).toContainText(
       "Tailnet looks fine, but the desktop isn't answering — asleep, or the gateway stopped. Last seen",
     );
-    const retryHeight = await page.locator("#status-banner .status-action").evaluate(
-      element => element.getBoundingClientRect().height,
-    );
-    expect(retryHeight).toBeGreaterThanOrEqual(44);
+    await expect.poll(
+      () => page.locator("#status-banner .status-action").evaluate(element => element.getBoundingClientRect().height),
+    ).toBeGreaterThanOrEqual(44);
     await assertFits();
 
     const eventRequestsBeforeDesktopRecovery = eventRequestCount();

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -6,11 +6,32 @@ import { fileURLToPath } from "node:url";
 const androidUserAgent =
   "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Mobile Safari/537.36";
 
+// The browser lane is benchmarked at 1, 2 and 4 workers through a `workflow_dispatch` input, so the
+// width is supplied out of band rather than derived from the machine. An unset variable is the serial
+// benchmark baseline; a workflow `env:` mapping over an absent input arrives as the empty string, and
+// means the same thing. Anything else is a wiring mistake and fails loudly here, because silently
+// falling back would attribute a run to a width it never used.
+function playwrightWorkers(): number {
+  const requested = process.env.PLAYWRIGHT_WORKERS;
+  switch (requested) {
+    case undefined:
+    case "":
+    case "1":
+      return 1;
+    case "2":
+      return 2;
+    case "4":
+      return 4;
+    default:
+      throw new Error(`PLAYWRIGHT_WORKERS must be "1", "2" or "4" when set, not ${JSON.stringify(requested)}`);
+  }
+}
+
 export default defineConfig({
   testDir: fileURLToPath(new URL("./e2e", import.meta.url)),
   testMatch: "*.e2e.ts",
   fullyParallel: false,
-  workers: 1,
+  workers: playwrightWorkers(),
   reporter: [["line"]],
   use: {
     browserName: "chromium",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -6,20 +6,19 @@ import { fileURLToPath } from "node:url";
 const androidUserAgent =
   "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Mobile Safari/537.36";
 
-// The browser lane is benchmarked at 1, 2 and 4 workers through a `workflow_dispatch` input, so the
-// width is supplied out of band rather than derived from the machine. An unset variable is the serial
-// benchmark baseline; a workflow `env:` mapping over an absent input arrives as the empty string, and
-// means the same thing. Anything else is a wiring mistake and fails loudly here, because silently
-// falling back would attribute a run to a width it never used.
+// The browser lane was benchmarked at 1, 2 and 4 workers through a `workflow_dispatch` input.
+// Two workers is the fastest stable width, so an unset variable or an empty workflow `env:` value
+// selects 2. Anything else is a wiring mistake and fails loudly here, because silently falling back
+// would attribute a run to a width it never used.
 function playwrightWorkers(): number {
   const requested = process.env.PLAYWRIGHT_WORKERS;
   switch (requested) {
     case undefined:
     case "":
-    case "1":
-      return 1;
     case "2":
       return 2;
+    case "1":
+      return 1;
     case "4":
       return 4;
     default:


### PR DESCRIPTION
## Summary
- split coverage into its own parallel, non-required job while keeping `implementation-checks` single-pass
- add a strictly validated 1/2/4 Playwright worker input and select 2 as the default
- make the transient retry-card layout assertion auto-retry instead of sampling during a reconnect re-render
- preserve the trust boundary: push and pull request jobs remain GitHub-hosted; only trusted `workflow_dispatch` runs with the one-time routing label can select gateway runners

## Target benchmark
Frozen commit: `5bbb469f3ee687f076bc3f3a642e1e804fa783c3`

| Workers | Successful runs | Browser step median / p95 | Dispatch-to-completion median / p95 | Result |
| --- | ---: | ---: | ---: | --- |
| 1 | 20/20 | 68s / 70s | 76s / 79s | stable baseline |
| 2 | 20/20 | 36s / 38s | 43s / 46s | selected |
| 4 | 19 successes, then failure | 27s / 27s over successes | 35s / 38s over successes | rejected: run 20 missed the existing 900ms gateway recovery bound |

## Verification
- `bun run check` — 382 tests passed; typecheck, build, capability scan, identifier scan passed
- default `bun run test:browser` — 22 tests passed using 2 workers
- focused retry-card regression — 40/40 serial and 40/40 four-worker repetitions passed locally
- invalid `PLAYWRIGHT_WORKERS=3` fails during Playwright config loading
- required branch contexts remain `implementation-checks` and `windows-service-lifecycle`; coverage is not required
