### PR TITLE
test(web): synchronize recovery stream failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable project changes will be documented here.
 
 The format is based on Keep a Changelog, and the project intends to use Semantic Versioning once implementation releases begin.
 
+## [Unreleased]
+
+### Fixed
+
+- Make browser recovery failure tests wait for and assert an active replacement SSE stream before
+  disconnecting it, eliminating a race where the snapshot hid the banner just before EventSource
+  installation and the fixture's disconnect became a silent no-op.
+
 ## [v0.1.0-beta.1] — 2026-08-21
 
 ### Added

--- a/apps/web/e2e/fixture-server.ts
+++ b/apps/web/e2e/fixture-server.ts
@@ -32,7 +32,7 @@ export interface DashboardFixture {
   readonly origin: string;
   readonly requests: readonly string[];
   readonly launchRequests: readonly FixtureLaunchRequest[];
-  disconnectEvents(): void;
+  disconnectEvents(): number;
   remove(instanceId: string, generation: number): void;
   setSnapshot(sessions: readonly SessionMetadata[], revision?: number): void;
   stop(): Promise<void>;
@@ -233,9 +233,11 @@ export async function startDashboardFixture(
     origin: `http://127.0.0.1:${address.port}`,
     requests,
     launchRequests,
-    disconnectEvents(): void {
+    disconnectEvents(): number {
+      const disconnected = streams.size;
       for (const stream of streams) stream.end();
       streams.clear();
+      return disconnected;
     },
     remove(instanceId, generation): void {
       const current = sessions.get(instanceId);

--- a/apps/web/e2e/network-recovery.e2e.ts
+++ b/apps/web/e2e/network-recovery.e2e.ts
@@ -29,7 +29,7 @@ test("dashboard reconnects after its live transport is interrupted", async ({ pa
       () => fixture.requests.filter(request => request === "GET /api/v1/events").length,
     ).toBeGreaterThanOrEqual(1);
 
-    fixture.disconnectEvents();
+    expect(fixture.disconnectEvents()).toBeGreaterThan(0);
     await expect(page.locator("#status-banner")).toHaveAttribute("data-kind", "gateway", { timeout: 900 });
     await expect(page.locator("#status-banner .status-title")).toHaveText("Gateway unavailable");
     await expect(page.locator(".working-row")).toHaveCount(1);
@@ -52,6 +52,8 @@ test("failure states keep stale sessions, exact copy, timestamps, and mobile fit
   test.setTimeout(60_000);
   const active = session();
   const fixture = await startDashboardFixture([active]);
+  const eventRequestCount = (): number =>
+    fixture.requests.filter(request => request === "GET /api/v1/events").length;
   const assertFits = async (): Promise<void> => {
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
     await expect(page.locator(".working-row")).toHaveCount(1);
@@ -60,6 +62,7 @@ test("failure states keep stale sessions, exact copy, timestamps, and mobile fit
   try {
     await page.goto(fixture.origin);
     await expect(page.locator(".working-row")).toHaveCount(1);
+    await expect.poll(eventRequestCount).toBeGreaterThanOrEqual(1);
 
     await context.setOffline(true);
     await expect(page.locator("#status-banner")).toHaveAttribute("data-kind", "offline");
@@ -69,11 +72,13 @@ test("failure states keep stale sessions, exact copy, timestamps, and mobile fit
     );
     await assertFits();
 
+    const eventRequestsBeforeOnline = eventRequestCount();
     await context.setOffline(false);
     await expect(page.locator("#status-banner")).toBeHidden({ timeout: 6_000 });
+    await expect.poll(eventRequestCount).toBeGreaterThan(eventRequestsBeforeOnline);
 
     await page.route("**/api/v1/sessions", route => route.abort("connectionrefused"));
-    fixture.disconnectEvents();
+    expect(fixture.disconnectEvents()).toBeGreaterThan(0);
     await expect(page.locator("#status-banner")).toHaveAttribute("data-kind", "tailnet", {
       timeout: 6_000,
     });
@@ -84,13 +89,15 @@ test("failure states keep stale sessions, exact copy, timestamps, and mobile fit
     await expect(page.locator("#status-banner .status-freshness")).toContainText("Last seen");
     await assertFits();
 
+    const eventRequestsBeforeTailnetRecovery = eventRequestCount();
     await page.unroute("**/api/v1/sessions");
     await expect(page.locator("#status-banner")).toBeHidden({ timeout: 6_000 });
+    await expect.poll(eventRequestCount).toBeGreaterThan(eventRequestsBeforeTailnetRecovery);
 
     await page.route("**/api/v1/sessions", route =>
       route.fulfill({ status: 503, contentType: "application/json", body: "{}" }),
     );
-    fixture.disconnectEvents();
+    expect(fixture.disconnectEvents()).toBeGreaterThan(0);
     await expect(page.locator("#status-banner")).toHaveAttribute("data-kind", "desktop", {
       timeout: 6_000,
     });
@@ -104,13 +111,15 @@ test("failure states keep stale sessions, exact copy, timestamps, and mobile fit
     expect(retryHeight).toBeGreaterThanOrEqual(44);
     await assertFits();
 
+    const eventRequestsBeforeDesktopRecovery = eventRequestCount();
     await page.unroute("**/api/v1/sessions");
     await expect(page.locator("#status-banner")).toBeHidden({ timeout: 6_000 });
+    await expect.poll(eventRequestCount).toBeGreaterThan(eventRequestsBeforeDesktopRecovery);
 
     // Keep replacement EventSource connections down as well as the stream that is open now. Without
     // this, the gateway banner can recover between the data-kind and copy assertions.
     await page.route("**/api/v1/events", route => route.abort("connectionrefused"));
-    fixture.disconnectEvents();
+    expect(fixture.disconnectEvents()).toBeGreaterThan(0);
     await expect(page.locator("#status-banner")).toHaveAttribute("data-kind", "gateway", {
       timeout: 900,
     });


### PR DESCRIPTION
## Problem

Post-merge main CI run [32539434561](https://github.com/alphastorm/omp-session-gateway/actions/runs/32539434561) failed the narrow-viewport recovery scenario: the snapshot hid the status banner just before `refreshAndConnect()` installed its replacement `EventSource`; the test then called `disconnectEvents()` while the fixture had no stream, making the intended failure injection a silent no-op. PR CI for the same runtime bytes had passed, confirming an interleaving-sensitive harness bug rather than a product regression.

## Fix

- expose the fixture's disconnected stream count;
- fail the test if a requested disconnect has no active stream;
- after each recovery snapshot, wait until the replacement SSE request reaches the fixture before injecting the next failure.

No production code or release artifact changes.

## Verification

- exact previously failed narrow scenario: 10/10 repeated passes;
- complete browser suite: 22/22 passes;
- `bun run check`: 389/389 tests, 2,009 assertions, typecheck/build/leak scans green.
