### PR TITLE
feat(release): automate post-release device smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
 - Add prolonged-outage recovery guidance in a help panel carried by the loaded PWA shell. The PWA
   keeps its bounded retry path, suggests force-stop/reopen only after 45 uninterrupted seconds of
   visible failure, removes the guidance on recovery, and makes no third-party probe.
+- Add a bounded post-release smoke command that verifies published stable provenance, upgrades or
+  verifies the configured local Mac without changing config/token or unrelated Serve mappings,
+  exercises exact patched OMP through an owned tmux fixture, and drives physical Android
+  View/Control, forbidden-sink, same-page recovery, and installed-WebAPK checks before scoped cleanup.
 
 ### Changed
 
@@ -57,6 +61,13 @@ The format is based on Keep a Changelog, and the project intends to use Semantic
 - Harden stable qualification with durable Debian dispatch identity, same-commit receipts, restart-safe
   Mac cleanup, NUL-framed sudo transport, exact candidate/native-byte pins, workstation-staged rollback
   assets, bounded session paths, generic persisted failures, and zero-listener teardown evidence.
+- Treat a ready Android directory with the owned target plus unrelated live sessions as recovered,
+  and require disposable-target eligibility in the standalone capability leak sweep. The prior
+  exactly-one-row probe falsely failed local post-release smoke while preserving unrelated sessions.
+- Let the macOS patched-OMP helper consume an explicit pinned Bun executable and private build/native
+  staging paths, so release smoke does not need to replace the user's global Bun runtime.
+- Refuse a missing, unauthorized, or ambiguous adb device before post-release download, host
+  mutation, or fixture startup instead of failing after an otherwise valid release setup.
 
 ## [v0.1.0-beta.1] — 2026-08-21
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,14 @@ and opens the exact encrypted OMP collaboration surface — without QR codes or 
 
 </div>
 
-> **Qualified beta; stable 0.1 qualification is in progress.**
-> [v0.1.0-beta.1](https://github.com/alphastorm/omp-session-gateway/releases/tag/v0.1.0-beta.1)
-> remains the current published release. A bare v0.1.0 will become GitHub Latest only after one
-> signed candidate repeats the exact Debian 13 x86-64, macOS 26.6.1 arm64, and Chrome 151 / Android
-> 17 Pixel matrix. Tailscale Serve with the TUN-mode client, Funnel disabled, and exact patched OMP
-> v17.4.1 remain mandatory. Windows, background Push qualification, Portal Tunnel, userspace
-> networking, and self-hosted/proxied relays stay outside the stable core claim. Details:
+> **Qualified stable v0.1.0.**
+> [v0.1.0](https://github.com/alphastorm/omp-session-gateway/releases/tag/v0.1.0) is the
+> current GitHub Latest release. It was promoted from exact signed candidate
+> `v0.1.0-prealpha.23` after the recorded Debian 13 x86-64, macOS 26.6.1 arm64, and Chrome 151 /
+> Android 17 Pixel matrix passed and candidate-to-stable runtime equivalence was verified.
+> Tailscale Serve with the TUN-mode client, Funnel disabled, and exact patched OMP v17.4.1 remain
+> mandatory. Windows, background Push qualification, Portal Tunnel, userspace networking, and
+> self-hosted/proxied relays stay outside the stable support claim. Details:
 > [Compatibility and release status](#compatibility-and-release-status) ·
 > [compatibility matrix](docs/COMPATIBILITY.md) · [release ledger](docs/RELEASE_STATUS.md).
 
@@ -141,22 +142,22 @@ never redacts.</sub>
 ## Compatibility and release status
 
 Support is qualified for exact combinations, not platform families. The current publication is the
-beta below; stable v0.1.0 is a target until its signed candidate completes the same matrix.
+stable release below; its support boundary remains deliberately narrow.
 
 | | Current claim |
 |---|---|
-| Current release | v0.1.0-beta.1, independently qualified against signed candidate v0.1.0-prealpha.20 |
-| Stable target | v0.1.0; not released until an exact signed successor candidate passes |
+| Current release | [`v0.1.0`](https://github.com/alphastorm/omp-session-gateway/releases/tag/v0.1.0), GitHub Latest |
+| Qualification | Runtime-equivalent to independently qualified signed candidate `v0.1.0-prealpha.23` |
 | Hosts | Debian 13 (trixie) x86-64 · macOS 26.6.1 arm64 |
 | Client | Chrome `151.0.7922.171` on Android 17 (Pixel 10 Pro) |
 | Remote path | Tailscale Serve over tailnet HTTPS, TUN-mode client, Funnel disabled |
 | OMP baseline | Exact `v17.4.1` plus the repository's pinned patch and versioned `omp-gateway-patched` route |
 
-**Upstream baseline.** Beta and the stable target use exact OMP v17.4.1 at
+**Upstream baseline.** Stable v0.1.0 uses exact OMP v17.4.1 at
 `9350b7990d26ebf69a604edc82d8558ef04adf30`, observed and qualified on **2026-08-21**.
 Stock OMP is insufficient; the required versioned build/activation route is
 [patches/oh-my-pi/README.md](patches/oh-my-pi/README.md#supported-01-prerequisite-route-linux-and-macos).
-The published alpha remains immutable at its recorded v17.3.8 commit. Exact package and source
+Earlier published prereleases remain immutable at their recorded baselines. Exact package and source
 metadata: [`UPSTREAM.lock.json`](UPSTREAM.lock.json).
 
 Known limits are part of the claim — read them before installing:
@@ -310,13 +311,13 @@ maintainers, and OMP itself may grow first-party enrollment and session listing
 |---|---|---|---|---|---|
 | Workflow boundary | Private directory, attention queue, and just-in-time View/Control broker for already-running terminal OMP sessions; not a second client | Web cockpit hosting its own OMP SDK sessions plus kanban, plan mode, inbox, knowledge base, routines, and messaging bridges | Skills plugin that exposes an agent from the phone — web chat, real terminal, sharing, notify — for OMP, Claude Code, Codex, Gemini CLI, and opencode | Web/desktop/mobile UI for Claude Code, Cursor CLI, and Codex with chat, shell, file and git explorers | Browser dashboard to spawn, mirror, and drive [`pi`](https://github.com/badlogic/pi-mono) agents; its README states Oh My Pi is **not** supported |
 | Zero-touch discovery of live terminal sessions | Yes — every live interactive OMP process registers through authenticated local IPC; no per-session command | No terminal attach; the deck creates and hosts its own sessions in-process | Per-surface setup through skills; its `omp-collab` skill shares one OMP session over OMP's own path | Discovers existing session files automatically; live terminal mirroring for OMP is proposed in the open PR below | For `pi` only, via a bridge extension loaded into every session |
-| Mobile surface | Android-first installable PWA qualified on physical Pixel hardware for directory/View/Control/lock-resume/capability isolation; opt-in Web Push is implemented but not beta-qualified | Responsive web app; Telegram bridge for DM-driven use | Phone browser over encrypted Portal tunnels; push via self-hosted ntfy | Responsive mobile design, hosted cloud, and desktop companion apps | Mobile-friendly responsive layout |
+| Mobile surface | Android-first installable PWA qualified on physical Pixel hardware for directory/View/Control/lock-resume/capability isolation; opt-in Web Push is implemented but outside the stable support boundary | Responsive web app; Telegram bridge for DM-driven use | Phone browser over encrypted Portal tunnels; push via self-hosted ntfy | Responsive mobile design, hosted cloud, and desktop companion apps | Mobile-friendly responsive layout |
 | Exact OMP collab client reuse | Yes — View/Control opens OMP's own encrypted `collab-web` client from pinned upstream source; no second chat surface | No — own chat surface over the embedded OMP SDK (`@oh-my-pi/*` 15.1.7) | No — own web chat over OMP RPC; `omp-collab` reuses OMP collab links separately | No — own transcript UI over ACP stdio | No — own WebSocket mirror protocol, `pi` only |
 | Attention triage | Metadata-only FIFO **Needs you** queue; the oldest ask is promoted to **Open request**; **All clear** otherwise | Plan-mode approvals and queued prompts per session; no cross-session attention queue described | `agent-notify` pushes when the agent needs you (labels-only content) | Interactive per-tool approvals in the UI; no cross-session queue described | Interactive `ask_user` prompts inside a session view |
 | Capability and secret handling | Collaboration capabilities stay memory-only, fetched `no-store` after an explicit tap; never in logs, URLs, push, or browser storage | Provider OAuth/API keys in `~/.omp/agent/auth.db` and a deck-managed `.env`, masked in the UI | Password/token gate per surface; hosted `my.omp.sh` link option is end-to-end encrypted | Agent tools disabled by default and enabled selectively; uses your own provider subscriptions | Provider keys in `auth.json`; paired-device bearer tokens for its MCP endpoint |
 | Remote path | Tailscale Serve over tailnet HTTPS only; loopback-only bind, TUN mode required; Funnel, Portal Tunnel, SSH/public tunnels, proxies, and public access unsupported | Loopback-only default; you front it with Tailscale Serve, an SSH tunnel, or an authenticated reverse proxy | Portal relay tunnels — end-to-end encrypted, terminating on your machine, behind a mandatory auth gate | Self-hosted on your network (`[yourip]:port`), documented remote-server setup, or the hosted CloudCLI Cloud | `localhost:8000` by default; optional zrok public tunnel with persistent URLs; mDNS LAN discovery |
 | Transcript storage | None — the directory renders bounded metadata only; transcripts stay in OMP | Sessions persist and resume by design (shared `~/.omp/agent` store; deck state in SQLite and markdown) | Web chat keeps conversation memory; the terminal is a live tmux | Session history persisted, with resume and paging | Mirrors live sessions and lazy-loads historical `pi` session files |
-| Install maturity and support | **Qualified beta; narrow stable 0.1 candidate in progress**: signed artifacts and a per-release evidence ledger for exact host/client combinations; requires the pinned six-commit OMP patch and versioned binary route; everything else unsupported | npm `0.6.1` global install or `bunx`; CI matrix and container builds | Plugin-marketplace install; contract-tested frontend bridge | Established npm/Docker/desktop/cloud distribution (AGPL-3.0); **OMP support is an open, unmerged PR ([#1143](https://github.com/siteboon/claudecodeui/pull/1143)) as of 2026-08-21** | Mature npm/Electron/Docker installers for `pi`; the only OMP route is a community fork ([`omp-agent-dashboard`](https://github.com/oldschoola/omp-agent-dashboard)), **fork-only and dormant since 2026-07** with no upstream merge path |
+| Install maturity and support | **Qualified stable v0.1.0 with a narrow support boundary**: signed artifacts and a per-release evidence ledger for exact host/client combinations; requires the pinned six-commit OMP patch and versioned binary route; everything else unsupported | npm `0.6.1` global install or `bunx`; CI matrix and container builds | Plugin-marketplace install; contract-tested frontend bridge | Established npm/Docker/desktop/cloud distribution (AGPL-3.0); **OMP support is an open, unmerged PR ([#1143](https://github.com/siteboon/claudecodeui/pull/1143)) as of 2026-08-21** | Mature npm/Electron/Docker installers for `pi`; the only OMP route is a community fork ([`omp-agent-dashboard`](https://github.com/oldschoola/omp-agent-dashboard)), with no upstream integration described |
 | Official OMP affiliation | None — independent community project | None | None | None | None; targets `pi`, not OMP |
 
 Where each one shines:
@@ -354,6 +355,7 @@ knowledge base, or messaging hub; reusing `collab-web` is the point.
 | `patches/oh-my-pi` | Apply-ready controller, auto-start, and publisher patch for pinned OMP |
 | `scripts/build-web.ts` | Reproducible hashed PWA/client asset build |
 | `scripts/build-release.ts` | Deterministic Bun-runtime release archive and SHA-256 manifest |
+| `scripts/post-release-smoke.ts` | Published-byte local Mac/physical-Android smoke with owned-fixture cleanup |
 | `docs/media` | Canonical README media plus its seeded-fixture capture provenance |
 | `docs/` | Architecture, protocol, security, operations, compatibility, and acceptance plans |
 | `UPSTREAM.lock.json` | Exact OMP source and package baseline |

--- a/apps/web/src/app.ts
+++ b/apps/web/src/app.ts
@@ -419,7 +419,7 @@ if (location.pathname === "/update/" || location.pathname === "/client/") {
   history.replaceState(null, "", "/");
 }
 
-const pendingAttentionLaunch = readPendingAttentionLaunch();
+let pendingAttentionLaunch = readPendingAttentionLaunch();
 let attentionRouteStatusLocked = pendingAttentionLaunch !== undefined;
 
 type StatusKind = "ready" | "offline" | "tailnet" | "desktop" | "gateway" | "unauthorized" | "expired" | "loading";
@@ -1496,6 +1496,23 @@ function connectEvents(epoch: number): void {
   };
 }
 
+async function resolvePendingAttentionRoute(): Promise<void> {
+  const pending = pendingAttentionLaunch;
+  if (pending === undefined) return;
+  pendingAttentionLaunch = undefined;
+  const session = sessions.get(pending.instanceId);
+  if (
+    session !== undefined &&
+    session.ask?.requestId === pending.requestId &&
+    session.inputRequired &&
+    session.canControl
+  ) {
+    await launch(session, "control", undefined, pending.requestId);
+  } else {
+    setStatus("expired", "That attention request was already resolved or the session changed.");
+  }
+}
+
 async function refreshAndConnect(resetBackoff = true): Promise<boolean> {
   if (resetBackoff) reconnectAttempt = 0;
   clearReconnectTimeout();
@@ -1512,6 +1529,7 @@ async function refreshAndConnect(resetBackoff = true): Promise<boolean> {
   if (loaded && epoch === directoryEpoch) {
     reconnectAttempt = 0;
     connectEvents(epoch);
+    await resolvePendingAttentionRoute();
     return true;
   }
   if (!authorizationDenied && epoch === directoryEpoch) scheduleReconnect();
@@ -1584,18 +1602,4 @@ document.addEventListener("visibilitychange", () => {
 
 const applicationWorkerRegistration = initializeApplicationWorker();
 void initializeNotifications(applicationWorkerRegistration);
-if (await refreshAndConnect()) {
-  if (pendingAttentionLaunch !== undefined) {
-    const session = sessions.get(pendingAttentionLaunch.instanceId);
-    if (
-      session !== undefined &&
-      session.ask?.requestId === pendingAttentionLaunch.requestId &&
-      session.inputRequired &&
-      session.canControl
-    ) {
-      await launch(session, "control", undefined, pendingAttentionLaunch.requestId);
-    } else {
-      setStatus("expired", "That attention request was already resolved or the session changed.");
-    }
-  }
-}
+await refreshAndConnect();

--- a/apps/web/test/app.test.ts
+++ b/apps/web/test/app.test.ts
@@ -287,8 +287,8 @@ function session(
   };
 }
 
-async function settleUntil(predicate: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
+async function settleUntil(predicate: () => boolean, attempts = 20): Promise<void> {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
     if (predicate()) return;
     await Promise.resolve();
   }
@@ -510,6 +510,9 @@ async function bootApp(options: {
   await import(`../src/app.ts?${options.suffix}`);
   await settleUntil(() => notificationButton.textContent !== "Checking background alerts…");
   await settleUntil(() => FakeEventSource.instances.length === 1);
+  if (options.pathname?.startsWith("/collab/") === true) {
+    await settleUntil(() => statusBanner.dataset.kind === "expired", 100);
+  }
 
   return {
     elements: {

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,6 +20,9 @@
 #     in `apps/web/e2e`, which Bun does not instrument, so its line coverage here reflects only what
 #     the unit tests load. It is kept in the report rather than ignored, because excluding production
 #     code to improve a number is exactly the move this file exists to discourage.
+# Coverage runs in one Bun test worker. Bun 1.3.14 produced different app.ts line/source-map totals
+# across identical multi-worker runs, moving the project status by more than its regression budget;
+# two consecutive single-worker runs produced identical per-file totals without increasing runtime.
 
 coverage:
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -53,4 +53,10 @@ ignore:
   # known-bad source map into the project line regression.
   - "scripts/android-device.ts"
   - "scripts/android-acceptance.ts"
+  # Published-byte post-release and View/Control harnesses are also external-effect physical lanes.
+  # Their owned-target, redaction, identity-binding, and cleanup contracts have focused unit tests,
+  # while the complete host/device transition is exercised as a release gate. Counting the unmocked
+  # orchestration body as unit-test debt would make the project gate measure hardware availability.
+  - "scripts/android-collab-smoke.ts"
+  - "scripts/post-release-smoke.ts"
   - "apps/web/e2e/**"

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -11,7 +11,7 @@
 
 The system is zero-effort per OMP session, not zero-effort to install. Initial Tailscale login, gateway installation, and OMP configuration happen once.
 
-Stock OMP does not provide automatic startup or authenticated registry publication. Beta operators
+Stock OMP does not provide automatic startup or authenticated registry publication. Stable operators
 must launch participating sessions with the versioned `omp-gateway-patched` executable; the route
 keeps the user's ordinary `omp` installation untouched and includes explicit provenance and
 rollback checks.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,10 +2,10 @@
 
 ## Pre-alpha, alpha, beta, and stable artifacts
 
-The repository can produce working Bun-runtime engineering candidates and advertised alpha, beta,
-and stable releases. v0.1.0-beta.1 remains the current qualified publication while the exact stable
-candidate is prepared. A bare v0.1.0 is the only stable tag shape and becomes GitHub Latest only
-after the release ledger records a GO decision for its signed predecessor.
+The repository produces working Bun-runtime engineering candidates and advertised alpha, beta,
+and stable releases. v0.1.0 is the current stable publication and GitHub Latest. Its support claim
+is bound to the signed predecessor and exact evidence in `STABLE_RELEASE.lock.json` and
+`RELEASE_STATUS.md`; generated artifacts never promote themselves.
 
 Stable 0.1 is a bounded support claim, not an expansion to platform families. It covers only the
 hosts, Android client, TUN-mode Tailscale Serve path, and exact patched OMP baseline recorded in
@@ -70,6 +70,55 @@ Mac qualification receives the archive SHA-256 already verified by the orchestra
 Prerequisites are `gh`, `cosign`, `adb`, the repository workflow secrets, one attached Pixel, and a mode-private `~/.scaleway-apikey` for the retained `omp-macqual-01` lease. Environment overrides are prefixed `OMP_STABLE_`; `--previous-tag` changes the exact rollback predecessor.
 
 The orchestrator refuses a dirty or unpublished branch, rejects changed candidate or receipt identity, and hash-guards `STABLE_RELEASE.lock.json` plus `docs/RELEASE_STATUS.md`. It never edits either file, creates a stable tag, or publishes a stable release. Ledger approval and stable publication remain separate maintainer effects after the receipt is reviewed.
+
+## Post-release local installation smoke
+
+After a stable release is public, run its published bytes on the configured local Darwin-arm64 Mac
+and the attached physical Android client. This is a post-publication install/upgrade smoke, not a
+second stable qualification run and not a substitute for `qualify:stable`.
+
+Prerequisites are Bun 1.3.14, `gh`, `cosign`, `git`, `shasum`, `tar`, `plutil`, `tailscale`, `tmux`,
+and `adb`; an attached supported Pixel; an existing private gateway config and publisher token; the
+configured Tailscale Serve origin; and the **OMP Sessions** WebAPK already installed for that exact
+origin. The Android qualification PIN stays in the documented macOS Keychain service.
+
+Zero, unauthorized, or ambiguous adb devices are refused before release download, host mutation, or
+fixture creation; set `OMP_ANDROID_SERIAL` when more than one authorized device is attached.
+
+For v0.1.0, run:
+
+```sh
+bunx bun@1.3.14 run smoke:release -- \
+  --tag v0.1.0 \
+  --archive-sha256 925957ab636eb611649bafb3b6bac85061eefd3127dd756a9377123333eda262
+```
+
+The command verifies the annotated tag, GitHub Latest state, all six release asset digests,
+`SHA256SUMS`, three GitHub attestations, three Sigstore bundles, archive source metadata, the hashed
+PWA asset, and the exact OMP/Bun pins. It then installs or verifies the stable gateway through the
+persistent pinned Bun runtime, proves the config and publisher token remained byte-identical,
+creates only the configured Serve mapping while comparing every unrelated mapping, and requires all
+`doctor` checks to pass.
+
+The OMP lane reuses an already exact source/runtime or builds the archived patch and pins without
+deleting a changed checkout. It starts one uniquely named `omp-post-release-*` tmux fixture carrying
+only the synthetic qualification credential, then runs physical View-to-Control prompt/interrupt,
+forbidden-sink, lock/Airplane/Doze same-page recovery, and installed-WebAPK launch checks. Target
+eligibility is checked before touching the device; protected, soak, old, missing, ambiguous, or
+non-Control fixtures fail closed.
+
+Normal success and failure kill only that tmux session, wait for registry revocation, remove the
+fixture only when its per-run ownership marker still matches, and delete private staging. The stable
+gateway, config/token, Bun runtime, exact patched OMP source/binary/symlink, Serve configuration, and
+WebAPK remain installed. `--force-reinstall` retests an already active stable gateway;
+`--rebuild-omp` rebuilds only an already exact source/runtime. `--plan` prints the bounded effects
+without network, service, Tailscale, OMP, or Android changes.
+
+If the orchestrator is killed before its `finally` cleanup runs, inspect tmux for the single
+`omp-post-release-*` name and require the matching
+`~/<label>/.omp-session-gateway-post-release-smoke` marker before killing or removing anything.
+Never wildcard-delete fixture directories or touch unrelated tmux sessions or Serve mappings.
+
 
 Before the real stable tag, rehearse the exact gh create/edit flags in a private repository. Require
 six assets in the draft and published states, prerelease/not-Latest for the prerelease control,

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -167,4 +167,8 @@ Initial targets, to revise with measurements:
 - version compatibility matrix recorded;
 - install/uninstall tested on every advertised OS;
 - no public-listener or Funnel configuration in defaults/examples;
+- after stable publication, run `bun run smoke:release` against the published digest on the configured
+  local Darwin-arm64 Mac and physical Android client; require exact asset/provenance binding,
+  config/token preservation, unrelated Serve preservation, View/Control, forbidden-sink,
+  same-page recovery, installed-WebAPK, revocation, and owned-fixture cleanup evidence;
 - documentation tells users how to revoke a lost phone and rotate the local token.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check:identifier-leaks": "bun scripts/check-identifier-leaks.ts",
     "release:build": "bun scripts/build-release.ts",
     "qualify:stable": "bun scripts/stable-qualification.ts",
+    "smoke:release": "bun scripts/post-release-smoke.ts",
     "qualify:relay-soak": "bun scripts/relay-soak.ts",
     "test:browser": "bun run build && bun scripts/test-browser.ts",
     "media:capture": "bun run build && bun scripts/media/capture-readme-media.ts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typecheck": "bun run --filter '*' typecheck",
     "build": "bun run --filter '@omp-session-gateway/web' build",
     "test": "bun test",
-    "test:coverage": "bun test --coverage --coverage-reporter=lcov",
+    "test:coverage": "bun test --coverage --coverage-reporter=lcov --parallel=1",
     "check:capability-leaks": "bun scripts/check-capability-leaks.ts",
     "check:identifier-leaks": "bun scripts/check-identifier-leaks.ts",
     "release:build": "bun scripts/build-release.ts",

--- a/scripts/android-collab-smoke.ts
+++ b/scripts/android-collab-smoke.ts
@@ -1,0 +1,224 @@
+import { isProtectedLabel, targetEligibility } from "./acceptance-target.ts";
+import { withAndroidChrome } from "./android-device.ts";
+
+const PROMPT_MARKER = "OMP_POST_RELEASE_ANDROID_CONTROL_SMOKE";
+const APP_ASSET_PATTERN = /^\/assets\/app\.[0-9a-f]+\.js$/u;
+
+export interface AndroidCollabSmokeOptions {
+  readonly origin: string;
+  readonly label: string;
+  readonly expectedAppAsset?: string;
+  readonly allowDisposableTarget: boolean;
+}
+
+export interface AndroidCollabSmokeResult {
+  readonly packageName: string;
+  readonly androidPackageVersion: string;
+  readonly appAsset: string;
+  readonly viewReadOnly: true;
+  readonly controlWritable: true;
+  readonly promptAccepted: true;
+  readonly returnedToDirectory: true;
+}
+interface SessionMetadata {
+  readonly cwdLabel: string;
+  readonly canView: boolean;
+  readonly canControl: boolean;
+  readonly startedAt?: string;
+}
+
+
+export function parseAndroidCollabSmokeArgs(argv: readonly string[]): AndroidCollabSmokeOptions {
+  const positional: string[] = [];
+  let expectedAppAsset: string | undefined;
+  let allowDisposableTarget = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]!;
+    if (value === "--disposable-target") {
+      allowDisposableTarget = true;
+      continue;
+    }
+    if (value === "--expected-app-asset") {
+      expectedAppAsset = argv[++index];
+      if (!expectedAppAsset) throw new Error("--expected-app-asset requires a path");
+      continue;
+    }
+    if (value.startsWith("--")) throw new Error(`unknown option: ${value}`);
+    positional.push(value);
+  }
+
+  if (positional.length !== 2) {
+    throw new Error(
+      "usage: bun scripts/android-collab-smoke.ts <origin> <disposable-label> [--expected-app-asset /assets/app.<hash>.js] [--disposable-target]",
+    );
+  }
+  const [origin, label] = positional as [string, string];
+  const parsedOrigin = new URL(origin);
+  if (parsedOrigin.protocol !== "https:" || parsedOrigin.pathname !== "/" || parsedOrigin.search || parsedOrigin.hash) {
+    throw new Error("origin must be an HTTPS origin without a path, query, or fragment");
+  }
+  if (isProtectedLabel(label)) throw new Error("refusing protected or soak target label");
+  if (expectedAppAsset !== undefined && !APP_ASSET_PATTERN.test(expectedAppAsset)) {
+    throw new Error("expected app asset must be a hashed /assets/app.*.js path");
+  }
+
+  return {
+    origin: parsedOrigin.origin,
+    label,
+    ...(expectedAppAsset === undefined ? {} : { expectedAppAsset }),
+    allowDisposableTarget,
+  };
+}
+
+async function assertEligibleTarget(options: AndroidCollabSmokeOptions): Promise<void> {
+  const response = await fetch(`${options.origin}/api/v1/sessions`, {
+    cache: "no-store",
+    credentials: "omit",
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) throw new Error(`session-list preflight failed with HTTP ${response.status}`);
+  const payload = (await response.json()) as { sessions?: SessionMetadata[] };
+  const matches = (payload.sessions ?? []).filter(session => session.cwdLabel === options.label);
+  if (matches.length !== 1) throw new Error(`expected exactly one disposable target; found ${matches.length}`);
+  const target = matches[0]!;
+  if (!target.canView || !target.canControl) throw new Error("disposable target lacks View or Control capability");
+  const eligibility = targetEligibility(options.label, target.startedAt, Date.now(), options.allowDisposableTarget);
+  if (!eligibility.eligible) throw new Error(eligibility.reason ?? "disposable target is ineligible");
+}
+
+async function pause(milliseconds: number): Promise<void> {
+  await new Promise<void>(resolve => setTimeout(resolve, milliseconds));
+}
+
+export async function runAndroidCollabSmoke(options: AndroidCollabSmokeOptions): Promise<AndroidCollabSmokeResult> {
+  await assertEligibleTarget(options);
+
+  return withAndroidChrome(async driver => {
+    await driver.openTab();
+    await driver.navigate(`${options.origin}/`);
+
+    const waitFor = async (name: string, expression: string, attempts = 60): Promise<void> => {
+      for (let attempt = 0; attempt < attempts; attempt += 1) {
+        if (await driver.evaluate<boolean>(expression).catch(() => false)) return;
+        await pause(500);
+      }
+      throw new Error(`${name} did not become ready`);
+    };
+
+    const quotedLabel = JSON.stringify(options.label);
+    await waitFor(
+      "directory target",
+      `Boolean([...document.querySelectorAll("button[aria-label]")].find(button => button.getAttribute("aria-label") === "View " + ${quotedLabel}))`,
+    );
+
+    const appAsset = await driver.evaluate<string | null>(
+      `performance.getEntriesByType("resource").map(entry => new URL(entry.name).pathname).find(path => /^\\/assets\\/app\\.[0-9a-f]+\\.js$/.test(path)) ?? null`,
+    );
+    if (appAsset === null || !APP_ASSET_PATTERN.test(appAsset)) throw new Error("hashed app asset was not loaded");
+    if (options.expectedAppAsset !== undefined && appAsset !== options.expectedAppAsset) {
+      throw new Error("installed app asset does not match the release archive");
+    }
+
+    const openedView = await driver.evaluate<boolean>(`(() => {
+      const button = [...document.querySelectorAll("button[aria-label]")].find(
+        candidate => candidate.getAttribute("aria-label") === "View " + ${quotedLabel},
+      );
+      if (!(button instanceof HTMLButtonElement)) return false;
+      button.click();
+      return true;
+    })()`);
+    if (!openedView) throw new Error("View action was unavailable");
+
+    await waitFor(
+      "View collaboration shell",
+      `location.pathname === "/client/" && document.querySelector(".conn-chip")?.dataset.state === "connected" && document.querySelector(".sh-composer-input") instanceof HTMLTextAreaElement`,
+      120,
+    );
+    const view = await driver.evaluate<{ readOnly: boolean; controlVisible: boolean; rootMounted: boolean }>(`(() => {
+      const editor = document.querySelector(".sh-composer-input");
+      const control = document.querySelector(".shell-control");
+      return {
+        readOnly: editor instanceof HTMLTextAreaElement && editor.disabled && editor.placeholder === "read-only session — watching only",
+        controlVisible: control instanceof HTMLButtonElement && !control.hidden,
+        rootMounted: document.querySelector("#root[role=application]") !== null,
+      };
+    })()`);
+    if (!view.readOnly || !view.controlVisible || !view.rootMounted) throw new Error("View did not remain read-only");
+
+    const upgraded = await driver.evaluate<boolean>(`(() => {
+      const control = document.querySelector(".shell-control");
+      if (!(control instanceof HTMLButtonElement) || control.hidden) return false;
+      control.click();
+      return true;
+    })()`);
+    if (!upgraded) throw new Error("Control upgrade action was unavailable");
+
+    await waitFor(
+      "Control collaboration shell",
+      `document.querySelector(".conn-chip")?.dataset.state === "connected" && document.querySelector(".shell-control")?.hidden === true && document.querySelector(".sh-composer-input") instanceof HTMLTextAreaElement && !document.querySelector(".sh-composer-input").disabled`,
+      120,
+    );
+    const control = await driver.evaluate<{ writable: boolean; sendInitiallyDisabled: boolean }>(`(() => {
+      const editor = document.querySelector(".sh-composer-input");
+      const send = document.querySelector('button[title="send (Enter)"]');
+      return {
+        writable: editor instanceof HTMLTextAreaElement && !editor.disabled && editor.placeholder === "prompt the host agent…",
+        sendInitiallyDisabled: send instanceof HTMLButtonElement && send.disabled,
+      };
+    })()`);
+    if (!control.writable || !control.sendInitiallyDisabled) throw new Error("Control composer was not writable");
+
+    const drafted = await driver.evaluate<boolean>(`(() => {
+      const editor = document.querySelector(".sh-composer-input");
+      if (!(editor instanceof HTMLTextAreaElement)) return false;
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      if (!setter) return false;
+      setter.call(editor, ${JSON.stringify(PROMPT_MARKER)});
+      editor.dispatchEvent(new Event("input", { bubbles: true }));
+      return true;
+    })()`);
+    if (!drafted) throw new Error("Control prompt could not be drafted");
+    await waitFor("Control send", `document.querySelector('button[title="send (Enter)"]')?.disabled === false`);
+    const sent = await driver.evaluate<boolean>(`(() => {
+      const send = document.querySelector('button[title="send (Enter)"]');
+      if (!(send instanceof HTMLButtonElement) || send.disabled) return false;
+      send.click();
+      return true;
+    })()`);
+    if (!sent) throw new Error("Control prompt could not be sent");
+    await waitFor("Control prompt acceptance", `document.body.innerText.includes(${JSON.stringify(PROMPT_MARKER)})`, 60);
+
+    await driver.evaluate(`(() => {
+      const stop = document.querySelector(".sh-btn-stop");
+      if (stop instanceof HTMLButtonElement && !stop.disabled) stop.click();
+    })()`);
+
+    const returned = await driver.evaluate<boolean>(`(() => {
+      const back = document.querySelector(".shell-back");
+      if (!(back instanceof HTMLButtonElement)) return false;
+      back.click();
+      return true;
+    })()`);
+    if (!returned) throw new Error("Sessions return action was unavailable");
+    await waitFor(
+      "directory return",
+      `location.pathname === "/" && Boolean([...document.querySelectorAll("button[aria-label]")].find(button => button.getAttribute("aria-label") === "View " + ${quotedLabel}))`,
+    );
+
+    return {
+      packageName: driver.packageName,
+      androidPackageVersion: driver.androidPackageVersion,
+      appAsset,
+      viewReadOnly: true,
+      controlWritable: true,
+      promptAccepted: true,
+      returnedToDirectory: true,
+    };
+  });
+}
+
+if (import.meta.main) {
+  const result = await runAndroidCollabSmoke(parseAndroidCollabSmokeArgs(process.argv.slice(2)));
+  console.log(JSON.stringify(result, null, 2));
+}

--- a/scripts/android-device.test.ts
+++ b/scripts/android-device.test.ts
@@ -13,7 +13,7 @@ import {
   wakeAndroidChrome,
 } from "./android-device.ts";
 describe("Android directory recovery observation", () => {
-  test("reads rendered recovery state without issuing a competing fetch", () => {
+  test("accepts a rendered target alongside unrelated sessions without issuing a competing fetch", () => {
     let fetchCalls = 0;
     const evaluate = new Function(
       "document",
@@ -36,7 +36,7 @@ describe("Android directory recovery observation", () => {
       {
         visibilityState: "visible",
         querySelector: () => status,
-        querySelectorAll: () => ({ length: 1 }),
+        querySelectorAll: () => ({ length: 3 }),
       },
       { onLine: false },
       { timeOrigin: 123_456, getEntriesByType: () => [{ name: "https://sessions.example/assets/app.abc123.js" }] },
@@ -52,7 +52,7 @@ describe("Android directory recovery observation", () => {
       visibility: "visible",
       statusHidden: true,
       statusKind: "ready",
-      sessionCount: 1,
+      sessionCount: 3,
       appAsset: "https://sessions.example/assets/app.abc123.js",
       pageTimeOrigin: 123_456,
       directoryReady: true,

--- a/scripts/android-device.ts
+++ b/scripts/android-device.ts
@@ -147,7 +147,7 @@ export function captureAndroidDirectorySurface(
         .map(entry => entry.name)
         .find(name => /\/assets\/app[.][0-9a-f]+[.]js$/u.test(name)) ?? null,
     pageTimeOrigin: pagePerformance.timeOrigin,
-    directoryReady: pageDocument.visibilityState === "visible" && statusHidden && sessionCount === 1,
+    directoryReady: pageDocument.visibilityState === "visible" && statusHidden && sessionCount >= 1,
     outageVisible:
       !statusHidden && ["offline", "tailnet", "desktop", "gateway"].includes(statusKind ?? ""),
   };

--- a/scripts/android-leak-sweep.ts
+++ b/scripts/android-leak-sweep.ts
@@ -17,6 +17,7 @@
  * Usage: `bun scripts/android-leak-sweep.ts <origin> <session-cwd-label>`
  */
 import { withAndroidChrome, type AndroidChromeDriver } from "./android-device.ts";
+import { isProtectedLabel, targetEligibility } from "./acceptance-target.ts";
 
 /** Sinks the sweep inspects. The control must be able to plant and detect every one. */
 const SINKS = [
@@ -225,10 +226,22 @@ function extract<T>(evaluation: Record<string, unknown>): T {
 
 const origin = process.argv[2];
 const label = process.argv[3];
-if (!origin || !label) {
-  console.error("usage: bun scripts/android-leak-sweep.ts <origin> <session-cwd-label>");
+const allowDisposableTarget = process.argv[4] === "--disposable-target";
+if (!origin || !label || process.argv.length > 5 || (process.argv[4] !== undefined && !allowDisposableTarget)) {
+  console.error("usage: bun scripts/android-leak-sweep.ts <origin> <session-cwd-label> [--disposable-target]");
   process.exit(2);
 }
+if (isProtectedLabel(label)) throw new Error("refusing protected or soak target label");
+const targetResponse = await fetch(origin + "/api/v1/sessions", { cache: "no-store", credentials: "omit" });
+if (!targetResponse.ok) throw new Error("session-list preflight failed with HTTP " + targetResponse.status);
+const targetPayload = (await targetResponse.json()) as {
+  sessions?: Array<{ cwdLabel: string; startedAt?: string; canView: boolean }>;
+};
+const targetMatches = (targetPayload.sessions ?? []).filter(session => session.cwdLabel === label);
+if (targetMatches.length !== 1) throw new Error("expected exactly one disposable target; found " + targetMatches.length);
+if (targetMatches[0]!.canView !== true) throw new Error("disposable target lacks View capability");
+const eligibility = targetEligibility(label, targetMatches[0]!.startedAt, Date.now(), allowDisposableTarget);
+if (!eligibility.eligible) throw new Error(eligibility.reason ?? "disposable target is ineligible");
 
 const { control, sweep, serial, browser } = await withAndroidChrome(async driver => {
   const browserVersion = await driver.version();

--- a/scripts/post-release-smoke.test.ts
+++ b/scripts/post-release-smoke.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "bun:test";
+import { isProtectedLabel } from "./acceptance-target.ts";
+import { parseAndroidCollabSmokeArgs } from "./android-collab-smoke.ts";
+import {
+  assertFixtureOwnership,
+  assertWebApkActiveTask,
+  assertReleaseArchiveIdentity,
+  createSmokeLabel,
+  findWebApkForHost,
+  formatCommandFailure,
+  parsePostReleaseSmokeArgs,
+  releaseAssetNames,
+  unrelatedServeSnapshot,
+  selectAdbDevice,
+} from "./post-release-smoke.ts";
+
+const SOURCE_COMMIT = "07ba8be884c268375890d50b1a6af51f22bdb16a";
+const ARCHIVE_SHA256 = "a".repeat(64);
+
+describe("post-release smoke arguments", () => {
+  test("defaults to the package's bare stable tag and accepts bounded rerun controls", () => {
+    expect(parsePostReleaseSmokeArgs([], "0.1.0")).toEqual({
+      tag: "v0.1.0",
+      repository: "alphastorm/omp-session-gateway",
+      forceReinstall: false,
+      rebuildOmp: false,
+      planOnly: false,
+    });
+    expect(
+      parsePostReleaseSmokeArgs(
+        [
+          "--tag",
+          "v0.1.0",
+          "--repo",
+          "alphastorm/omp-session-gateway",
+          "--archive-sha256",
+          ARCHIVE_SHA256,
+          "--force-reinstall",
+          "--rebuild-omp",
+          "--plan",
+        ],
+        "0.1.0",
+      ),
+    ).toEqual({
+      tag: "v0.1.0",
+      repository: "alphastorm/omp-session-gateway",
+      expectedArchiveSha256: ARCHIVE_SHA256,
+      forceReinstall: true,
+      rebuildOmp: true,
+      planOnly: true,
+    });
+  });
+
+  test("rejects prereleases, mismatched versions, malformed digests, and unknown options", () => {
+    expect(() => parsePostReleaseSmokeArgs(["--tag", "v0.1.0-beta.1"], "0.1.0")).toThrow("bare stable tag");
+    expect(() => parsePostReleaseSmokeArgs(["--tag", "v0.2.0"], "0.1.0")).toThrow("package.json version");
+    expect(() => parsePostReleaseSmokeArgs(["--archive-sha256", "A".repeat(64)], "0.1.0")).toThrow(
+      "lowercase hexadecimal",
+    );
+    expect(() => parsePostReleaseSmokeArgs(["--skip-android"], "0.1.0")).toThrow("unknown option");
+  });
+});
+
+describe("published release binding", () => {
+  test("requires the exact six stable assets", () => {
+    const names = releaseAssetNames("0.1.0");
+    expect(names.archive).toBe("omp-session-gateway-0.1.0-bun.tar");
+    expect(names.sbom).toBe("omp-session-gateway-0.1.0.spdx.json");
+    expect(names.attested).toEqual([names.archive, names.sbom, "SHA256SUMS"]);
+    expect(names.all).toHaveLength(6);
+    expect(names.all).toContain("SHA256SUMS.sigstore.json");
+  });
+
+  test("binds archive identity to stable source, runtime, and qualification", () => {
+    const identity = {
+      product: "OMP Session Gateway",
+      version: "0.1.0",
+      sourceCommit: SOURCE_COMMIT,
+      runtime: "Bun >=1.3.14",
+      qualification: "qualified stable 0.1",
+    };
+    expect(() => assertReleaseArchiveIdentity(identity, "0.1.0", SOURCE_COMMIT, "1.3.14")).not.toThrow();
+    expect(() => assertReleaseArchiveIdentity({ ...identity, sourceCommit: "0".repeat(40) }, "0.1.0", SOURCE_COMMIT, "1.3.14")).toThrow(
+      "does not match",
+    );
+    expect(() => assertReleaseArchiveIdentity({ ...identity, runtime: "Bun >=1.4.0" }, "0.1.0", SOURCE_COMMIT, "1.3.14")).toThrow(
+      "does not match",
+    );
+  });
+
+  test("redacts command output unless the caller explicitly marks it safe", () => {
+    const syntheticSecret = "qualification-capability-never-log-this";
+    const redacted = formatCommandFailure("Android smoke", 1, syntheticSecret, "", false);
+    expect(redacted).toBe("Android smoke failed with exit 1");
+    expect(redacted).not.toContain(syntheticSecret);
+    expect(formatCommandFailure("artifact verification", 1, "", "signature mismatch", true)).toContain(
+      "signature mismatch",
+    );
+  });
+});
+
+describe("disposable fixture safety", () => {
+  test("generates an unprotected owned label", () => {
+    const label = createSmokeLabel("0.1.0", "deadbeef");
+    expect(label).toBe("omp-post-release-0-1-0-deadbeef");
+    expect(isProtectedLabel(label)).toBe(false);
+    expect(() => createSmokeLabel("0.1.0", "../unsafe")).toThrow("nonce");
+  });
+
+  test("requires the exact per-run marker before recursive cleanup", () => {
+    expect(() => assertFixtureOwnership("run-id\n", "run-id")).not.toThrow();
+    expect(() => assertFixtureOwnership("somebody-else\n", "run-id")).toThrow("refusing directory cleanup");
+  });
+
+  test("preserves every unrelated Tailscale Serve mapping", () => {
+    const baseline = {
+      TCP: { "443": { HTTPS: true }, "8443": { HTTPS: true } },
+      Web: {
+        "gateway.example.ts.net:443": { Handlers: { "/": { Proxy: "http://127.0.0.1:4317" } } },
+        "gateway.example.ts.net:8443": { Handlers: { "/": { Proxy: "http://127.0.0.1:14317" } } },
+      },
+    };
+    const replacedTarget = {
+      ...baseline,
+      TCP: { ...baseline.TCP, "443": { HTTPS: false } },
+      Web: {
+        ...baseline.Web,
+        "gateway.example.ts.net:443": { Handlers: { "/": { Proxy: "http://127.0.0.1:9999" } } },
+      },
+    };
+    expect(unrelatedServeSnapshot(replacedTarget, "gateway.example.ts.net", 443)).toBe(
+      unrelatedServeSnapshot(baseline, "gateway.example.ts.net", 443),
+    );
+    const changedUnrelated = {
+      ...baseline,
+      Web: {
+        ...baseline.Web,
+        "gateway.example.ts.net:8443": { Handlers: { "/": { Proxy: "http://127.0.0.1:9999" } } },
+      },
+    };
+    expect(unrelatedServeSnapshot(changedUnrelated, "gateway.example.ts.net", 443)).not.toBe(
+      unrelatedServeSnapshot(baseline, "gateway.example.ts.net", 443),
+    );
+  });
+});
+
+describe("physical Android release target", () => {
+  test("parses exact app binding and explicit old-fixture acknowledgement", () => {
+    expect(
+      parseAndroidCollabSmokeArgs([
+        "https://gateway.example.ts.net",
+        "omp-post-release-0-1-0-deadbeef",
+        "--expected-app-asset",
+        "/assets/app.abc123.js",
+        "--disposable-target",
+      ]),
+    ).toEqual({
+      origin: "https://gateway.example.ts.net",
+      label: "omp-post-release-0-1-0-deadbeef",
+      expectedAppAsset: "/assets/app.abc123.js",
+      allowDisposableTarget: true,
+    });
+  });
+
+  test("rejects protected targets and non-origin URLs before touching the device", () => {
+    expect(() => parseAndroidCollabSmokeArgs(["https://gateway.example.ts.net", "relay-soak", "--disposable-target"])).toThrow(
+      "protected",
+    );
+    expect(() => parseAndroidCollabSmokeArgs(["http://gateway.example.ts.net", "omp-disposable"])).toThrow("HTTPS origin");
+    expect(() => parseAndroidCollabSmokeArgs(["https://gateway.example.ts.net/path", "omp-disposable"])).toThrow(
+      "without a path",
+    );
+  });
+
+  test("finds one WebAPK bound to the exact gateway authority", () => {
+    const packages = ["package:org.chromium.webapk.owned_v2", "package:org.chromium.webapk.other_v2"].join("\n");
+    const dumps = {
+      "org.chromium.webapk.owned_v2": 'Authority: "gateway.example.ts.net": -1',
+      "org.chromium.webapk.other_v2": 'Authority: "other.example.ts.net": -1',
+    };
+    expect(findWebApkForHost(packages, dumps, "gateway.example.ts.net")).toBe("org.chromium.webapk.owned_v2");
+    expect(findWebApkForHost(packages, dumps, "missing.example.ts.net")).toBeUndefined();
+    expect(() =>
+      findWebApkForHost(
+        packages,
+        {
+          ...dumps,
+          "org.chromium.webapk.other_v2": 'Authority: "gateway.example.ts.net": -1',
+        },
+        "gateway.example.ts.net",
+      ),
+    ).toThrow("multiple installed WebAPKs");
+  });
+
+  test("refuses a missing or ambiguous adb device before release effects", () => {
+    const oneDevice = "List of devices attached\nPIXEL_SERIAL\tdevice product:pixel model:Pixel transport_id:1\n";
+    expect(selectAdbDevice(oneDevice)).toBe("PIXEL_SERIAL");
+    expect(selectAdbDevice(oneDevice, "PIXEL_SERIAL")).toBe("PIXEL_SERIAL");
+    expect(() => selectAdbDevice("List of devices attached\n\n")).toThrow("exactly one attached");
+    expect(() =>
+      selectAdbDevice("List of devices attached\nFIRST\tdevice\nSECOND\tdevice\n"),
+    ).toThrow("exactly one attached");
+    expect(() => selectAdbDevice(oneDevice, "OTHER_SERIAL")).toThrow("configured Android device");
+  });
+
+  test("requires the exact WebAPK to own the focused standalone task", () => {
+    const packageName = "org.chromium.webapk.owned_v2";
+    const active = [
+      "topResumedActivity=ActivityRecord{abc u0 com.android.chrome/SameTaskWebApkActivity t1}",
+      "topDisplayFocusedRootTask=Task{abc A=10466:" + packageName + "}",
+    ].join("\n");
+    expect(() => assertWebApkActiveTask(active, packageName)).not.toThrow();
+    expect(() => assertWebApkActiveTask("topResumedActivity=com.android.chrome/Main", packageName)).toThrow(
+      "active standalone task",
+    );
+  });
+});

--- a/scripts/post-release-smoke.ts
+++ b/scripts/post-release-smoke.ts
@@ -1,0 +1,1123 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import { spawn } from "node:child_process";
+import {
+  chmod,
+  copyFile,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { createServer } from "node:net";
+import { fileURLToPath } from "node:url";
+import { defaultGatewayPaths, loadGatewayConfig } from "../apps/gateway/src/config.ts";
+import { parseQualificationPins, type OmpPins } from "./stable-qualification.ts";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_REPOSITORY = "alphastorm/omp-session-gateway";
+const COMMAND_OUTPUT_LIMIT = 4 * 1024 * 1024;
+const STABLE_TAG_PATTERN = /^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/u;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u;
+
+interface PackageManifest {
+  readonly version: string;
+  readonly packageManager: string;
+}
+
+export interface PostReleaseSmokeOptions {
+  readonly tag: string;
+  readonly repository: string;
+  readonly expectedArchiveSha256?: string;
+  readonly forceReinstall: boolean;
+  readonly rebuildOmp: boolean;
+  readonly planOnly: boolean;
+}
+
+export interface ReleaseAssetNames {
+  readonly archive: string;
+  readonly sbom: string;
+  readonly checksums: "SHA256SUMS";
+  readonly all: readonly string[];
+  readonly attested: readonly string[];
+}
+
+interface CommandOptions {
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly timeoutMs?: number;
+  readonly allowedExitCodes?: readonly number[];
+  readonly safeFailureOutput?: boolean;
+}
+
+interface CommandResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+interface VerifiedRelease {
+  readonly version: string;
+  readonly sourceCommit: string;
+  readonly archiveSha256: string;
+  readonly archiveRoot: string;
+  readonly appAsset: string;
+  readonly pins: OmpPins;
+}
+
+interface ServeStatus {
+  readonly TCP?: Readonly<Record<string, unknown>>;
+  readonly Web?: Readonly<Record<string, unknown>>;
+  readonly [key: string]: unknown;
+}
+
+interface OmpInstall {
+  readonly exact: boolean;
+  readonly sourceExists: boolean;
+  readonly versionDirectoryExists: boolean;
+  readonly sourceExact: boolean;
+  readonly runtimeExact: boolean;
+  readonly sourceDirectory: string;
+  readonly versionDirectory: string;
+  readonly binary: string;
+  readonly symlink: string;
+  readonly binarySha256?: string;
+}
+
+interface PublishedSession {
+  readonly cwdLabel?: string;
+  readonly instanceId?: string;
+  readonly generation?: number;
+  readonly canView?: boolean;
+  readonly canControl?: boolean;
+}
+
+interface FixtureHandle {
+  readonly label: string;
+  readonly runId: string;
+  readonly directory: string;
+  readonly marker: string;
+  published: boolean;
+  tmuxStarted: boolean;
+}
+
+export function releaseAssetNames(version: string): ReleaseAssetNames {
+  if (!/^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/u.test(version)) {
+    throw new Error("release version must be bare SemVer");
+  }
+  const archive = `omp-session-gateway-${version}-bun.tar`;
+  const sbom = `omp-session-gateway-${version}.spdx.json`;
+  const checksums = "SHA256SUMS" as const;
+  const attested = [archive, sbom, checksums];
+  return {
+    archive,
+    sbom,
+    checksums,
+    attested,
+    all: [...attested, ...attested.map(name => `${name}.sigstore.json`)].sort(),
+  };
+}
+
+export function parsePostReleaseSmokeArgs(
+  argv: readonly string[],
+  packageVersion: string,
+): PostReleaseSmokeOptions {
+  let tag = `v${packageVersion}`;
+  let repository = DEFAULT_REPOSITORY;
+  let expectedArchiveSha256: string | undefined;
+  let forceReinstall = false;
+  let rebuildOmp = false;
+  let planOnly = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]!;
+    if (value === "--tag") {
+      tag = argv[++index] ?? "";
+    } else if (value === "--repo") {
+      repository = argv[++index] ?? "";
+    } else if (value === "--archive-sha256") {
+      expectedArchiveSha256 = argv[++index] ?? "";
+    } else if (value === "--force-reinstall") {
+      forceReinstall = true;
+    } else if (value === "--rebuild-omp") {
+      rebuildOmp = true;
+    } else if (value === "--plan") {
+      planOnly = true;
+    } else {
+      throw new Error(`unknown option: ${value}`);
+    }
+  }
+
+  const match = STABLE_TAG_PATTERN.exec(tag);
+  if (!match) throw new Error("post-release smoke accepts only a bare stable tag such as v0.1.0");
+  if (tag !== `v${packageVersion}`) throw new Error("tag must match package.json version");
+  if (!REPOSITORY_PATTERN.test(repository)) throw new Error("repository must be owner/name");
+  if (expectedArchiveSha256 !== undefined && !SHA256_PATTERN.test(expectedArchiveSha256)) {
+    throw new Error("--archive-sha256 must be 64 lowercase hexadecimal characters");
+  }
+
+  return {
+    tag,
+    repository,
+    ...(expectedArchiveSha256 === undefined ? {} : { expectedArchiveSha256 }),
+    forceReinstall,
+    rebuildOmp,
+    planOnly,
+  };
+}
+
+export function createSmokeLabel(version: string, nonce: string): string {
+  if (!/^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/u.test(version)) {
+    throw new Error("smoke label version must be bare SemVer");
+  }
+  if (!/^[a-z0-9]{8}$/u.test(nonce)) throw new Error("smoke label nonce must be eight lowercase alphanumeric characters");
+  return `omp-post-release-${version.replaceAll(".", "-")}-${nonce}`;
+}
+
+export function formatCommandFailure(
+  name: string,
+  exitCode: number,
+  stdout: string,
+  stderr: string,
+  includeSafeOutput: boolean,
+): string {
+  const detail = includeSafeOutput ? `: ${(stderr || stdout).trim().slice(-2_000)}` : "";
+  return `${name} failed with exit ${exitCode}${detail}`;
+}
+
+export function assertReleaseArchiveIdentity(
+  releaseInfo: Readonly<Record<string, unknown>>,
+  version: string,
+  sourceCommit: string,
+  bunVersion: string,
+): void {
+  if (
+    releaseInfo.version !== version ||
+    releaseInfo.sourceCommit !== sourceCommit ||
+    releaseInfo.product !== "OMP Session Gateway" ||
+    releaseInfo.runtime !== `Bun >=${bunVersion}` ||
+    typeof releaseInfo.qualification !== "string" ||
+    !releaseInfo.qualification.startsWith("qualified stable")
+  ) {
+    throw new Error("release archive identity does not match the stable tag");
+  }
+}
+
+export function assertFixtureOwnership(actualMarker: string, runId: string): void {
+  if (actualMarker !== `${runId}\n`) {
+    throw new Error("smoke fixture ownership marker changed; refusing directory cleanup");
+  }
+}
+
+export function selectAdbDevice(devicesOutput: string, requestedSerial?: string): string {
+  const devices = devicesOutput
+    .split(/\r?\n/u)
+    .slice(1)
+    .map(line => line.trim().split(/\s+/u))
+    .filter((fields): fields is [string, string, ...string[]] => fields.length >= 2 && fields[1] === "device");
+  if (requestedSerial !== undefined) {
+    if (!devices.some(([serial]) => serial === requestedSerial)) {
+      throw new Error("configured Android device is not attached and authorized");
+    }
+    return requestedSerial;
+  }
+  if (devices.length !== 1) throw new Error("post-release smoke requires exactly one attached and authorized Android device");
+  return devices[0]![0];
+}
+
+export function assertWebApkActiveTask(activities: string, packageName: string): void {
+  const activityLines = activities.split(/\r?\n/u);
+  const focusedTask = activityLines.some(
+    line => line.includes("topDisplayFocusedRootTask=") && line.includes(`:${packageName}`),
+  );
+  const resumedWebApk = activityLines.some(
+    line => line.includes("topResumedActivity=") && line.includes("SameTaskWebApkActivity"),
+  );
+  if (!focusedTask || !resumedWebApk) throw new Error("installed WebAPK did not become the active standalone task");
+}
+
+function hashBytes(value: Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function sha256File(path: string): Promise<string> {
+  return hashBytes(await readFile(path));
+}
+
+
+async function runCommand(name: string, command: readonly string[], options: CommandOptions = {}): Promise<CommandResult> {
+  const [executable, ...arguments_] = command;
+  if (executable === undefined) throw new Error(`${name} command was empty`);
+  const environment = Object.fromEntries(
+    Object.entries({ ...process.env, ...options.env }).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
+  const child = spawn(executable, arguments_, {
+    cwd: options.cwd ?? repositoryRoot,
+    env: environment,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  let outputBytes = 0;
+  let outputExceeded = false;
+  const append = (chunks: Buffer[], chunk: Buffer): void => {
+    outputBytes += chunk.length;
+    if (outputBytes > COMMAND_OUTPUT_LIMIT) {
+      outputExceeded = true;
+      child.kill("SIGTERM");
+      return;
+    }
+    chunks.push(chunk);
+  };
+  child.stdout.on("data", (chunk: Buffer) => append(stdoutChunks, chunk));
+  child.stderr.on("data", (chunk: Buffer) => append(stderrChunks, chunk));
+
+  const timeoutMs = options.timeoutMs ?? 120_000;
+  let timedOut = false;
+  let forceTimeout: ReturnType<typeof setTimeout> | undefined;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    child.kill("SIGTERM");
+    forceTimeout = setTimeout(() => child.kill("SIGKILL"), 2_000);
+  }, timeoutMs);
+  try {
+    const exitCode = await new Promise<number>((resolveExit, rejectExit) => {
+      child.once("error", rejectExit);
+      child.once("close", code => resolveExit(code ?? 1));
+    });
+    const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+    const stderr = Buffer.concat(stderrChunks).toString("utf8");
+    if (outputExceeded) throw new Error(`${name} output exceeded the safety limit`);
+    if (timedOut) throw new Error(`${name} timed out`);
+    if (!(options.allowedExitCodes ?? [0]).includes(exitCode)) {
+      throw new Error(formatCommandFailure(name, exitCode, stdout, stderr, options.safeFailureOutput === true));
+    }
+    return { stdout, stderr, exitCode };
+  } finally {
+    clearTimeout(timeout);
+    if (forceTimeout !== undefined) clearTimeout(forceTimeout);
+  }
+}
+
+async function commandOutput(name: string, command: readonly string[], options: CommandOptions = {}): Promise<string> {
+  return (await runCommand(name, command, options)).stdout.trim();
+}
+async function sleep(milliseconds: number): Promise<void> {
+  await new Promise<void>(resolveSleep => setTimeout(resolveSleep, milliseconds));
+}
+
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function parseJsonRecord(value: string, name: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(value);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) throw new Error(`${name} was not a JSON object`);
+  return parsed as Record<string, unknown>;
+}
+
+function assertExactNames(actual: readonly string[], expected: readonly string[], name: string): void {
+  const left = [...actual].sort();
+  const right = [...expected].sort();
+  if (left.length !== right.length || left.some((value, index) => value !== right[index])) {
+    throw new Error(`${name} did not contain the exact expected files`);
+  }
+}
+
+async function verifyPublishedRelease(
+  options: PostReleaseSmokeOptions,
+  staging: string,
+  packageManifest: PackageManifest,
+): Promise<VerifiedRelease> {
+  const version = options.tag.slice(1);
+  const names = releaseAssetNames(version);
+  const downloadDirectory = join(staging, "release");
+  await mkdir(downloadDirectory, { mode: 0o700 });
+  await runCommand(
+    "release download",
+    ["gh", "release", "download", options.tag, "--repo", options.repository, "--dir", downloadDirectory],
+    { timeoutMs: 300_000, safeFailureOutput: true },
+  );
+  assertExactNames(await readdir(downloadDirectory), names.all, "published release");
+
+  await runCommand("release checksums", ["shasum", "-a", "256", "-c", names.checksums], {
+    cwd: downloadDirectory,
+    safeFailureOutput: true,
+  });
+
+  const release = parseJsonRecord(
+    await commandOutput("release metadata", ["gh", "api", `repos/${options.repository}/releases/tags/${options.tag}`], {
+      safeFailureOutput: true,
+    }),
+    "release metadata",
+  );
+  if (release.tag_name !== options.tag || release.draft !== false || release.prerelease !== false) {
+    throw new Error("published release is not the requested stable release");
+  }
+  const latest = parseJsonRecord(
+    await commandOutput("latest release metadata", ["gh", "api", `repos/${options.repository}/releases/latest`], {
+      safeFailureOutput: true,
+    }),
+    "latest release metadata",
+  );
+  if (latest.tag_name !== options.tag) throw new Error("published stable tag is not GitHub Latest");
+
+  const assets = Array.isArray(release.assets) ? release.assets : [];
+  const assetDigests = new Map<string, string>();
+  for (const asset of assets) {
+    if (typeof asset !== "object" || asset === null || Array.isArray(asset)) continue;
+    const record = asset as Record<string, unknown>;
+    if (typeof record.name === "string" && typeof record.digest === "string") assetDigests.set(record.name, record.digest);
+  }
+  assertExactNames([...assetDigests.keys()], names.all, "release asset metadata");
+  for (const name of names.all) {
+    const localDigest = await sha256File(join(downloadDirectory, name));
+    if (assetDigests.get(name) !== `sha256:${localDigest}`) throw new Error(`GitHub asset digest mismatch for ${name}`);
+  }
+
+  const workflow = `${options.repository}/.github/workflows/signed-release.yml`;
+  const certificateIdentity = `https://github.com/${workflow}@refs/tags/${options.tag}`;
+  for (const name of names.attested) {
+    await runCommand(
+      `GitHub attestation for ${name}`,
+      [
+        "gh",
+        "attestation",
+        "verify",
+        join(downloadDirectory, name),
+        "--repo",
+        options.repository,
+        "--signer-workflow",
+        workflow,
+        "--source-ref",
+        `refs/tags/${options.tag}`,
+      ],
+      { timeoutMs: 180_000, safeFailureOutput: true },
+    );
+    await runCommand(
+      `Sigstore bundle for ${name}`,
+      [
+        "cosign",
+        "verify-blob",
+        "--bundle",
+        join(downloadDirectory, `${name}.sigstore.json`),
+        "--certificate-identity",
+        certificateIdentity,
+        "--certificate-oidc-issuer",
+        "https://token.actions.githubusercontent.com",
+        join(downloadDirectory, name),
+      ],
+      { timeoutMs: 180_000, safeFailureOutput: true },
+    );
+  }
+
+  const localTagObject = await commandOutput("local stable tag", ["git", "rev-parse", `refs/tags/${options.tag}`]);
+  const remoteRef = parseJsonRecord(
+    await commandOutput("remote stable tag", ["gh", "api", `repos/${options.repository}/git/ref/tags/${options.tag}`], {
+      safeFailureOutput: true,
+    }),
+    "remote stable tag",
+  );
+  const remoteObject =
+    typeof remoteRef.object === "object" && remoteRef.object !== null && !Array.isArray(remoteRef.object)
+      ? (remoteRef.object as Record<string, unknown>)
+      : undefined;
+  if (remoteObject?.sha !== localTagObject || remoteObject.type !== "tag") {
+    throw new Error("local and GitHub annotated tag objects differ");
+  }
+  await runCommand("signed stable tag", ["git", "tag", "-v", options.tag], { safeFailureOutput: true });
+  const sourceCommit = await commandOutput("stable tag source", ["git", "rev-parse", `${options.tag}^{commit}`]);
+  await runCommand("stable tag ancestry", ["git", "merge-base", "--is-ancestor", sourceCommit, "origin/main"]);
+  const remoteTag = parseJsonRecord(
+    await commandOutput("remote annotated tag", ["gh", "api", `repos/${options.repository}/git/tags/${localTagObject}`], {
+      safeFailureOutput: true,
+    }),
+    "remote annotated tag",
+  );
+  const remoteTagTarget =
+    typeof remoteTag.object === "object" && remoteTag.object !== null && !Array.isArray(remoteTag.object)
+      ? (remoteTag.object as Record<string, unknown>)
+      : undefined;
+  const verification =
+    typeof remoteTag.verification === "object" && remoteTag.verification !== null && !Array.isArray(remoteTag.verification)
+      ? (remoteTag.verification as Record<string, unknown>)
+      : undefined;
+  if (remoteTagTarget?.sha !== sourceCommit || verification?.verified !== true) {
+    throw new Error("GitHub does not report the annotated stable tag as verified for the expected source");
+  }
+
+  const archivePath = join(downloadDirectory, names.archive);
+  const archiveSha256 = await sha256File(archivePath);
+  if (options.expectedArchiveSha256 !== undefined && archiveSha256 !== options.expectedArchiveSha256) {
+    throw new Error("archive digest does not match --archive-sha256");
+  }
+  const extractedDirectory = join(staging, "extracted");
+  await mkdir(extractedDirectory, { mode: 0o700 });
+  await runCommand("release extraction", ["tar", "-xf", archivePath, "-C", extractedDirectory], {
+    timeoutMs: 120_000,
+    safeFailureOutput: true,
+  });
+  const roots = await readdir(extractedDirectory);
+  if (roots.length !== 1) throw new Error("release archive did not contain exactly one root directory");
+  const archiveRoot = join(extractedDirectory, roots[0]!);
+  if (!(await stat(archiveRoot)).isDirectory()) throw new Error("release archive root is not a directory");
+
+  const releaseInfo = parseJsonRecord(await readFile(join(archiveRoot, "release-info.json"), "utf8"), "release-info.json");
+  assertReleaseArchiveIdentity(releaseInfo, version, sourceCommit, packageManifest.packageManager.replace(/^bun@/u, ""));
+  const assetFiles = await readdir(join(archiveRoot, "apps/web/dist/assets"));
+  const appAssets = assetFiles.filter(name => /^app\.[0-9a-f]+\.js$/u.test(name));
+  if (appAssets.length !== 1) throw new Error("release archive did not contain exactly one hashed app asset");
+  const appAsset = `/assets/${appAssets[0]!}`;
+  const pins = parseQualificationPins(await readFile(join(archiveRoot, "patches/oh-my-pi/qualification.env"), "utf8"));
+  const upstream = parseJsonRecord(await readFile(join(archiveRoot, "UPSTREAM.lock.json"), "utf8"), "UPSTREAM.lock.json");
+  if (
+    upstream.commit !== pins.sourceCommit ||
+    upstream.packageVersion !== pins.version ||
+    upstream.bunVersion !== pins.bunVersion ||
+    pins.bunVersion !== packageManifest.packageManager.replace(/^bun@/u, "")
+  ) {
+    throw new Error("release archive OMP and Bun pins disagree");
+  }
+
+  return { version, sourceCommit, archiveSha256, archiveRoot, appAsset, pins };
+}
+
+async function ensurePersistentBun(version: string): Promise<string> {
+  if (process.versions.bun !== version) {
+    throw new Error(`post-release smoke must run under Bun ${version}; received ${process.versions.bun}`);
+  }
+  const directory = join(homedir(), ".local", "lib", "omp-session-gateway", "bun", `v${version}`);
+  const executable = join(directory, "bun");
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  if (!(await pathExists(executable))) {
+    await copyFile(process.execPath, executable);
+    await chmod(executable, 0o755);
+  }
+  if ((await commandOutput("pinned Bun", [executable, "--version"])) !== version) {
+    throw new Error("persistent Bun executable does not match the release pin");
+  }
+  return executable;
+}
+
+async function capturePrivateFile(path: string, name: string): Promise<Buffer> {
+  const metadata = await lstat(path);
+  if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.uid !== process.getuid?.() || (metadata.mode & 0o077) !== 0) {
+    throw new Error(`${name} is not a private current-user regular file`);
+  }
+  return readFile(path);
+}
+
+function equalPrivateBytes(left: Buffer, right: Buffer): boolean {
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+async function installedReleaseMatches(version: string, sourceCommit: string): Promise<boolean> {
+  const installationRoot = join(defaultGatewayPaths().stateDir, "installation");
+  try {
+    const pointer = parseJsonRecord(await readFile(join(installationRoot, "current.json"), "utf8"), "current.json");
+    if (typeof pointer.versionDirectory !== "string") return false;
+    const releaseInfo = parseJsonRecord(
+      await readFile(join(installationRoot, "versions", pointer.versionDirectory, "release-info.json"), "utf8"),
+      "installed release-info.json",
+    );
+    return releaseInfo.version === version && releaseInfo.sourceCommit === sourceCommit;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function serviceUsesBun(executable: string): Promise<boolean> {
+  const plist = join(homedir(), "Library", "LaunchAgents", "omp-session-gateway.plist");
+  if (!(await pathExists(plist))) return false;
+  try {
+    return (
+      (await commandOutput("LaunchAgent runtime", ["plutil", "-extract", "ProgramArguments.0", "raw", plist])) === executable
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function installOrVerifyGateway(
+  options: PostReleaseSmokeOptions,
+  release: VerifiedRelease,
+  bunExecutable: string,
+): Promise<{ installed: boolean }> {
+  const config = await loadGatewayConfig();
+  if (config.auth.mode !== "tailscale-serve" || config.auth.allowedLogins.length === 0) {
+    throw new Error("post-release smoke requires an existing Tailscale Serve config with an exact login allowlist");
+  }
+  const paths = defaultGatewayPaths();
+  const configBefore = await capturePrivateFile(paths.configPath, "gateway config");
+  const tokenBefore = await capturePrivateFile(paths.tokenPath, "publisher token");
+  let installed = false;
+  try {
+    const currentMatches = await installedReleaseMatches(release.version, release.sourceCommit);
+    const runtimeMatches = await serviceUsesBun(bunExecutable);
+    if (options.forceReinstall || !currentMatches || !runtimeMatches) {
+      const command = [
+        bunExecutable,
+        join(release.archiveRoot, "apps/gateway/src/cli.js"),
+        "install",
+        "--origin",
+        config.http.publicOrigin,
+        "--port",
+        String(config.http.port),
+      ];
+      for (const login of config.auth.allowedLogins) command.push("--allow", login);
+      await runCommand("gateway install", command, { timeoutMs: 180_000 });
+      installed = true;
+    }
+
+    const configAfter = await capturePrivateFile(paths.configPath, "gateway config");
+    const tokenAfter = await capturePrivateFile(paths.tokenPath, "publisher token");
+    try {
+      if (!equalPrivateBytes(configBefore, configAfter)) throw new Error("gateway install changed the existing config bytes");
+      if (!equalPrivateBytes(tokenBefore, tokenAfter)) throw new Error("gateway install changed the publisher token bytes");
+    } finally {
+      configAfter.fill(0);
+      tokenAfter.fill(0);
+    }
+
+    const cli = join(release.archiveRoot, "apps/gateway/src/cli.js");
+    const status = parseJsonRecord(await commandOutput("gateway status", [bunExecutable, cli, "status"]), "gateway status");
+    if (status.installed !== true || status.active !== true || status.ready !== true || status.diverged !== false) {
+      throw new Error("installed gateway is not active, ready, and non-diverged");
+    }
+    if (!(await installedReleaseMatches(release.version, release.sourceCommit))) {
+      throw new Error("active gateway runtime does not match the stable release source");
+    }
+    if (!(await serviceUsesBun(bunExecutable))) throw new Error("LaunchAgent does not use the pinned persistent Bun executable");
+    return { installed };
+  } finally {
+    configBefore.fill(0);
+    tokenBefore.fill(0);
+  }
+}
+async function verifyGatewayDoctor(release: VerifiedRelease, bunExecutable: string): Promise<number> {
+  const cli = join(release.archiveRoot, "apps/gateway/src/cli.js");
+  const doctor = parseJsonRecord(
+    await commandOutput("gateway doctor", [bunExecutable, cli, "doctor"], { timeoutMs: 180_000 }),
+    "gateway doctor",
+  );
+  const checks =
+    typeof doctor.checks === "object" && doctor.checks !== null && !Array.isArray(doctor.checks)
+      ? Object.values(doctor.checks as Record<string, unknown>)
+      : [];
+  if (checks.length === 0 || checks.some(value => value !== true)) throw new Error("gateway doctor did not pass every check");
+  return checks.length;
+}
+
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => [key, sortJson(child)]),
+  );
+}
+
+export function unrelatedServeSnapshot(status: ServeStatus, host: string, port: number): string {
+  const copy = structuredClone(status) as Record<string, unknown>;
+  const tcp = typeof copy.TCP === "object" && copy.TCP !== null && !Array.isArray(copy.TCP) ? (copy.TCP as Record<string, unknown>) : undefined;
+  const web = typeof copy.Web === "object" && copy.Web !== null && !Array.isArray(copy.Web) ? (copy.Web as Record<string, unknown>) : undefined;
+  delete tcp?.[String(port)];
+  delete web?.[`${host}:${port}`];
+  return JSON.stringify(sortJson(copy));
+}
+
+function serveMappingMatches(status: ServeStatus, host: string, publicPort: number, target: string): boolean {
+  const tcp = status.TCP?.[String(publicPort)];
+  const web = status.Web?.[`${host}:${publicPort}`];
+  if (typeof tcp !== "object" || tcp === null || Array.isArray(tcp) || (tcp as Record<string, unknown>).HTTPS !== true) return false;
+  if (typeof web !== "object" || web === null || Array.isArray(web)) return false;
+  const handlers = (web as Record<string, unknown>).Handlers;
+  if (typeof handlers !== "object" || handlers === null || Array.isArray(handlers)) return false;
+  const root = (handlers as Record<string, unknown>)["/"];
+  return typeof root === "object" && root !== null && !Array.isArray(root) && (root as Record<string, unknown>).Proxy === target;
+}
+
+async function ensureServeMapping(): Promise<{ changed: boolean }> {
+  const config = await loadGatewayConfig();
+  const origin = new URL(config.http.publicOrigin);
+  const publicPort = origin.port === "" ? 443 : Number(origin.port);
+  const host = origin.hostname;
+  const target = `http://${config.http.hostname}:${config.http.port}`;
+  const before = JSON.parse(await commandOutput("Tailscale Serve status", ["tailscale", "serve", "status", "--json"])) as ServeStatus;
+  const unrelatedBefore = unrelatedServeSnapshot(before, host, publicPort);
+  let changed = false;
+  if (!serveMappingMatches(before, host, publicPort, target)) {
+    await runCommand("Tailscale Serve mapping", ["tailscale", "serve", "--bg", `--https=${publicPort}`, target], {
+      timeoutMs: 120_000,
+      safeFailureOutput: true,
+    });
+    changed = true;
+  }
+  const after = JSON.parse(await commandOutput("updated Tailscale Serve status", ["tailscale", "serve", "status", "--json"])) as ServeStatus;
+  if (!serveMappingMatches(after, host, publicPort, target)) throw new Error("Tailscale Serve mapping does not match the gateway config");
+  if (unrelatedServeSnapshot(after, host, publicPort) !== unrelatedBefore) {
+    throw new Error("Tailscale Serve changed an unrelated mapping");
+  }
+  return { changed };
+}
+
+async function inspectOmpInstall(pins: OmpPins): Promise<OmpInstall> {
+  const sourceDirectory = join(homedir(), "src", `oh-my-pi-gateway-v${pins.version}`);
+  const versionDirectory = join(
+    homedir(),
+    ".local",
+    "lib",
+    "omp-session-gateway",
+    "omp",
+    `v${pins.version}-${pins.patchedTree.slice(0, 8)}`,
+  );
+  const binary = join(versionDirectory, "omp");
+  const symlink = join(homedir(), ".local", "bin", "omp-gateway-patched");
+  const sourceExists = await pathExists(sourceDirectory);
+  const versionDirectoryExists = await pathExists(versionDirectory);
+  let sourceExact = false;
+  if (sourceExists) {
+    try {
+      const tree = await commandOutput("patched OMP tree", ["git", "-C", sourceDirectory, "rev-parse", "HEAD^{tree}"]);
+      const statusOutput = await commandOutput("patched OMP status", [
+        "git",
+        "-C",
+        sourceDirectory,
+        "status",
+        "--porcelain",
+        "--untracked-files=all",
+        "--",
+        ".",
+        ":(exclude)packages/natives/native/pi_natives.darwin-arm64.node",
+      ]);
+      const nativeSha256 = await sha256File(join(sourceDirectory, "packages/natives/native/pi_natives.darwin-arm64.node"));
+      sourceExact = tree === pins.patchedTree && statusOutput === "" && nativeSha256 === pins.nativeBinarySha256;
+    } catch {
+      sourceExact = false;
+    }
+  }
+
+  let runtimeExact = false;
+  let symlinkExact = false;
+  let settingsExact = false;
+  let binarySha256: string | undefined;
+  if (await pathExists(binary)) {
+    try {
+      const version = await commandOutput("patched OMP version", [binary, "--version"]);
+      runtimeExact = version === `omp/${pins.version}`;
+      binarySha256 = await sha256File(binary);
+      symlinkExact = (await readlink(symlink)) === binary;
+      const autoStart = parseJsonRecord(
+        await commandOutput("patched OMP auto-start", [binary, "config", "get", "collab.autoStart", "--json"]),
+        "OMP auto-start",
+      );
+      const registry = parseJsonRecord(
+        await commandOutput("patched OMP registry", [binary, "config", "get", "collab.registryEndpoint", "--json"]),
+        "OMP registry",
+      );
+      settingsExact = autoStart.value === "control" && registry.value === "auto";
+    } catch {
+      runtimeExact = false;
+    }
+  }
+  return {
+    exact: sourceExact && runtimeExact && symlinkExact && settingsExact,
+    sourceExists,
+    versionDirectoryExists,
+    sourceExact,
+    runtimeExact,
+    sourceDirectory,
+    versionDirectory,
+    binary,
+    symlink,
+    ...(binarySha256 === undefined ? {} : { binarySha256 }),
+  };
+}
+
+function qualificationEnvironment(
+  release: VerifiedRelease,
+  bunExecutable: string,
+  staging: string,
+  label: string,
+): Record<string, string> {
+  return {
+    OMP_QUAL_GATEWAY_ROOT: release.archiveRoot,
+    OMP_PIN_SOURCE_COMMIT: release.pins.sourceCommit,
+    OMP_PIN_PATCHED_TREE: release.pins.patchedTree,
+    OMP_PIN_VERSION: release.pins.version,
+    OMP_PIN_BUN_VERSION: release.pins.bunVersion,
+    OMP_PIN_NATIVE_TARBALL_SHA256: release.pins.nativeTarballSha256,
+    OMP_PIN_NATIVE_BINARY_SHA256: release.pins.nativeBinarySha256,
+    OMP_PIN_BUN_EXECUTABLE: bunExecutable,
+    OMP_QUAL_NATIVE_FIXTURE: join(staging, "native-fixture"),
+    OMP_QUAL_BUILD_LOG: join(staging, "omp-build.log"),
+    OMP_QUAL_SESSION_LABEL: label,
+  };
+}
+
+async function installOrVerifyOmp(
+  options: PostReleaseSmokeOptions,
+  release: VerifiedRelease,
+  bunExecutable: string,
+  staging: string,
+  label: string,
+): Promise<{ built: boolean; binarySha256: string }> {
+  let inspection = await inspectOmpInstall(release.pins);
+  let built = false;
+  if (options.rebuildOmp || !inspection.exact) {
+    if (inspection.sourceExists && !inspection.sourceExact) {
+      throw new Error(`refusing to replace changed or unverified patched OMP source at ${inspection.sourceDirectory}`);
+    }
+    if (inspection.versionDirectoryExists && !inspection.runtimeExact) {
+      throw new Error(`refusing to replace changed or unverified patched OMP runtime at ${inspection.versionDirectory}`);
+    }
+    await runCommand("patched OMP build", ["bash", join(repositoryRoot, "scripts/qualify-macos-omp.sh"), "build"], {
+      env: qualificationEnvironment(release, bunExecutable, staging, label),
+      timeoutMs: 1_800_000,
+      safeFailureOutput: true,
+    });
+    built = true;
+    inspection = await inspectOmpInstall(release.pins);
+  }
+  if (!inspection.exact || inspection.binarySha256 === undefined) throw new Error("patched OMP install does not match the release pins");
+  return { built, binarySha256: inspection.binarySha256 };
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+async function createFixture(version: string): Promise<FixtureHandle> {
+  const runId = randomBytes(16).toString("hex");
+  const label = createSmokeLabel(version, randomBytes(4).toString("hex"));
+  const directory = join(homedir(), label);
+  const marker = join(directory, ".omp-session-gateway-post-release-smoke");
+  if (await pathExists(directory)) throw new Error("generated smoke fixture directory already exists");
+  await mkdir(directory, { mode: 0o700 });
+  await writeFile(marker, `${runId}\n`, { mode: 0o600, flag: "wx" });
+  return { label, runId, directory, marker, published: false, tmuxStarted: false };
+}
+
+async function startFixture(
+  handle: FixtureHandle,
+  release: VerifiedRelease,
+  bunExecutable: string,
+  staging: string,
+): Promise<void> {
+  const environment = qualificationEnvironment(release, bunExecutable, staging, handle.label);
+  const launcher = join(staging, "launch-omp-smoke.sh");
+  const exports = Object.entries(environment).map(([name, value]) => `export ${name}=${shellQuote(value)}`);
+  await writeFile(
+    launcher,
+    ["#!/usr/bin/env bash", "set -euo pipefail", ...exports, `exec bash ${shellQuote(join(repositoryRoot, "scripts/qualify-macos-omp.sh"))} run`, ""].join("\n"),
+    { mode: 0o700, flag: "wx" },
+  );
+  await runCommand("tmux smoke fixture", [
+    "tmux",
+    "new-session",
+    "-d",
+    "-s",
+    handle.label,
+    "-c",
+    repositoryRoot,
+    `exec ${shellQuote(launcher)}`,
+  ]);
+  handle.tmuxStarted = true;
+
+  const config = await loadGatewayConfig();
+  for (let attempt = 0; attempt < 90; attempt += 1) {
+    const response = await fetch(`${config.http.publicOrigin}/api/v1/sessions`, { cache: "no-store", credentials: "omit" });
+    if (response.ok) {
+      const payload = (await response.json()) as { sessions?: PublishedSession[] };
+      const matches = (payload.sessions ?? []).filter(session => session.cwdLabel === handle.label);
+      if (matches.length === 1) {
+        const session = matches[0]!;
+        if (
+          session.canView !== true ||
+          session.canControl !== true ||
+          typeof session.instanceId !== "string" ||
+          typeof session.generation !== "number"
+        ) {
+          throw new Error("published smoke fixture metadata is incomplete");
+        }
+        handle.published = true;
+        return;
+      }
+      if (matches.length > 1) throw new Error("generated smoke fixture label was not unique");
+    }
+    await sleep(1_000);
+  }
+  throw new Error("patched OMP smoke fixture did not publish within 90 seconds");
+}
+
+async function stopFixture(handle: FixtureHandle | undefined): Promise<void> {
+  if (handle === undefined) return;
+  const errors: unknown[] = [];
+  if (handle.tmuxStarted) {
+    try {
+      const before = await runCommand("tmux smoke status", ["tmux", "has-session", "-t", handle.label], {
+        allowedExitCodes: [0, 1],
+      });
+      if (before.exitCode === 0) await runCommand("tmux smoke cleanup", ["tmux", "kill-session", "-t", handle.label]);
+      const after = await runCommand("tmux smoke cleanup status", ["tmux", "has-session", "-t", handle.label], {
+        allowedExitCodes: [0, 1],
+      });
+      if (after.exitCode === 0) throw new Error("tmux smoke session remained active after cleanup");
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (handle.published) {
+    try {
+      const config = await loadGatewayConfig();
+      let revoked = false;
+      for (let attempt = 0; attempt < 45; attempt += 1) {
+        const response = await fetch(`${config.http.publicOrigin}/api/v1/sessions`, { cache: "no-store", credentials: "omit" });
+        const payload = (await response.json()) as { sessions?: PublishedSession[] };
+        if (!(payload.sessions ?? []).some(session => session.cwdLabel === handle.label)) {
+          revoked = true;
+          break;
+        }
+        await sleep(500);
+      }
+      if (!revoked) throw new Error("smoke fixture capability was not revoked");
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  try {
+    const marker = await readFile(handle.marker, "utf8");
+    assertFixtureOwnership(marker, handle.runId);
+    await rm(handle.directory, { recursive: true });
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length > 0) throw new AggregateError(errors, "post-release fixture cleanup failed");
+}
+
+export function findWebApkForHost(
+  packageList: string,
+  packageDumps: Readonly<Record<string, string>>,
+  host: string,
+): string | undefined {
+  const packages = packageList
+    .split(/\r?\n/u)
+    .map(line => line.trim().replace(/^package:/u, ""))
+    .filter(name => /^org[.]chromium[.]webapk[.][A-Za-z0-9_.-]+$/u.test(name));
+  const needle = `Authority: "${host}"`;
+  const matches = packages.filter(name => packageDumps[name]?.includes(needle));
+  if (matches.length > 1) throw new Error("multiple installed WebAPKs claim the gateway origin");
+  return matches[0];
+}
+
+async function chooseLoopbackPort(): Promise<number> {
+  return new Promise<number>((resolvePort, rejectPort) => {
+    const server = createServer();
+    server.once("error", rejectPort);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        server.close();
+        rejectPort(new Error("could not reserve a loopback port"));
+        return;
+      }
+      server.close(error => (error === undefined ? resolvePort(address.port) : rejectPort(error)));
+    });
+  });
+}
+
+async function verifyInstalledWebApk(origin: string): Promise<void> {
+  const host = new URL(origin).hostname;
+  const packageList = await commandOutput("installed WebAPK list", ["adb", "shell", "cmd", "package", "list", "packages", "org.chromium.webapk"]);
+  const packages = packageList
+    .split(/\r?\n/u)
+    .map(line => line.trim().replace(/^package:/u, ""))
+    .filter(Boolean);
+  const packageDumps: Record<string, string> = {};
+  for (const packageName of packages) {
+    packageDumps[packageName] = await commandOutput("installed WebAPK metadata", ["adb", "shell", "dumpsys", "package", packageName]);
+  }
+  const packageName = findWebApkForHost(packageList, packageDumps, host);
+  if (packageName === undefined) throw new Error("OMP Sessions WebAPK is not installed for the gateway origin");
+
+  await runCommand(
+    "installed WebAPK launch",
+    ["adb", "shell", "monkey", "-p", packageName, "-c", "android.intent.category.LAUNCHER", "1"],
+    { timeoutMs: 30_000 },
+  );
+  await sleep(2_000);
+  const activities = await commandOutput("installed WebAPK activity", ["adb", "shell", "dumpsys", "activity", "activities"]);
+  assertWebApkActiveTask(activities, packageName);
+
+  const port = await chooseLoopbackPort();
+  await runCommand("WebAPK DevTools forward", ["adb", "forward", `tcp:${port}`, "localabstract:chrome_devtools_remote"]);
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+    if (!response.ok) throw new Error("WebAPK DevTools target list was unavailable");
+    const targets = (await response.json()) as Array<{ type?: string; title?: string; url?: string }>;
+    if (!targets.some(target => target.type === "page" && target.title === "OMP Sessions" && target.url?.startsWith(`${origin}/`))) {
+      throw new Error("installed WebAPK did not render the OMP Sessions origin");
+    }
+  } finally {
+    await runCommand("WebAPK DevTools cleanup", ["adb", "forward", "--remove", `tcp:${port}`]);
+  }
+}
+
+async function runAndroidLanes(
+  release: VerifiedRelease,
+  bunExecutable: string,
+  label: string,
+): Promise<void> {
+  const config = await loadGatewayConfig();
+  const collab = parseJsonRecord(
+    await commandOutput(
+      "Android View and Control smoke",
+      [
+        bunExecutable,
+        join(repositoryRoot, "scripts/android-collab-smoke.ts"),
+        config.http.publicOrigin,
+        label,
+        "--expected-app-asset",
+        release.appAsset,
+      ],
+      { timeoutMs: 300_000 },
+    ),
+    "Android View and Control smoke",
+  );
+  if (
+    collab.appAsset !== release.appAsset ||
+    collab.viewReadOnly !== true ||
+    collab.controlWritable !== true ||
+    collab.promptAccepted !== true ||
+    collab.returnedToDirectory !== true
+  ) {
+    throw new Error("Android View and Control smoke returned an incomplete result");
+  }
+  await runCommand(
+    "Android capability sink sweep",
+    [bunExecutable, join(repositoryRoot, "scripts/android-leak-sweep.ts"), config.http.publicOrigin, label],
+    { timeoutMs: 300_000 },
+  );
+  await runCommand(
+    "Android same-page recovery",
+    [bunExecutable, join(repositoryRoot, "scripts/android-acceptance.ts"), config.http.publicOrigin, label],
+    { timeoutMs: 900_000 },
+  );
+  await verifyInstalledWebApk(config.http.publicOrigin);
+}
+
+async function assertRequiredTools(): Promise<void> {
+  for (const tool of ["gh", "cosign", "git", "shasum", "tar", "plutil", "tailscale", "tmux", "adb"]) {
+    await runCommand(`${tool} prerequisite`, ["sh", "-c", `command -v ${tool} >/dev/null`]);
+  }
+  const devices = await commandOutput("Android device preflight", ["adb", "devices", "-l"]);
+  selectAdbDevice(devices, process.env.OMP_ANDROID_SERIAL);
+}
+
+export async function runPostReleaseSmoke(options: PostReleaseSmokeOptions): Promise<Record<string, unknown>> {
+  const packageManifest = JSON.parse(await readFile(join(repositoryRoot, "package.json"), "utf8")) as PackageManifest;
+  const bunVersion = packageManifest.packageManager.replace(/^bun@/u, "");
+  if (process.platform !== "darwin" || process.arch !== "arm64") {
+    throw new Error("post-release smoke currently supports the qualified Darwin-arm64 host only");
+  }
+  if (process.versions.bun !== bunVersion) {
+    throw new Error(`run post-release smoke with Bun ${bunVersion}`);
+  }
+  if (options.planOnly) {
+    return {
+      tag: options.tag,
+      repository: options.repository,
+      effects: [
+        "verify published release provenance",
+        "install or verify the stable gateway without changing config or publisher token",
+        "preserve unrelated Tailscale Serve mappings",
+        "build or verify exact patched OMP",
+        "exercise an owned disposable tmux session on the physical Android client",
+        "remove only the owned session and private staging",
+        "leave the stable gateway, patched OMP, and installed PWA in place",
+      ],
+    };
+  }
+
+  await assertRequiredTools();
+  const staging = await mkdtemp(join(tmpdir(), "omp-gateway-post-release-"));
+  await chmod(staging, 0o700);
+  let fixture: FixtureHandle | undefined;
+  let primaryError: unknown;
+  try {
+    const release = await verifyPublishedRelease(options, staging, packageManifest);
+    const bunExecutable = await ensurePersistentBun(release.pins.bunVersion);
+    const gateway = await installOrVerifyGateway(options, release, bunExecutable);
+    const serve = await ensureServeMapping();
+    const doctorChecks = await verifyGatewayDoctor(release, bunExecutable);
+    const omp = await installOrVerifyOmp(options, release, bunExecutable, staging, "omp-post-release-build");
+    fixture = await createFixture(release.version);
+    await startFixture(fixture, release, bunExecutable, staging);
+    await runAndroidLanes(release, bunExecutable, fixture.label);
+    return {
+      tag: options.tag,
+      sourceCommit: release.sourceCommit,
+      archiveSha256: release.archiveSha256,
+      appAsset: release.appAsset,
+      gateway: {
+        installed: gateway.installed,
+        configPreserved: true,
+        publisherTokenPreserved: true,
+        doctorChecks,
+      },
+      tailscaleServe: { changed: serve.changed, unrelatedMappingsPreserved: true },
+      omp: { version: release.pins.version, built: omp.built, binarySha256: omp.binarySha256 },
+      android: {
+        viewReadOnly: true,
+        controlWritable: true,
+        capabilitySinksClean: true,
+        samePageRecovery: true,
+        installedWebApk: true,
+      },
+      leaveInstalled: { gateway: true, patchedOmp: true, webApk: true },
+    };
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    const cleanupErrors: unknown[] = [];
+    try {
+      await stopFixture(fixture);
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    try {
+      await rm(staging, { recursive: true });
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    if (cleanupErrors.length > 0) {
+      if (primaryError !== undefined) throw new AggregateError([primaryError, ...cleanupErrors], "post-release smoke and cleanup failed");
+      throw new AggregateError(cleanupErrors, "post-release smoke cleanup failed");
+    }
+  }
+}
+
+if (import.meta.main) {
+  const packageManifest = JSON.parse(await readFile(join(repositoryRoot, "package.json"), "utf8")) as PackageManifest;
+  const options = parsePostReleaseSmokeArgs(process.argv.slice(2), packageManifest.version);
+  const result = await runPostReleaseSmoke(options);
+  console.log(JSON.stringify(result, null, 2));
+}

--- a/scripts/qualify-macos-omp.sh
+++ b/scripts/qualify-macos-omp.sh
@@ -12,6 +12,7 @@ bun_version="${OMP_PIN_BUN_VERSION:-}"
 native_tarball_sha256="${OMP_PIN_NATIVE_TARBALL_SHA256:-}"
 native_binary_sha256="${OMP_PIN_NATIVE_BINARY_SHA256:-}"
 session_label="${OMP_QUAL_SESSION_LABEL:-omp-stable-pixel-qualification}"
+bun_executable="${OMP_PIN_BUN_EXECUTABLE:-${HOME:-}/.bun/bin/bun}"
 
 fail() { printf 'FAILED: %s\n' "$*" >&2; exit 1; }
 require_value() { [ -n "$2" ] || fail "$1 is required"; }
@@ -33,8 +34,8 @@ omp_root="$HOME/src/oh-my-pi-gateway-v${omp_version}"
 version_dir="$HOME/.local/lib/omp-session-gateway/omp/v${omp_version}-${patched_tree:0:8}"
 binary="$version_dir/omp"
 symlink="$HOME/.local/bin/omp-gateway-patched"
-fixture="$HOME/omp-native-fixture"
-build_log="/tmp/omp-stable-patched-build.log"
+fixture="${OMP_QUAL_NATIVE_FIXTURE:-$HOME/omp-native-fixture}"
+build_log="${OMP_QUAL_BUILD_LOG:-/tmp/omp-stable-patched-build.log}"
 qualification_cwd="$HOME/$session_label"
 patch="$gateway_root/patches/oh-my-pi/0001-collab-controller-autostart-registry.patch"
 native_path="$omp_root/packages/natives/native/pi_natives.darwin-arm64.node"
@@ -43,10 +44,11 @@ native_tarball_url="https://registry.npmjs.org/@oh-my-pi/pi-natives-darwin-arm64
 validate_host() {
   [ "$(uname -s)-$(uname -m)" = "Darwin-arm64" ] || fail "patched OMP stable qualification requires Darwin-arm64"
   local tool
-  for tool in bun git python3 curl shasum tar; do
+  for tool in git python3 curl shasum tar; do
     command -v "$tool" >/dev/null 2>&1 || fail "$tool is missing"
   done
-  [ "$(bun --version)" = "$bun_version" ] || fail "bun version does not match the qualification pin"
+  [ -x "$bun_executable" ] || fail "pinned bun executable is missing"
+  [ "$("$bun_executable" --version)" = "$bun_version" ] || fail "bun version does not match the qualification pin"
   [ -f "$patch" ] || fail "candidate artifact is missing the OMP patch"
 }
 
@@ -75,7 +77,7 @@ prepare_source() {
   [ "$(git -C "$omp_root" rev-parse 'HEAD^{tree}')" = "$patched_tree" ] || fail "patched tree does not match the pin"
   (
     cd "$omp_root"
-    bun install --frozen-lockfile >"$build_log" 2>&1
+    "$bun_executable" install --frozen-lockfile >"$build_log" 2>&1
   )
   rm -rf "$fixture"
   mkdir -p "$fixture/unpack"
@@ -94,9 +96,9 @@ build() {
   validate_host
   prepare_source
   : >"$build_log"
-  (cd "$omp_root" && bun install --frozen-lockfile) >>"$build_log" 2>&1 || { tail -100 "$build_log" >&2; fail "bun install failed"; }
+  (cd "$omp_root" && "$bun_executable" install --frozen-lockfile) >>"$build_log" 2>&1 || { tail -100 "$build_log" >&2; fail "bun install failed"; }
   set +e
-  python3 - "$HOME/.bun/bin/bun" "$omp_root" "$build_log" <<'PY'
+  python3 - "$bun_executable" "$omp_root" "$build_log" <<'PY'
 import subprocess
 import sys
 bun, root, log = sys.argv[1:]
@@ -116,7 +118,7 @@ PY
     tail -100 "$build_log" >&2
     exit "$check_exit"
   fi
-  (cd "$omp_root" && bun --cwd=packages/coding-agent run build) >>"$build_log" 2>&1
+  (cd "$omp_root" && "$bun_executable" --cwd=packages/coding-agent run build) >>"$build_log" 2>&1
   [ "$("$omp_root/packages/coding-agent/dist/omp" --version)" = "omp/$omp_version" ] || fail "built OMP version is wrong"
 
   mkdir -p "$version_dir" "$HOME/.local/bin"


### PR DESCRIPTION
## Summary

- add a published-byte post-release smoke orchestrator for the configured Darwin-arm64 Mac and physical Android client
- add reusable Android View → Control → prompt/interrupt and installed-WebAPK checks
- preserve private config/token bytes and unrelated Tailscale Serve mappings; build or reuse exact patched OMP
- clean only a per-run marker-owned tmux fixture and staging; update stable v0.1.0 README/release documentation
- make Android recovery accept the owned target alongside unrelated live sessions and refuse unsafe leak-sweep targets

## Security / threat-model impact

- capabilities remain in the gateway/client memory path; child output is redacted and no capability enters argv, environment, files, receipts, or diagnostics
- protected, old, missing, ambiguous, or non-Control targets fail before device actions
- absent/ambiguous adb devices fail before release download, host mutation, or fixture creation
- recursive cleanup requires an exact random per-run ownership marker; changed OMP source/runtime and unrelated Serve mappings fail closed
- no Funnel, public listener, relay, transcript, or second-agent-UI behavior is added

## Verification

- `bunx bun@1.3.14 run check`: 473 tests passed; typecheck, deterministic build, capability scan, and identifier scan passed
- complete `smoke:release` against published v0.1.0 bytes passed: exact tag/assets/attestations/Sigstore/source binding, doctor 17/17, config/token preservation, unrelated Serve preservation, exact patched OMP, physical View/Control, forbidden sinks, lock/Airplane/Doze same-page recovery, installed WebAPK, revocation, and owned cleanup
- disconnected-device regression proved refusal before staging or tmux creation
