### PR TITLE
feat(ci): support exact-SHA fleet checkpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Validate bounded gateway dispatch
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.target_sha != '' }}
         env:
           ROUTING_LABEL: ${{ inputs.routing_label }}
           TARGET_SHA: ${{ inputs.target_sha }}
@@ -63,15 +63,15 @@ jobs:
         run: |
           [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]
           [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]]
-          [[ "$RUNNER_NAME" =~ ^gateway-ci-(nyc|sf)-[1-3]$ ]]
+          [[ "$RUNNER_NAME" =~ ^gateway-ci-nyc-[1-3]$ ]]
           [[ ! -S /var/run/docker.sock ]]
       - name: Check out exact target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && inputs.target_sha || github.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.target_sha != '' && inputs.target_sha || github.sha }}
           persist-credentials: false
       - name: Verify exact dispatch target
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && inputs.target_sha != '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.target_sha != '' }}
         env:
           TARGET_SHA: ${{ inputs.target_sha }}
         run: test "$(git rev-parse HEAD)" = "$TARGET_SHA"
@@ -101,7 +101,7 @@ jobs:
       CODECOV_TOKEN: ${{ (github.event_name != 'workflow_dispatch' || inputs.runner != 'gateway-ci') && secrets.CODECOV_TOKEN || '' }}
     steps:
       - name: Validate bounded gateway dispatch
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.target_sha != '' }}
         env:
           ROUTING_LABEL: ${{ inputs.routing_label }}
           TARGET_SHA: ${{ inputs.target_sha }}
@@ -109,15 +109,15 @@ jobs:
         run: |
           [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]
           [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]]
-          [[ "$RUNNER_NAME" =~ ^gateway-ci-(nyc|sf)-[1-3]$ ]]
+          [[ "$RUNNER_NAME" =~ ^gateway-ci-nyc-[1-3]$ ]]
           [[ ! -S /var/run/docker.sock ]]
       - name: Check out exact target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && inputs.target_sha || github.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.target_sha != '' && inputs.target_sha || github.sha }}
           persist-credentials: false
       - name: Verify exact dispatch target
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && inputs.target_sha != '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.target_sha != '' }}
         env:
           TARGET_SHA: ${{ inputs.target_sha }}
         run: test "$(git rev-parse HEAD)" = "$TARGET_SHA"
@@ -156,7 +156,7 @@ jobs:
       PLAYWRIGHT_WORKERS: ${{ github.event_name == 'workflow_dispatch' && inputs.playwright_workers || '2' }}
     steps:
       - name: Validate bounded gateway dispatch
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.target_sha != '' }}
         env:
           ROUTING_LABEL: ${{ inputs.routing_label }}
           TARGET_SHA: ${{ inputs.target_sha }}
@@ -164,15 +164,15 @@ jobs:
         run: |
           [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]
           [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]]
-          [[ "$RUNNER_NAME" =~ ^gateway-ci-(nyc|sf)-[1-3]$ ]]
+          [[ "$RUNNER_NAME" =~ ^gateway-ci-nyc-[1-3]$ ]]
           [[ ! -S /var/run/docker.sock ]]
       - name: Check out exact target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && inputs.target_sha || github.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.target_sha != '' && inputs.target_sha || github.sha }}
           persist-credentials: false
       - name: Verify exact dispatch target
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && inputs.target_sha != '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.target_sha != '' }}
         env:
           TARGET_SHA: ${{ inputs.target_sha }}
         run: test "$(git rev-parse HEAD)" = "$TARGET_SHA"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,12 @@ jobs:
         env:
           ROUTING_LABEL: ${{ inputs.routing_label }}
           TARGET_SHA: ${{ inputs.target_sha }}
+          RUNNER_NAME: ${{ runner.name }}
         run: |
           [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]
           [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$RUNNER_NAME" =~ ^gateway-ci-(nyc|sf)-[1-3]$ ]]
+          [[ ! -S /var/run/docker.sock ]]
       - name: Check out exact target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -102,9 +105,12 @@ jobs:
         env:
           ROUTING_LABEL: ${{ inputs.routing_label }}
           TARGET_SHA: ${{ inputs.target_sha }}
+          RUNNER_NAME: ${{ runner.name }}
         run: |
           [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]
           [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$RUNNER_NAME" =~ ^gateway-ci-(nyc|sf)-[1-3]$ ]]
+          [[ ! -S /var/run/docker.sock ]]
       - name: Check out exact target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -154,9 +160,12 @@ jobs:
         env:
           ROUTING_LABEL: ${{ inputs.routing_label }}
           TARGET_SHA: ${{ inputs.target_sha }}
+          RUNNER_NAME: ${{ runner.name }}
         run: |
           [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]
           [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$RUNNER_NAME" =~ ^gateway-ci-(nyc|sf)-[1-3]$ ]]
+          [[ ! -S /var/run/docker.sock ]]
       - name: Check out exact target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ on:
         description: Controller-supplied one-time label; leave blank in the GitHub UI
         required: false
         type: string
+      target_sha:
+        description: Exact commit tested by a trusted fleet dispatch
+        required: false
+        type: string
       playwright_workers:
         description: Playwright workers for the browser suite; 2 is the qualified default, 3 is UNQUALIFIED pending a benchmark campaign, and 4 was REJECTED for missing the 900 ms gateway recovery bound.
         required: false
@@ -46,11 +50,28 @@ jobs:
     # the unpredictable one-time label shared by the ephemeral runners it registers for this
     # invocation. The jobs here are independent, so a parallel self-hosted run needs one free
     # runner per job.
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.routing_label || 'ubuntu-24.04' }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.target_sha != '' && inputs.routing_label || 'ubuntu-24.04' }}
     # Observed ~20s. A bound keeps a hung step from holding a required check for the 6h default.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Validate bounded gateway dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' }}
+        env:
+          ROUTING_LABEL: ${{ inputs.routing_label }}
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: |
+          [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]
+          [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]]
+      - name: Check out exact target
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && inputs.target_sha || github.sha }}
+          persist-credentials: false
+      - name: Verify exact dispatch target
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && inputs.target_sha != '' }}
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: test "$(git rev-parse HEAD)" = "$TARGET_SHA"
       - name: Set up Bun
         if: ${{ runner.environment == 'github-hosted' }}
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -68,15 +89,32 @@ jobs:
     # problem can never turn the required gate red, and the seconds it costs overlap that job
     # instead of extending it.
     # Same one-time-label invariant as implementation-checks.
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.routing_label || 'ubuntu-24.04' }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.target_sha != '' && inputs.routing_label || 'ubuntu-24.04' }}
     # Observed ~20s of tests plus the upload round trip; same bound as implementation-checks.
     timeout-minutes: 15
     env:
-      # Referenced by the upload step's `if`, which cannot read `secrets` directly. Absent on
-      # Dependabot and fork pull requests, which do not receive repository secrets.
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      # Referenced by the upload step's `if`, which cannot read `secrets` directly. Explicitly blank
+      # on fleet jobs so code from an exact target SHA receives no repository secret.
+      CODECOV_TOKEN: ${{ (github.event_name != 'workflow_dispatch' || inputs.runner != 'gateway-ci') && secrets.CODECOV_TOKEN || '' }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Validate bounded gateway dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' }}
+        env:
+          ROUTING_LABEL: ${{ inputs.routing_label }}
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: |
+          [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]
+          [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]]
+      - name: Check out exact target
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && inputs.target_sha || github.sha }}
+          persist-credentials: false
+      - name: Verify exact dispatch target
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && inputs.target_sha != '' }}
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: test "$(git rev-parse HEAD)" = "$TARGET_SHA"
       - name: Set up Bun
         if: ${{ runner.environment == 'github-hosted' }}
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -92,7 +130,7 @@ jobs:
         if: ${{ env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           files: coverage/lcov.info
           # Coverage reporting must not gate a merge on a third-party service being reachable. A
           # failed upload shows up as a stale Codecov status on the pull request instead.
@@ -101,7 +139,7 @@ jobs:
   browser-notifications:
     # Same one-time-label invariant as implementation-checks: automatic and concurrently
     # queued jobs cannot select this invocation's runners.
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.routing_label || 'ubuntu-24.04' }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && startsWith(inputs.routing_label, 'gateway-ci-linux-x64-') && inputs.target_sha != '' && inputs.routing_label || 'ubuntu-24.04' }}
     # Observed 2-7 min. On 2026-08-19 an Ubuntu mirror stall inside `playwright install --with-deps`
     # hung this job for 38 minutes with no output before it was cancelled by hand.
     timeout-minutes: 20
@@ -111,7 +149,24 @@ jobs:
       # benchmark campaign, and 4 was REJECTED for missing the 900 ms gateway recovery bound.
       PLAYWRIGHT_WORKERS: ${{ github.event_name == 'workflow_dispatch' && inputs.playwright_workers || '2' }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Validate bounded gateway dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' }}
+        env:
+          ROUTING_LABEL: ${{ inputs.routing_label }}
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: |
+          [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]
+          [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]]
+      - name: Check out exact target
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && inputs.target_sha || github.sha }}
+          persist-credentials: false
+      - name: Verify exact dispatch target
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'gateway-ci' && inputs.target_sha != '' }}
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: test "$(git rev-parse HEAD)" = "$TARGET_SHA"
       - name: Set up Bun
         if: ${{ runner.environment == 'github-hosted' }}
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0


### PR DESCRIPTION
## Summary
- accept an exact target SHA for trusted manual fleet dispatches
- validate one-time runner labels and exact checkout in every job
- withhold Codecov credentials and checkout persistence from fleet jobs
- keep automatic events and ordinary manual runs on GitHub-hosted runners

## Verification
- `actionlint .github/workflows/ci.yml`
- `bun run check` (473 tests)
