### PR TITLE
docs(release): record active signed workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
   before stable publication; recheck checkout HEAD and tag target before provenance, draft creation,
   and public promotion. Move future signatures to signed-release.yml so the superseded historical
   tag workflow can be disabled.
-- Disable historical GitHub workflow ID 316404456 for release.yml before merging the hardened
-  signed-release.yml replacement, preventing old commits from selecting pre-remediation tag logic.
+- Retire historical GitHub workflow ID 316404456 with state deleted and activate hardened
+  signed-release.yml as workflow ID 339848215, preventing old commits from selecting
+  pre-remediation tag logic.
 - Rehearse the exact six-asset GitHub draft/publish commands with gh 2.97.0 in a private repository:
   prerelease remained not-Latest, stable became non-prerelease Latest only when published, the
   latest-release API resolved to stable, and all synthetic releases/tags were removed.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -501,8 +501,8 @@ the real tag; syntax-only or mock evidence is insufficient for that external sta
 The hardened workflow moves to signed-release.yml. The superseded release.yml workflow must be
 disabled in GitHub before another tag is created; otherwise an old commit can select its historical
 workflow definition and bypass controls that did not exist there.
-**Control-plane update (2026-08-22):** GitHub workflow ID 316404456 for release.yml now reports
-disabled_manually. No new tag may be created until signed-release.yml is active on main.
+**Control-plane update (2026-08-22):** historical workflow ID 316404456 for release.yml reports
+state deleted; hardened signed-release.yml is active on main as workflow ID 339848215.
 Draft and published release state must be read back through the GitHub API, including six uploaded
 asset digests compared with the exact local signed files and Latest status. Observation receives
 bounded 0/2/4/8-second retries. A persistently failed draft or post-publication observation attempts

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -61,9 +61,9 @@ collab-web, and wire bytes remain identical. A bounded real relay smoke still ru
 candidate. Windows and every other excluded mode are not stable blockers because they are not
 advertised; they must remain explicit exclusions.
 
-The superseded release.yml workflow (GitHub workflow ID 316404456) is disabled_manually. Before any
-new tag, merge signed-release.yml and verify that replacement is active. Historical tags retain
-release.yml in their certificate identity; new tags use signed-release.yml. A run that fails after
+The superseded release.yml workflow (GitHub workflow ID 316404456) reports state deleted. Hardened
+signed-release.yml is active as workflow ID 339848215. Historical tags retain release.yml in their
+certificate identity; new tags use signed-release.yml. A run that fails after
 attestation or Cosign signing may leave public GitHub
 attestations or Rekor entries even when no release is published; those records are failed-attempt
 provenance, not an advertised release.

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -42,9 +42,9 @@ states for all six synthetic assets, then removed the release and tag; the same 
 contains the digestBinding row.
 
 
-**Workflow cutover:** GitHub workflow ID 316404456 at .github/workflows/release.yml is
-disabled_manually. The signed-release.yml replacement must be active on main before the candidate
-tag is created.
+**Workflow cutover:** historical workflow ID 316404456 at .github/workflows/release.yml reports
+state deleted; .github/workflows/signed-release.yml is active on main as workflow ID 339848215.
+The candidate tag may use only the active replacement.
 
 ### Beta advertised combinations
 


### PR DESCRIPTION
Record the completed GitHub Actions control-plane cutover after PR #128 merged.

- historical workflow ID 316404456 / release.yml now reports state deleted;
- signed-release.yml is active on main as workflow ID 339848215;
- candidate tags are permitted to use only the active replacement.

Verification: GitHub Actions workflow API queried after merge; handoff validation passes.