### PR TITLE
test(web): accept 3 playwright workers for qualification

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -8,8 +8,9 @@ const androidUserAgent =
 
 // The browser lane was benchmarked at 1, 2 and 4 workers through a `workflow_dispatch` input.
 // Two workers is the fastest stable width, so an unset variable or an empty workflow `env:` value
-// selects 2. Anything else is a wiring mistake and fails loudly here, because silently falling back
-// would attribute a run to a width it never used.
+// selects 2. Three is accepted for a bounded qualification campaign and is not yet qualified.
+// Anything else is a wiring mistake and fails loudly here, because silently falling back would
+// attribute a run to a width it never used.
 function playwrightWorkers(): number {
   const requested = process.env.PLAYWRIGHT_WORKERS;
   switch (requested) {
@@ -19,10 +20,14 @@ function playwrightWorkers(): number {
       return 2;
     case "1":
       return 1;
+    case "3":
+      return 3;
     case "4":
       return 4;
     default:
-      throw new Error(`PLAYWRIGHT_WORKERS must be "1", "2" or "4" when set, not ${JSON.stringify(requested)}`);
+      throw new Error(
+        `PLAYWRIGHT_WORKERS must be "1", "2", "3" or "4" when set, not ${JSON.stringify(requested)}`,
+      );
   }
 }
 


### PR DESCRIPTION
The `playwright_workers` workflow input already offers `3`, but `apps/web/playwright.config.ts` rejected it, so every 3-worker dispatch failed in `browser-notifications` before running a test. This lands the missing half; without it the option is dead on arrival.

Default stays `2`. Nothing changes unless a dispatch explicitly asks for 3.

Measured on the self-hosted appliance at this width, 20 runs per host across `nyc-pc` and `sf-pc`, 40/40 success and zero recovery-bound failures:

| metric | 2 workers | 3 workers |
| --- | --: | --: |
| `browserNotifications` | 42-43s | 35s median (34-37s) |
| workflow completion, nyc | 60262ms | 52709ms (p95 54826) |
| workflow completion, sf | 57855ms | 50032ms (p95 54194) |

About 17% off the browser job and 12-13% off end to end. Treating 3 as enabled, default off, and watched rather than pre-certified: a bad width fails loudly in `browser-notifications` and a re-dispatch at 2 is the whole rollback.