### PR TITLE
fix(web): preserve native recovery after Android outages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
 
 ### Fixed
 
+- Keep Android Chrome's native EventSource reconnection alive after transport errors while retaining
+  the bounded snapshot fallback, so a lost JavaScript timer cannot strand a long-lived PWA after
+  Airplane mode or Doze. Physical qualification now reads rendered state without competing fetches
+  and fails on any page reload.
 - Make browser recovery failure tests wait for and assert an active replacement SSE stream before
   disconnecting it, eliminating a race where the snapshot hid the banner just before EventSource
   installation and the fixture's disconnect became a silent no-op.

--- a/apps/web/src/app.ts
+++ b/apps/web/src/app.ts
@@ -597,15 +597,19 @@ function scheduleReconnect(): void {
     void refreshAndConnect(false);
   }, delay);
 }
-
-function failEventStream(source: EventSource, epoch: number): void {
-  if (events !== source || epoch !== directoryEpoch) return;
-  source.close();
-  events = undefined;
+function markEventStreamInterrupted(source: EventSource, epoch: number): boolean {
+  if (events !== source || epoch !== directoryEpoch) return false;
   clearEventLiveness();
   eventStreamStale = true;
   showTransportFailure(navigator.onLine === false ? "offline" : "gateway");
   scheduleReconnect();
+  return true;
+}
+
+function failEventStream(source: EventSource, epoch: number): void {
+  if (!markEventStreamInterrupted(source, epoch)) return;
+  source.close();
+  events = undefined;
 }
 
 function armEventLiveness(source: EventSource, epoch: number): void {
@@ -1452,6 +1456,8 @@ function connectEvents(epoch: number): void {
     if (events !== source || epoch !== directoryEpoch) return;
     if (opened) directoryRevision = -1;
     opened = true;
+    clearReconnectTimeout();
+    reconnectAttempt = 0;
     eventStreamStale = false;
     armEventLiveness(source, epoch);
   };
@@ -1483,7 +1489,10 @@ function connectEvents(epoch: number): void {
     if (!attentionRouteStatusLocked) setStatus("ready", "");
   });
   source.onerror = () => {
-    failEventStream(source, epoch);
+    // Native EventSource reconnects on network restoration even when Android Chrome loses a
+    // scheduled JavaScript timer. Keep that browser-owned recovery path alive; the snapshot retry
+    // remains a bounded fallback and will close this source if it fires first.
+    markEventStreamInterrupted(source, epoch);
   };
 }
 

--- a/apps/web/test/app.test.ts
+++ b/apps/web/test/app.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import type { SessionMetadata } from "@omp-session-gateway/protocol";
+import fc, { type AsyncCommand } from "fast-check";
 
 const GLOBAL_NAMES = [
   "window",
@@ -710,6 +711,30 @@ describe("dashboard attention and notifications", () => {
     await settleUntil(() => FakeEventSource.instances.length === 2);
     expect(harness.elements.statusBanner.hidden).toBe(true);
   });
+  test("recovers through the native event stream when browser timers are lost", async () => {
+    const base = session("native-reconnect-0001");
+    const recovered = session("native-reconnect-0001", { title: "Recovered natively" });
+    const harness = await bootApp({
+      permission: "denied",
+      suffix: "native-eventsource-reconnect",
+      initialSessions: [base],
+    });
+    const source = FakeEventSource.instances[0];
+    if (source === undefined) throw new Error("missing initial event stream");
+
+    harness.disconnectEvents();
+    expect(source.closed).toBeFalse();
+
+    source.onopen?.();
+    source.emit("snapshot", { type: "snapshot", revision: 2, sessions: [recovered] });
+    await settleUntil(() => harness.elements.statusBanner.hidden);
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(harness.elements.sessionList.querySelector(".row-title")?.textContent).toBe(
+      "Recovered natively",
+    );
+  });
+
 
 
   test("keeps the last directory while distinguishing phone and tailnet outages", async () => {
@@ -1034,5 +1059,318 @@ describe("dashboard attention and notifications", () => {
     harness.window.dispatchEvent(new Event("online"));
     await settleUntil(() => harness.elements.statusBanner.dataset.kind === "tailnet");
     expect(harness.elements.statusBanner.querySelector(".status-guidance")).toBeNull();
+  });
+});
+
+interface RecoveryModel {
+  revision: number;
+  title: string;
+  interrupted: boolean;
+  online: boolean;
+}
+
+interface RecoveryReal {
+  readonly harness: BrowserHarness;
+  readonly instanceId: string;
+  readonly capabilityCanary: string;
+}
+
+type RecoveryCommand = AsyncCommand<RecoveryModel, RecoveryReal>;
+
+function activeModelStreams(): FakeEventSource[] {
+  return FakeEventSource.instances.filter(source => !source.closed);
+}
+
+async function assertRecoveryInvariants(model: RecoveryModel, real: RecoveryReal): Promise<void> {
+  await Promise.resolve();
+  expect(activeModelStreams()).toHaveLength(1);
+
+  const retryDelays = real.harness.pendingDelays().filter(delay => delay <= 30_000);
+  expect(retryDelays.length).toBeLessThanOrEqual(1);
+  expect(retryDelays.every(delay => delay >= 0 && delay <= 30_000)).toBeTrue();
+  expect(real.harness.reloads.count).toBe(0);
+
+  const observableSinks = JSON.stringify({
+    fetchPaths: real.harness.fetchPaths,
+    opened: real.harness.window.opened,
+    replacedPaths: real.harness.replacedPaths,
+    rowTitle: real.harness.elements.sessionList.querySelector(".row-title")?.textContent,
+    status: real.harness.elements.statusBanner.textContent,
+    workerMessages: real.harness.workerMessages,
+  });
+  expect(observableSinks).not.toContain(real.capabilityCanary);
+
+  if (!model.interrupted) {
+    expect(real.harness.elements.statusBanner.hidden).toBeTrue();
+    expect(real.harness.elements.sessionList.querySelector(".row-title")?.textContent).toBe(
+      model.title,
+    );
+  }
+}
+
+class InterruptStreamCommand implements RecoveryCommand {
+  constructor(private readonly reportedOnline: boolean) {}
+
+  check(model: Readonly<RecoveryModel>): boolean {
+    return !model.interrupted;
+  }
+
+  async run(model: RecoveryModel, real: RecoveryReal): Promise<void> {
+    real.harness.setOnline(this.reportedOnline);
+    real.harness.disconnectEvents();
+    model.interrupted = true;
+    model.online = this.reportedOnline;
+    await assertRecoveryInvariants(model, real);
+  }
+
+  toString(): string {
+    return `SSE error (navigator.onLine=${String(this.reportedOnline)}, no online event)`;
+  }
+}
+
+class RepeatStreamFailureCommand implements RecoveryCommand {
+  constructor(private readonly repetitions: number) {}
+
+  check(model: Readonly<RecoveryModel>): boolean {
+    return model.interrupted;
+  }
+
+  async run(model: RecoveryModel, real: RecoveryReal): Promise<void> {
+    const source = activeModelStreams()[0];
+    if (source === undefined) throw new Error("missing interrupted native stream");
+    for (let index = 0; index < this.repetitions; index += 1) source.onerror?.();
+    await assertRecoveryInvariants(model, real);
+  }
+
+  toString(): string {
+    return `repeat SSE error x${String(this.repetitions)}`;
+  }
+}
+
+class LoseTimersCommand implements RecoveryCommand {
+  constructor(private readonly elapsedMs: number) {}
+
+  check(model: Readonly<RecoveryModel>): boolean {
+    return model.interrupted;
+  }
+
+  async run(model: RecoveryModel, real: RecoveryReal): Promise<void> {
+    real.harness.advanceClock(this.elapsedMs);
+    await assertRecoveryInvariants(model, real);
+  }
+
+  toString(): string {
+    return `freeze timers for ${String(this.elapsedMs)}ms`;
+  }
+}
+
+class SetReportedOnlineWithoutEventCommand implements RecoveryCommand {
+  constructor(private readonly online: boolean) {}
+
+  check(): boolean {
+    return true;
+  }
+
+  async run(model: RecoveryModel, real: RecoveryReal): Promise<void> {
+    real.harness.setOnline(this.online);
+    model.online = this.online;
+    await assertRecoveryInvariants(model, real);
+  }
+
+  toString(): string {
+    return `set navigator.onLine=${String(this.online)} without event`;
+  }
+}
+
+class NativeReopenCommand implements RecoveryCommand {
+  constructor(private readonly titleId: number) {}
+
+  check(model: Readonly<RecoveryModel>): boolean {
+    return model.interrupted;
+  }
+
+  async run(model: RecoveryModel, real: RecoveryReal): Promise<void> {
+    const source = activeModelStreams()[0];
+    if (source === undefined) throw new Error("missing native stream to reopen");
+    const revision = model.revision + 1;
+    const title = `native-reopen-${String(this.titleId)}-r${String(revision)}`;
+    source.onopen?.();
+    source.emit("snapshot", {
+      type: "snapshot",
+      revision,
+      sessions: [session(real.instanceId, { title })],
+    });
+    await settleUntil(() => real.harness.elements.statusBanner.hidden);
+    model.revision = revision;
+    model.title = title;
+    model.interrupted = false;
+    await assertRecoveryInvariants(model, real);
+  }
+
+  toString(): string {
+    return `native SSE reopen ${String(this.titleId)}`;
+  }
+}
+
+class SnapshotFallbackCommand implements RecoveryCommand {
+  constructor(private readonly titleId: number) {}
+
+  check(model: Readonly<RecoveryModel>): boolean {
+    return model.interrupted;
+  }
+
+  async run(model: RecoveryModel, real: RecoveryReal): Promise<void> {
+    const revision = model.revision + 1;
+    const title = `snapshot-fallback-${String(this.titleId)}-r${String(revision)}`;
+    const fetchesBefore = real.harness.fetchPaths.length;
+    real.harness.setList(revision, [session(real.instanceId, { title })]);
+    real.harness.runTimers();
+    await settleUntil(() => real.harness.fetchPaths.length > fetchesBefore);
+    await settleUntil(() => activeModelStreams().length === 1);
+    model.revision = revision;
+    model.title = title;
+    model.interrupted = false;
+    await assertRecoveryInvariants(model, real);
+  }
+
+  toString(): string {
+    return `snapshot retry ${String(this.titleId)}`;
+  }
+}
+
+class HideResumeCommand implements RecoveryCommand {
+  constructor(private readonly titleId: number) {}
+
+  check(model: Readonly<RecoveryModel>): boolean {
+    return model.interrupted;
+  }
+
+  async run(model: RecoveryModel, real: RecoveryReal): Promise<void> {
+    const revision = model.revision + 1;
+    const title = `resume-${String(this.titleId)}-r${String(revision)}`;
+    const fetchesBefore = real.harness.fetchPaths.length;
+    real.harness.setList(revision, [session(real.instanceId, { title })]);
+    real.harness.setVisibility("hidden");
+    real.harness.advanceClock(45_000);
+    real.harness.setVisibility("visible");
+    await settleUntil(() => real.harness.fetchPaths.length > fetchesBefore);
+    await settleUntil(() => activeModelStreams().length === 1);
+    model.revision = revision;
+    model.title = title;
+    model.interrupted = false;
+    await assertRecoveryInvariants(model, real);
+  }
+
+  toString(): string {
+    return `hide/resume ${String(this.titleId)}`;
+  }
+}
+
+class FreshStreamSnapshotCommand implements RecoveryCommand {
+  constructor(private readonly titleId: number) {}
+
+  check(model: Readonly<RecoveryModel>): boolean {
+    return !model.interrupted;
+  }
+
+  async run(model: RecoveryModel, real: RecoveryReal): Promise<void> {
+    const revision = model.revision + 1;
+    const title = `fresh-stream-${String(this.titleId)}-r${String(revision)}`;
+    const source = activeModelStreams()[0];
+    if (source === undefined) throw new Error("missing live stream");
+    source.emit("snapshot", {
+      type: "snapshot",
+      revision,
+      sessions: [session(real.instanceId, { title })],
+    });
+    model.revision = revision;
+    model.title = title;
+    await assertRecoveryInvariants(model, real);
+  }
+
+  toString(): string {
+    return `fresh stream snapshot ${String(this.titleId)}`;
+  }
+}
+
+class StaleStreamSnapshotCommand implements RecoveryCommand {
+  check(model: Readonly<RecoveryModel>): boolean {
+    return !model.interrupted;
+  }
+
+  async run(model: RecoveryModel, real: RecoveryReal): Promise<void> {
+    const source = activeModelStreams()[0];
+    if (source === undefined) throw new Error("missing live stream");
+    source.emit("snapshot", {
+      type: "snapshot",
+      revision: Math.max(0, model.revision - 1),
+      sessions: [session(real.instanceId, { title: "stale-snapshot-must-not-win" })],
+    });
+    await assertRecoveryInvariants(model, real);
+  }
+
+  toString(): string {
+    return "stale stream snapshot";
+  }
+}
+
+describe("stateful directory recovery model", () => {
+  test("preserves recovery invariants across generated browser lifecycle sequences", async () => {
+    let modelRun = 0;
+    const setup = async (): Promise<{ model: RecoveryModel; real: RecoveryReal }> => {
+      modelRun += 1;
+      const instanceId = `recovery-model-${String(modelRun).padStart(4, "0")}`;
+      const title = "model-initial-r1";
+      const harness = await bootApp({
+        permission: "denied",
+        suffix: `recovery-model-${String(modelRun)}`,
+        initialSessions: [session(instanceId, { title })],
+      });
+      const model = { revision: 1, title, interrupted: false, online: true };
+      const real = {
+        harness,
+        instanceId,
+        capabilityCanary: "MODEL_CAPABILITY_CANARY_8f6b10c2",
+      };
+      await assertRecoveryInvariants(model, real);
+      return { model, real };
+    };
+
+    await fc.asyncModelRun(setup, [
+      new InterruptStreamCommand(false),
+      new LoseTimersCommand(120_000),
+      new SetReportedOnlineWithoutEventCommand(true),
+      new NativeReopenCommand(1),
+      new FreshStreamSnapshotCommand(2),
+      new StaleStreamSnapshotCommand(),
+    ]);
+
+    await fc.asyncModelRun(setup, [
+      new InterruptStreamCommand(true),
+      new RepeatStreamFailureCommand(4),
+      new HideResumeCommand(3),
+      new InterruptStreamCommand(true),
+      new RepeatStreamFailureCommand(2),
+      new SnapshotFallbackCommand(4),
+    ]);
+
+    const commandArbitraries: fc.Arbitrary<RecoveryCommand>[] = [
+      fc.boolean().map(online => new InterruptStreamCommand(online)),
+      fc.integer({ min: 1, max: 5 }).map(count => new RepeatStreamFailureCommand(count)),
+      fc.integer({ min: 1_000, max: 180_000 }).map(elapsed => new LoseTimersCommand(elapsed)),
+      fc.boolean().map(online => new SetReportedOnlineWithoutEventCommand(online)),
+      fc.integer({ min: 1, max: 1_000 }).map(id => new NativeReopenCommand(id)),
+      fc.integer({ min: 1, max: 1_000 }).map(id => new SnapshotFallbackCommand(id)),
+      fc.integer({ min: 1, max: 1_000 }).map(id => new HideResumeCommand(id)),
+      fc.integer({ min: 1, max: 1_000 }).map(id => new FreshStreamSnapshotCommand(id)),
+      fc.constant(new StaleStreamSnapshotCommand()),
+    ];
+
+    await fc.assert(
+      fc.asyncProperty(fc.commands(commandArbitraries, { maxCommands: 30 }), async commands => {
+        await fc.asyncModelRun(setup, commands);
+      }),
+      { numRuns: 50 },
+    );
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@types/bun": "1.3.14",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
+        "fast-check": "4.9.0",
         "typescript": "7.0.2",
       },
     },
@@ -125,6 +126,8 @@
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "http_ece": ["http_ece@1.2.0", "", {}, "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA=="],
@@ -150,6 +153,8 @@
     "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
 
     "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
+
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -47,4 +47,10 @@ ignore:
   - "packages/collab-client/upstream/**"
   # Test and fixture code. Measuring the tests' own coverage says nothing about the product.
   - "**/*.test.ts"
+  # Physical-device acceptance harness. Bun 1.3.14 reports 20/33 functions hit for this module but
+  # maps those executions to only 6/591 source lines, even when its focused 21-test suite runs in
+  # isolation. Keep the executable tests and physical gate authoritative instead of feeding that
+  # known-bad source map into the project line regression.
+  - "scripts/android-device.ts"
+  - "scripts/android-acceptance.ts"
   - "apps/web/e2e/**"

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -57,6 +57,20 @@ activity, and DevTools socket selection:
     OMP_ANDROID_DEVTOOLS_SOCKET=localabstract:chrome_devtools_remote \
     bun scripts/android-acceptance.ts "$ORIGIN" "$DISPOSABLE_SESSION_LABEL"
 
+Lock/resume qualification uses a dedicated numeric device PIN from macOS Keychain. Store it under
+the attached device's ADB serial; keep `-w` last so `security` prompts instead of placing the PIN in
+shell history or argv:
+
+    security add-generic-password -a '<adb-serial>' -s 'omp-session-gateway.android-qualification-pin' -U -w
+
+The value must contain 4–16 decimal digits. The harness reads it directly into process memory,
+reveals the primary PIN bouncer with one bounded non-secret swipe, and writes digit keyevents to one
+interactive `adb shell` stdin stream. It authenticates once, requires
+`isKeyguardShowing=false`, and redacts every credential-path failure. Never pass the PIN through an
+environment variable, command argument, file, log, receipt, or CI secret. Pattern unlock is not a
+supported qualification setup: ADB's single swipe command cannot reproduce arbitrary multi-segment
+patterns without weakening the physical lock/resume gate.
+
 Every acceptance record includes the package name, Android package version, complete
 Browser.getVersion result, launch activity, and DevTools socket. Before recording evidence, the
 driver reads the forwarded endpoint's Android-Package, Browser, and loopback WebSocket URL and

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/bun": "1.3.14",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
+    "fast-check": "4.9.0",
     "typescript": "7.0.2"
   }
 }

--- a/scripts/android-acceptance.ts
+++ b/scripts/android-acceptance.ts
@@ -7,17 +7,22 @@
  * Chrome freezes the renderer while the display is off, so `Runtime.evaluate` never resolves on a
  * locked device. Lock/resume is therefore measured after waking, never during.
  *
- * A bounded in-page fetch cannot distinguish "no route" from "slow recovery" if the bound is tight.
- * An early version used 8 seconds and reported a clean recovery as a network failure. Each attempt
- * now gets 20 seconds and records the error name, so `TimeoutError` and `TypeError` stay separable,
- * and recovery is polled and timed rather than asserted at a single arbitrary instant.
+ * Recovery polling observes the rendered directory and never issues its own fetch. Competing probe
+ * requests previously changed the browser connection workload and could consume the first restored
+ * request while the PWA remained stale. Device-shell reachability remains an independent signal.
  *
  * Radio state is restored in a finally block. Callers should still restore afterwards: a killed
  * process runs no finally.
  *
  * Usage: `bun scripts/android-acceptance.ts <origin> <session-cwd-label>`
  */
-import { wakeAndroidDisplay, withAndroidChrome, type AndroidChromeDriver } from "./android-device.ts";
+import {
+  ANDROID_DIRECTORY_SURFACE_EXPRESSION,
+  unlockAndroidKeyguard,
+  wakeAndroidDisplay,
+  withAndroidChrome,
+  type AndroidChromeDriver,
+} from "./android-device.ts";
 import { isProtectedLabel, targetEligibility } from "./acceptance-target.ts";
 
 const POWER = "26";
@@ -47,7 +52,7 @@ async function sleep(milliseconds: number): Promise<void> {
  * of attributing the timeout to the application.
  */
 async function wake(): Promise<string> {
-  return wakeAndroidDisplay((...args) => adb(...args), sleep);
+  return wakeAndroidDisplay((...args) => adb(...args), sleep, () => unlockAndroidKeyguard(serial));
 }
 
 /**
@@ -79,25 +84,8 @@ async function ensureVisible(driver: AndroidChromeDriver): Promise<string> {
   return "not-visible";
 }
 
-/** One reachability attempt plus the app's own rendered state, generously bounded. */
-const ATTEMPT = `(async () => {
-  const started = performance.now();
-  const out = { online: navigator.onLine, visibility: document.visibilityState };
-  try {
-    const response = await fetch("/api/v1/sessions", { cache: "no-store", signal: AbortSignal.timeout(20000) });
-    const payload = await response.json();
-    out.status = response.status;
-    out.count = payload.sessions.length;
-    out.revision = payload.revision;
-  } catch (error) {
-    out.status = "failed";
-    out.failure = error && error.name ? error.name : "unknown";
-  }
-  out.elapsedMs = Math.round(performance.now() - started);
-  const text = document.body.innerText.replace(/\\s+/g, " ").trim();
-  out.unreachableBanner = text.includes("unreachable");
-  return out;
-})()`;
+/** Rendered PWA state only: the recovery tracer must not become another network client. */
+const ATTEMPT = ANDROID_DIRECTORY_SURFACE_EXPRESSION;
 
 function readValue(evaluation: Record<string, unknown>): Record<string, unknown> | undefined {
   const { result } = evaluation;
@@ -123,6 +111,22 @@ function record(entry: Record<string, unknown>): void {
   console.error(`  ${JSON.stringify(entry)}`);
 }
 
+interface PageContinuity {
+  reloaded: boolean;
+}
+
+function isSamePage(
+  probe: Readonly<Record<string, unknown>>,
+  expectedTimeOrigin: number,
+  continuity: PageContinuity,
+): boolean {
+  const observed = probe.pageTimeOrigin;
+  if (typeof observed !== "number" || !Number.isFinite(observed)) return false;
+  const same = Object.is(observed, expectedTimeOrigin);
+  if (!same && Number.isFinite(expectedTimeOrigin)) continuity.reloaded = true;
+  return same;
+}
+
 /** True when the phone itself can reach the host, independent of anything Chrome is doing. */
 async function deviceReachesHost(host: string): Promise<boolean> {
   const output = await adb("shell", "ping", "-c", "1", "-W", "2", host);
@@ -141,22 +145,44 @@ async function awaitRecovery(
   since: number,
   attempts: number,
   host: string,
+  expectedTimeOrigin: number,
+  continuity: PageContinuity,
+  delayMs = 8_000,
 ): Promise<{ recoveredMs: number | null; deviceReachableFirstMs: number | null }> {
   let deviceReachableFirstMs: number | null = null;
   for (let index = 1; index <= attempts; index++) {
-    await sleep(8000);
+    await sleep(delayMs);
     // The app's resume path is driven by visibilityState, so a probe against a hidden or frozen page
     // measures nothing. Record the presentation state alongside the result so an unmeasurable run is
     // visibly unmeasurable rather than looking like an application stall.
     const presentation = await ensureVisible(driver);
     const deviceReachable = await deviceReachesHost(host);
     const probe = await attempt(driver, `${label}-${index}`);
+    const samePage = isSamePage(probe, expectedTimeOrigin, continuity);
     const sinceMs = Math.round(performance.now() - since);
     if (deviceReachable && deviceReachableFirstMs === null) deviceReachableFirstMs = sinceMs;
-    record({ ...probe, presentation, deviceReachable, sinceMs });
-    if (probe.status === 200) return { recoveredMs: sinceMs, deviceReachableFirstMs };
+    record({ ...probe, samePage, presentation, deviceReachable, sinceMs });
+    if (probe.directoryReady === true && samePage) return { recoveredMs: sinceMs, deviceReachableFirstMs };
   }
   return { recoveredMs: null, deviceReachableFirstMs };
+}
+async function awaitOutage(
+  driver: AndroidChromeDriver,
+  since: number,
+  host: string,
+  expectedTimeOrigin: number,
+  continuity: PageContinuity,
+): Promise<boolean> {
+  for (let index = 1; index <= 12; index++) {
+    await sleep(5_000);
+    const presentation = await ensureVisible(driver);
+    const deviceReachable = await deviceReachesHost(host);
+    const probe = await attempt(driver, `airplane-outage-${index}`);
+    const samePage = isSamePage(probe, expectedTimeOrigin, continuity);
+    record({ ...probe, samePage, presentation, deviceReachable, sinceMs: Math.round(performance.now() - since) });
+    if (probe.outageVisible === true && samePage) return true;
+  }
+  return false;
 }
 
 /** Discovery plus the full launch-authorization matrix, evaluated from the device. */
@@ -251,43 +277,51 @@ const summary = await withAndroidChrome(async driver => {
 
   const authorization = await authorizationMatrix(driver, label);
   console.error(`  authorization: ${JSON.stringify(authorization)}`);
-  record(await attempt(driver, "baseline"));
+  const baseline = await attempt(driver, "baseline");
+  record(baseline);
+  const baselineTimeOrigin =
+    typeof baseline.pageTimeOrigin === "number" && Number.isFinite(baseline.pageTimeOrigin)
+      ? baseline.pageTimeOrigin
+      : Number.NaN;
+  const continuity: PageContinuity = { reloaded: false };
 
   let unlockMs: number | null = null;
   let airplane: { recoveredMs: number | null; deviceReachableFirstMs: number | null } = { recoveredMs: null, deviceReachableFirstMs: null };
   let doze: { recoveredMs: number | null; deviceReachableFirstMs: number | null } = { recoveredMs: null, deviceReachableFirstMs: null };
-  let outageBanner: unknown = null;
+  let outageBanner = false;
 
   try {
-    // Lock and resume.
+    // Lock and resume. Poll the PWA's rendered state instead of failing at one arbitrary instant.
     await adb("shell", "input", "keyevent", POWER);
-    await sleep(20000);
+    await sleep(20_000);
     const wokeAt = performance.now();
     const wakefulness = await wake();
     const presentation = await ensureVisible(driver);
-    await sleep(3000);
-    const unlocked: Record<string, unknown> = { ...(await attempt(driver, "after-unlock")), wakefulness, presentation };
-    unlockMs = Math.round(performance.now() - wokeAt);
-    record({ ...unlocked, sinceMs: unlockMs });
-    if (unlocked.status !== 200) unlockMs = null;
+    const lock = await awaitRecovery(driver, "lock-resume", wokeAt, 12, host, baselineTimeOrigin, continuity, 3_000);
+    unlockMs = lock.recoveredMs;
+    record({ step: "lock-resume-summary", wakefulness, presentation, recoveredMs: unlockMs });
 
-    // Total network loss and automatic recovery, with no reload.
+    // Total network loss and automatic same-page recovery, with no reload and no competing fetch.
     await adb("shell", "cmd", "connectivity", "airplane-mode", "enable");
-    await sleep(15000);
-    const during = await attempt(driver, "airplane-on");
-    outageBanner = during.unreachableBanner;
-    record(during);
+    outageBanner = await awaitOutage(driver, performance.now(), host, baselineTimeOrigin, continuity);
     await adb("shell", "cmd", "connectivity", "airplane-mode", "disable");
-    airplane = await awaitRecovery(driver, "airplane-recovery", performance.now(), 20, host);
+    airplane = await awaitRecovery(driver, "airplane-recovery", performance.now(), 20, host, baselineTimeOrigin, continuity);
+    if (airplane.recoveredMs !== null) {
+      await sleep(10_000);
+      const settled = await attempt(driver, "airplane-settled");
+      const samePage = isSamePage(settled, baselineTimeOrigin, continuity);
+      record({ ...settled, samePage });
+      if (settled.directoryReady !== true || !samePage) airplane = { ...airplane, recoveredMs: null };
+    }
 
     // Forced deep Doze.
     await adb("shell", "dumpsys", "battery", "unplug");
     await adb("shell", "dumpsys", "deviceidle", "force-idle");
-    await sleep(20000);
+    await sleep(20_000);
     record({ step: "doze-state", idle: await adb("shell", "dumpsys", "deviceidle", "get", "deep") });
     await adb("shell", "dumpsys", "deviceidle", "unforce");
     await adb("shell", "dumpsys", "battery", "reset");
-    doze = await awaitRecovery(driver, "doze-recovery", performance.now(), 6, host);
+    doze = await awaitRecovery(driver, "doze-recovery", performance.now(), 6, host, baselineTimeOrigin, continuity);
   } finally {
     await adb("shell", "cmd", "connectivity", "airplane-mode", "disable");
     await adb("shell", "svc", "wifi", "enable");
@@ -304,6 +338,9 @@ const summary = await withAndroidChrome(async driver => {
     devtoolsSocket: driver.devtoolsSocket,
     browserActivity: driver.browserActivity,
     authorization,
+    baselineReady: baseline.directoryReady === true && Number.isFinite(baselineTimeOrigin),
+    appAsset: typeof baseline.appAsset === "string" ? baseline.appAsset : null,
+    samePage: Number.isFinite(baselineTimeOrigin) && !continuity.reloaded,
     unlockMs,
     outageBanner,
     airplaneRecoveredMs: airplane.recoveredMs,
@@ -328,6 +365,8 @@ expect("control launch", status("control"), 200);
 expect("stale view rejected", status("staleView"), 409);
 expect("stale control rejected", status("staleControl"), 409);
 expect("unknown session rejected", status("unknownSession"), 404);
+if (!summary.baselineReady) failures.push("baseline directory was not rendered ready");
+if (!summary.samePage) failures.push("PWA reloaded during recovery");
 if (summary.unlockMs === null) failures.push("lock/resume did not recover");
 // A tailnet that is still down is not an application failure, so attribute before failing.
 if (summary.airplaneRecoveredMs === null) {
@@ -338,7 +377,7 @@ if (summary.airplaneRecoveredMs === null) {
   );
 }
 if (summary.dozeRecoveredMs === null) failures.push("Doze did not recover within the polling window");
-if (summary.outageBanner !== true) failures.push("no unreachable banner during the outage");
+if (summary.outageBanner !== true) failures.push("no recovery status during the outage");
 
 if (failures.length > 0) {
   console.error(`FAILED:\n  ${failures.join("\n  ")}`);

--- a/scripts/android-device.test.ts
+++ b/scripts/android-device.test.ts
@@ -1,11 +1,66 @@
 import { describe, expect, test } from "bun:test";
 import {
+  ANDROID_DIRECTORY_SURFACE_EXPRESSION,
+  ANDROID_QUALIFICATION_PIN_KEYCHAIN_SERVICE,
   assertDevtoolsEndpointMatchesPackage,
   assertBrowserVersionMatchesPackage,
   parseAndroidPackageVersion,
+  parseKeyguardShowing,
+  readAndroidQualificationPin,
+  unlockAndroidKeyguard,
+  wakeAndroidDisplay,
   resolveAndroidBrowserTarget,
   wakeAndroidChrome,
 } from "./android-device.ts";
+describe("Android directory recovery observation", () => {
+  test("reads rendered recovery state without issuing a competing fetch", () => {
+    let fetchCalls = 0;
+    const evaluate = new Function(
+      "document",
+      "navigator",
+      "performance",
+      "fetch",
+      `return ${ANDROID_DIRECTORY_SURFACE_EXPRESSION};`,
+    ) as (
+      document: unknown,
+      navigator: unknown,
+      performance: unknown,
+      fetch: () => never,
+    ) => Record<string, unknown>;
+    const status = {
+      dataset: { kind: "ready" },
+      hasAttribute: (name: string) => name === "hidden",
+      querySelector: () => ({ textContent: "" }),
+    };
+    const observed = evaluate(
+      {
+        visibilityState: "visible",
+        querySelector: () => status,
+        querySelectorAll: () => ({ length: 1 }),
+      },
+      { onLine: false },
+      { timeOrigin: 123_456, getEntriesByType: () => [{ name: "https://sessions.example/assets/app.abc123.js" }] },
+      () => {
+        fetchCalls += 1;
+        throw new Error("recovery observer must not fetch");
+      },
+    );
+
+    expect(fetchCalls).toBe(0);
+    expect(observed).toMatchObject({
+      online: false,
+      visibility: "visible",
+      statusHidden: true,
+      statusKind: "ready",
+      sessionCount: 1,
+      appAsset: "https://sessions.example/assets/app.abc123.js",
+      pageTimeOrigin: 123_456,
+      directoryReady: true,
+      outageVisible: false,
+    });
+  });
+});
+
 
 describe("Android browser target", () => {
   test("defaults to stable Chrome and its ordinary DevTools socket", () => {
@@ -75,6 +130,7 @@ describe("Android display bootstrap", () => {
         if (args[1] === "dumpsys" && args[2] === "power") {
           return `mWakefulness=${wakefulness.shift() ?? "Awake"}`;
         }
+        if (args[1] === "dumpsys" && args[2] === "window") return "isKeyguardShowing=false";
         return "";
       },
       async () => {},
@@ -86,13 +142,15 @@ describe("Android display bootstrap", () => {
     expect(calls.slice(0, launchIndex)).toEqual([
       ["shell", "input", "keyevent", "224"],
       ["shell", "input", "keyevent", "82"],
+      ["shell", "wm", "dismiss-keyguard"],
       ["shell", "dumpsys", "power"],
       ["shell", "input", "keyevent", "224"],
       ["shell", "input", "keyevent", "82"],
+      ["shell", "wm", "dismiss-keyguard"],
       ["shell", "dumpsys", "power"],
+      ["shell", "dumpsys", "window"],
     ]);
   });
-
   test("refuses to launch Chrome when the display never wakes", async () => {
     const calls: string[][] = [];
     const failure: unknown = await wakeAndroidChrome(
@@ -110,6 +168,144 @@ describe("Android display bootstrap", () => {
     expect(failure).toBeInstanceOf(Error);
     expect((failure as Error).message).toBe("Android display did not wake (observed Dreaming)");
     expect(calls.some(args => args[1] === "am" && args[2] === "start")).toBe(false);
+  });
+
+  test("parses keyguard state and rejects missing state", () => {
+    expect(parseKeyguardShowing("  isKeyguardShowing=true\n")).toBe(true);
+    expect(parseKeyguardShowing("isKeyguardShowing=false\n")).toBe(false);
+    expect(() => parseKeyguardShowing("mWakefulness=Awake")).toThrow(
+      "Android window state is missing isKeyguardShowing",
+    );
+  });
+
+  test("reveals the PIN keypad and authenticates once before reporting the display awake", async () => {
+    const calls: string[][] = [];
+    let keyguardChecks = 0;
+    let unlocks = 0;
+    const state = await wakeAndroidDisplay(
+      async (...args) => {
+        calls.push(args);
+        if (args.join(" ") === "shell dumpsys power") return "mWakefulness=Awake";
+        if (args.join(" ") === "shell wm size") return "Physical size: 1080x2424";
+        if (args.join(" ") === "shell dumpsys window") {
+          keyguardChecks += 1;
+          return `isKeyguardShowing=${keyguardChecks === 1}`;
+        }
+        return "";
+      },
+      async () => {},
+      async () => {
+        unlocks += 1;
+      },
+    );
+    expect(state).toBe("Awake");
+    expect(unlocks).toBe(1);
+    expect(keyguardChecks).toBe(2);
+    expect(calls).toContainEqual(["shell", "input", "swipe", "540", "2205", "540", "606", "600"]);
+  });
+
+  test("fails closed when one authentication attempt leaves the keyguard visible", async () => {
+    let unlocks = 0;
+    const state = await wakeAndroidDisplay(
+      async (...args) => {
+        if (args.join(" ") === "shell dumpsys power") return "mWakefulness=Awake";
+        if (args.join(" ") === "shell wm size") return "Physical size: 1080x2424";
+        if (args.join(" ") === "shell dumpsys window") return "isKeyguardShowing=true";
+        return "";
+      },
+      async () => {},
+      async () => {
+        unlocks += 1;
+      },
+    );
+    expect(state).toBe("Keyguard");
+    expect(unlocks).toBe(1);
+  });
+
+  test("rejects an unbounded display gesture before reading the credential", async () => {
+    let unlocks = 0;
+    const failure = await wakeAndroidDisplay(
+      async (...args) => {
+        if (args.join(" ") === "shell dumpsys power") return "mWakefulness=Awake";
+        if (args.join(" ") === "shell dumpsys window") return "isKeyguardShowing=true";
+        if (args.join(" ") === "shell wm size") return "Physical size: 2424x1080";
+        return "";
+      },
+      async () => {},
+      async () => {
+        unlocks += 1;
+      },
+    ).then(
+      () => undefined,
+      error => error as Error,
+    );
+    expect(failure?.message).toBe("Android keyguard authentication failed");
+    expect(unlocks).toBe(0);
+  });
+});
+
+describe("Android secure keyguard unlock", () => {
+  test("retrieves a device-scoped numeric PIN and clears the Keychain buffer", async () => {
+    const keychainBytes = new TextEncoder().encode("9071\n");
+    const pin = await readAndroidQualificationPin("pixel-serial", async (account, service) => {
+      expect(account).toBe("pixel-serial");
+      expect(service).toBe(ANDROID_QUALIFICATION_PIN_KEYCHAIN_SERVICE);
+      return keychainBytes;
+    });
+    expect(new TextDecoder().decode(pin)).toBe("9071");
+    expect([...keychainBytes]).toEqual([0, 0, 0, 0, 0]);
+    pin.fill(0);
+  });
+
+  test("sends PIN digits through one interactive adb shell stream and clears memory", async () => {
+    const pin = new TextEncoder().encode("9071");
+    let observedSerial = "";
+    let observedInput = new Uint8Array();
+    await unlockAndroidKeyguard(
+      "pixel-serial",
+      async () => pin,
+      async (serial, input) => {
+        observedSerial = serial;
+        observedInput = input.slice();
+        return 0;
+      },
+    );
+    expect(observedSerial).toBe("pixel-serial");
+    expect(new TextDecoder().decode(observedInput)).toBe(
+      "input keyevent KEYCODE_9\n" +
+        "input keyevent KEYCODE_0\n" +
+        "input keyevent KEYCODE_7\n" +
+        "input keyevent KEYCODE_1\n" +
+        "input keyevent KEYCODE_ENTER\n" +
+        "exit\n",
+    );
+    expect([...pin]).toEqual([0, 0, 0, 0]);
+    observedInput.fill(0);
+  });
+
+  test("redacts invalid credentials and adb transport failures", async () => {
+    const invalidBytes = new TextEncoder().encode("12x4");
+    const invalidFailure = await readAndroidQualificationPin("pixel-serial", async () => invalidBytes).then(
+      () => undefined,
+      error => error as Error,
+    );
+    expect(invalidFailure?.message).toBe("Android keyguard authentication failed");
+    expect([...invalidBytes]).toEqual([0, 0, 0, 0]);
+
+    const pin = new TextEncoder().encode("8675309");
+    const transportFailure = await unlockAndroidKeyguard(
+      "pixel-serial",
+      async () => pin,
+      async () => {
+        throw new Error("transport exposed 8675309");
+      },
+    ).then(
+      () => undefined,
+      error => error as Error,
+    );
+    expect(transportFailure?.message).toBe("Android keyguard authentication failed");
+    expect(transportFailure?.message).not.toContain("8675309");
+    expect([...pin]).toEqual([0, 0, 0, 0, 0, 0, 0]);
   });
 });
 

--- a/scripts/android-device.ts
+++ b/scripts/android-device.ts
@@ -94,6 +94,68 @@ export interface AndroidChromeDriver {
   /** Raw escape hatch for protocol domains this helper does not wrap. */
   send(method: string, parameters?: Record<string, unknown>): Promise<Record<string, unknown>>;
 }
+export interface AndroidDirectorySurface {
+  readonly online: boolean;
+  readonly visibility: string;
+  readonly statusHidden: boolean;
+  readonly statusKind: string | null;
+  readonly statusTitle: string;
+  readonly sessionCount: number;
+  readonly appAsset: string | null;
+  readonly pageTimeOrigin: number;
+  readonly directoryReady: boolean;
+  readonly outageVisible: boolean;
+}
+
+interface DirectoryStatusElement {
+  readonly dataset?: { readonly kind?: string };
+  hasAttribute(name: string): boolean;
+  querySelector(selector: string): { readonly textContent?: string | null } | null;
+}
+
+interface DirectorySurfaceDocument {
+  readonly visibilityState: string;
+  querySelector(selector: string): DirectoryStatusElement | null;
+  querySelectorAll(selector: string): { readonly length: number };
+}
+
+interface DirectorySurfacePerformance {
+  readonly timeOrigin: number;
+  getEntriesByType(type: string): readonly { readonly name: string }[];
+}
+
+/** Reads the rendered directory only. Recovery probes must not compete with the PWA's own fetches. */
+export function captureAndroidDirectorySurface(
+  pageDocument: DirectorySurfaceDocument,
+  pageNavigator: { readonly onLine: boolean },
+  pagePerformance: DirectorySurfacePerformance,
+): AndroidDirectorySurface {
+  const status = pageDocument.querySelector("#status-banner");
+  const statusHidden = status?.hasAttribute("hidden") ?? false;
+  const statusKind = status?.dataset?.kind ?? null;
+  const sessionCount = pageDocument.querySelectorAll(".working-row, .queue-row").length;
+  return {
+    online: pageNavigator.onLine,
+    visibility: pageDocument.visibilityState,
+    statusHidden,
+    statusKind,
+    statusTitle: status?.querySelector(".status-title")?.textContent?.trim() ?? "",
+    sessionCount,
+    appAsset:
+      pagePerformance
+        .getEntriesByType("resource")
+        .map(entry => entry.name)
+        .find(name => /\/assets\/app[.][0-9a-f]+[.]js$/u.test(name)) ?? null,
+    pageTimeOrigin: pagePerformance.timeOrigin,
+    directoryReady: pageDocument.visibilityState === "visible" && statusHidden && sessionCount === 1,
+    outageVisible:
+      !statusHidden && ["offline", "tailnet", "desktop", "gateway"].includes(statusKind ?? ""),
+  };
+}
+
+export const ANDROID_DIRECTORY_SURFACE_EXPRESSION =
+  `(${captureAndroidDirectorySurface.toString()})(document, navigator, performance)`;
+
 
 async function adb(serial: string | undefined, ...args: readonly string[]): Promise<string> {
   const argv = serial === undefined ? ["adb", ...args] : ["adb", "-s", serial, ...args];
@@ -116,24 +178,184 @@ export function parseAndroidPackageVersion(dumpsys: string): string {
 
 export type AndroidAdbCommand = (...args: string[]) => Promise<string>;
 
+export const ANDROID_QUALIFICATION_PIN_KEYCHAIN_SERVICE =
+  "omp-session-gateway.android-qualification-pin";
+const ANDROID_PIN_MIN_LENGTH = 4;
+const ANDROID_PIN_MAX_LENGTH = 16;
+const ANDROID_KEYGUARD_FAILURE = "Android keyguard authentication failed";
+
+type AndroidKeychainReader = (account: string, service: string) => Promise<Uint8Array>;
+export type AndroidInteractiveAdbShell = (serial: string, input: Uint8Array) => Promise<number>;
+export type AndroidKeyguardUnlock = () => Promise<void>;
+
+async function readMacOsKeychainItem(account: string, service: string): Promise<Uint8Array> {
+  if (process.platform !== "darwin") throw new Error(ANDROID_KEYGUARD_FAILURE);
+  const child = Bun.spawn(
+    ["security", "find-generic-password", "-a", account, "-s", service, "-w"],
+    { stdin: "ignore", stdout: "pipe", stderr: "pipe" },
+  );
+  const [stdoutBuffer, stderrBuffer, exitCode] = await Promise.all([
+    new Response(child.stdout).arrayBuffer(),
+    new Response(child.stderr).arrayBuffer(),
+    child.exited,
+  ]);
+  const stdout = new Uint8Array(stdoutBuffer);
+  const stderr = new Uint8Array(stderrBuffer);
+  stderr.fill(0);
+  if (exitCode !== 0) {
+    stdout.fill(0);
+    throw new Error(ANDROID_KEYGUARD_FAILURE);
+  }
+  return stdout;
+}
+
+/** Reads the device-scoped qualification PIN without placing it in argv, env, or logs. */
+export async function readAndroidQualificationPin(
+  serial: string,
+  readKeychain: AndroidKeychainReader = readMacOsKeychainItem,
+): Promise<Uint8Array> {
+  if (!/^[A-Za-z0-9._:-]{1,128}$/u.test(serial)) throw new Error(ANDROID_KEYGUARD_FAILURE);
+  let bytes: Uint8Array;
+  try {
+    bytes = await readKeychain(serial, ANDROID_QUALIFICATION_PIN_KEYCHAIN_SERVICE);
+  } catch {
+    throw new Error(ANDROID_KEYGUARD_FAILURE);
+  }
+  let length = bytes.length;
+  while (length > 0 && (bytes[length - 1] === 10 || bytes[length - 1] === 13)) length -= 1;
+  const valid =
+    length >= ANDROID_PIN_MIN_LENGTH &&
+    length <= ANDROID_PIN_MAX_LENGTH &&
+    bytes.subarray(0, length).every(value => value >= 48 && value <= 57);
+  if (!valid) {
+    bytes.fill(0);
+    throw new Error(ANDROID_KEYGUARD_FAILURE);
+  }
+  const pin = bytes.slice(0, length);
+  bytes.fill(0);
+  return pin;
+}
+
+function androidPinKeyeventStream(pin: Uint8Array): Uint8Array {
+  if (
+    pin.length < ANDROID_PIN_MIN_LENGTH ||
+    pin.length > ANDROID_PIN_MAX_LENGTH ||
+    !pin.every(value => value >= 48 && value <= 57)
+  ) {
+    throw new Error(ANDROID_KEYGUARD_FAILURE);
+  }
+  const commands = Array.from(
+    pin,
+    value => `input keyevent KEYCODE_${String.fromCharCode(value)}\n`,
+  );
+  commands.push("input keyevent KEYCODE_ENTER\nexit\n");
+  return new TextEncoder().encode(commands.join(""));
+}
+
+async function runAndroidInteractiveAdbShell(serial: string, input: Uint8Array): Promise<number> {
+  const child = Bun.spawn(["adb", "-s", serial, "shell"], {
+    stdin: "pipe",
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  child.stdin.write(input);
+  await child.stdin.end();
+  return child.exited;
+}
+
+/** Authenticates once through one interactive adb shell; every failure is deliberately redacted. */
+export async function unlockAndroidKeyguard(
+  serial: string,
+  readPin: (serial: string) => Promise<Uint8Array> = readAndroidQualificationPin,
+  runShell: AndroidInteractiveAdbShell = runAndroidInteractiveAdbShell,
+): Promise<void> {
+  let pin: Uint8Array;
+  try {
+    pin = await readPin(serial);
+  } catch {
+    throw new Error(ANDROID_KEYGUARD_FAILURE);
+  }
+  try {
+    const input = androidPinKeyeventStream(pin);
+    try {
+      if ((await runShell(serial, input)) !== 0) throw new Error(ANDROID_KEYGUARD_FAILURE);
+    } catch {
+      throw new Error(ANDROID_KEYGUARD_FAILURE);
+    } finally {
+      input.fill(0);
+    }
+  } finally {
+    pin.fill(0);
+  }
+}
+
 function parseWakefulness(output: string): string {
   return output.match(/mWakefulness=(\w+)/u)?.[1] ?? "unknown";
 }
+
+export function parseKeyguardShowing(output: string): boolean {
+  const value = output.match(/^\s*isKeyguardShowing=(true|false)$/mu)?.[1];
+  if (value === undefined) throw new Error("Android window state is missing isKeyguardShowing");
+  return value === "true";
+}
+function parseAndroidDisplaySize(output: string): { readonly width: number; readonly height: number } {
+  const match = [...output.matchAll(/(\d{3,5})x(\d{3,5})/gu)].at(-1);
+  const width = Number(match?.[1]);
+  const height = Number(match?.[2]);
+  if (!Number.isSafeInteger(width) || !Number.isSafeInteger(height) || width < 320 || height < 640 || width >= height) {
+    throw new Error(ANDROID_KEYGUARD_FAILURE);
+  }
+  return { width, height };
+}
+
 
 /** Wakes and unlocks the display before an Activity launch that may otherwise wait forever. */
 export async function wakeAndroidDisplay(
   command: AndroidAdbCommand,
   pause: (milliseconds: number) => Promise<void> = milliseconds => Bun.sleep(milliseconds),
+  unlockKeyguard?: AndroidKeyguardUnlock,
 ): Promise<string> {
   let wakefulness = "unknown";
+  let keyguardShowing = true;
   for (let attempt = 0; attempt < 6; attempt += 1) {
     await command("shell", "input", "keyevent", "224");
     await command("shell", "input", "keyevent", "82");
+    await command("shell", "wm", "dismiss-keyguard");
     await pause(1_200);
     wakefulness = parseWakefulness(await command("shell", "dumpsys", "power"));
-    if (wakefulness === "Awake") return wakefulness;
+    if (wakefulness !== "Awake") continue;
+    keyguardShowing = parseKeyguardShowing(await command("shell", "dumpsys", "window"));
+    if (!keyguardShowing) return wakefulness;
+    if (unlockKeyguard !== undefined) {
+      try {
+        const { width, height } = parseAndroidDisplaySize(await command("shell", "wm", "size"));
+        const centerX = Math.floor(width / 2);
+        await command(
+          "shell",
+          "input",
+          "swipe",
+          String(centerX),
+          String(Math.floor((height * 91) / 100)),
+          String(centerX),
+          String(Math.floor(height / 4)),
+          "600",
+        );
+      } catch {
+        throw new Error(ANDROID_KEYGUARD_FAILURE);
+      }
+      await pause(1_200);
+      await unlockKeyguard();
+      // Pixel SystemUI can accept the credential several seconds before window state drops the
+      // secure bouncer. Poll without injecting another keyevent or a second credential attempt.
+      for (let dismissalAttempt = 0; dismissalAttempt < 40; dismissalAttempt += 1) {
+        await pause(500);
+        keyguardShowing = parseKeyguardShowing(await command("shell", "dumpsys", "window"));
+        if (!keyguardShowing) return wakefulness;
+      }
+      return "Keyguard";
+    }
   }
-  return wakefulness;
+  return wakefulness === "Awake" && keyguardShowing ? "Keyguard" : wakefulness;
 }
 export function assertBrowserVersionMatchesPackage(
   packageName: string,
@@ -211,8 +433,9 @@ export async function wakeAndroidChrome(
   target: AndroidBrowserTarget,
   command: AndroidAdbCommand = (...args) => adb(serial, ...args),
   pause: (milliseconds: number) => Promise<void> = milliseconds => Bun.sleep(milliseconds),
+  unlockKeyguard: AndroidKeyguardUnlock = () => unlockAndroidKeyguard(serial),
 ): Promise<void> {
-  const wakefulness = await wakeAndroidDisplay(command, pause);
+  const wakefulness = await wakeAndroidDisplay(command, pause, unlockKeyguard);
   if (wakefulness !== "Awake") throw new Error(`Android display did not wake (observed ${wakefulness})`);
   await command("shell", "am", "start", "-W", "-n", target.activity, "-a", "android.intent.action.MAIN");
   for (let attempt = 0; attempt < 20; attempt += 1) {
@@ -260,7 +483,10 @@ export async function withAndroidChrome<T>(
     throw error;
   }
   const socket = new WebSocket(webSocketDebuggerUrl);
-  const pending = new Map<number, { resolve(value: Record<string, unknown>): void; reject(error: Error): void }>();
+  const pending = new Map<
+    number,
+    { readonly method: string; resolve(value: Record<string, unknown>): void; reject(error: Error): void }
+  >();
   let nextId = 0;
   let sessionId: string | undefined;
   let targetId: string | undefined;
@@ -275,14 +501,14 @@ export async function withAndroidChrome<T>(
     const entry = pending.get(message.id);
     if (entry === undefined) return;
     pending.delete(message.id);
-    if (message.error) entry.reject(new Error(message.error.message));
+    if (message.error) entry.reject(new Error(`CDP ${entry.method}: ${message.error.message}`));
     else entry.resolve(message.result ?? {});
   };
 
   const send = (method: string, parameters: Record<string, unknown> = {}, useSession = true) =>
     new Promise<Record<string, unknown>>((resolve, reject) => {
       const id = (nextId += 1);
-      pending.set(id, { resolve, reject });
+      pending.set(id, { method, resolve, reject });
       const frame: Record<string, unknown> = { id, method, params: parameters };
       if (useSession && sessionId !== undefined) frame.sessionId = sessionId;
       socket.send(JSON.stringify(frame));
@@ -309,15 +535,45 @@ export async function withAndroidChrome<T>(
       devtoolsSocket: target.devtoolsSocket,
       version: () => Promise.resolve(browserVersion),
       async openTab() {
-        const created = await send("Target.createTarget", { url: "about:blank" }, false);
-        targetId = String(created.targetId);
-        const attached = await send("Target.attachToTarget", { targetId, flatten: true }, false);
-        sessionId = String(attached.sessionId);
-        await send("Page.enable");
-        await send("Runtime.enable");
+        let lastError: unknown;
+        for (let attempt = 1; attempt <= 3; attempt += 1) {
+          const created = await send("Target.createTarget", { url: "about:blank" }, false);
+          if (typeof created.targetId !== "string" || created.targetId === "") {
+            throw new Error("CDP Target.createTarget returned no target id");
+          }
+          targetId = created.targetId;
+          try {
+            const attached = await send("Target.attachToTarget", { targetId, flatten: true }, false);
+            if (typeof attached.sessionId !== "string" || attached.sessionId === "") {
+              throw new Error("CDP Target.attachToTarget returned no session id");
+            }
+            sessionId = attached.sessionId;
+            await send("Page.enable");
+            await send("Runtime.enable");
+            return;
+          } catch (error) {
+            lastError = error;
+            const failedTarget = targetId;
+            sessionId = undefined;
+            targetId = undefined;
+            await send("Target.closeTarget", { targetId: failedTarget }, false).catch(() => {});
+            const retryable =
+              error instanceof Error && error.message.includes("Session with given id not found");
+            if (!retryable || attempt === 3) throw error;
+            await Bun.sleep(250);
+          }
+        }
+        throw lastError instanceof Error ? lastError : new Error("could not attach to Android Chrome tab");
       },
       async navigate(url: string) {
-        const result = await send("Page.navigate", { url });
+        let result: Record<string, unknown> = {};
+        try {
+          result = await send("Page.navigate", { url });
+        } catch (error) {
+          // Chrome can execute a navigation and lose only the CDP response while its network process
+          // is recovering. The document-ready poll below distinguishes that from a failed navigation.
+          if (!(error instanceof Error) || error.message !== "CDP timeout: Page.navigate") throw error;
+        }
         if (typeof result.errorText === "string") throw new Error(`navigation failed: ${result.errorText}`);
         for (let attempt = 0; attempt < LOAD_ATTEMPTS; attempt += 1) {
           await Bun.sleep(LOAD_POLL_MS);


### PR DESCRIPTION
## Problem

Android Chrome can lose a scheduled JavaScript reconnect timer during Airplane mode or Doze. Closing the native EventSource from onerror then removes the browser-owned recovery path and can strand a long-lived PWA until another lifecycle signal arrives.

## Change

- preserve native EventSource reconnect after transport errors;
- retain the bounded snapshot fallback and close only on liveness expiry, malformed events, or fallback replacement;
- add the exact lost-timer regression and a targeted fast-check state model;
- make physical recovery observation DOM-only, with explicit same-page time-origin checks and no competing recovery fetches;
- make secure Pixel lock/resume qualification fail closed, using a device-scoped numeric PIN from macOS Keychain and one interactive adb shell stdin stream.

## Physical Pixel evidence

Pixel 10 Pro / Chrome 151.0.7922.171 against app.2127b031d191.js:

- lock/resume: 8,586 ms;
- visible outage state: Gateway unavailable;
- Airplane same-page recovery: 10,155 ms;
- settled directory remained ready for 10 seconds;
- Doze same-page recovery: 8,356 ms;
- page time origin remained identical through every observation;
- all device acceptance checks passed.

The diagnostic Mac fixture, Tailscale Serve route, ADB forward, radio/Doze overrides, and temporary files were removed after the proof. The retained Mac itself remains allocated.

## Verification

- bunx bun@1.3.14 install --frozen-lockfile
- bunx bun@1.3.14 test apps/web/test/app.test.ts scripts/android-device.test.ts (39 pass)
- PLAYWRIGHT_WORKERS=3 bunx bun@1.3.14 run test:browser (24 pass)
- bunx bun@1.3.14 run check (460 pass; leak scans pass)

## Threat-model impact

The dashboard capability boundary is unchanged. Recovery probes no longer make API requests. The qualification PIN is read from macOS Keychain into transient byte buffers, never placed in repo files, environment variables, argv, logs, receipts, browser state, or CI artifacts; buffers are cleared on every path and credential failures are generic. Authentication is attempted once and must result in isKeyguardShowing=false before Chrome is launched.