### PR TITLE
ci: support sf fleet runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,14 @@ jobs:
           TARGET_SHA: ${{ inputs.target_sha }}
           RUNNER_NAME: ${{ runner.name }}
         run: |
-          [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]
-          [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]]
-          [[ "$RUNNER_NAME" =~ ^gateway-ci-nyc-[1-3]$ ]]
-          [[ ! -S /var/run/docker.sock ]]
+          fail() {
+            printf 'invalid gateway fleet dispatch: %s\n' "$1" >&2
+            exit 2
+          }
+          [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]] || fail routing_label
+          [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]] || fail target_sha
+          [[ "$RUNNER_NAME" =~ ^gateway-ci-(nyc|sf)-[1-3]$ ]] || fail runner_name
+          [[ ! -S /var/run/docker.sock ]] || fail docker_socket
       - name: Check out exact target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -107,10 +111,14 @@ jobs:
           TARGET_SHA: ${{ inputs.target_sha }}
           RUNNER_NAME: ${{ runner.name }}
         run: |
-          [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]
-          [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]]
-          [[ "$RUNNER_NAME" =~ ^gateway-ci-nyc-[1-3]$ ]]
-          [[ ! -S /var/run/docker.sock ]]
+          fail() {
+            printf 'invalid gateway fleet dispatch: %s\n' "$1" >&2
+            exit 2
+          }
+          [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]] || fail routing_label
+          [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]] || fail target_sha
+          [[ "$RUNNER_NAME" =~ ^gateway-ci-(nyc|sf)-[1-3]$ ]] || fail runner_name
+          [[ ! -S /var/run/docker.sock ]] || fail docker_socket
       - name: Check out exact target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -162,10 +170,14 @@ jobs:
           TARGET_SHA: ${{ inputs.target_sha }}
           RUNNER_NAME: ${{ runner.name }}
         run: |
-          [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]
-          [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]]
-          [[ "$RUNNER_NAME" =~ ^gateway-ci-nyc-[1-3]$ ]]
-          [[ ! -S /var/run/docker.sock ]]
+          fail() {
+            printf 'invalid gateway fleet dispatch: %s\n' "$1" >&2
+            exit 2
+          }
+          [[ "$ROUTING_LABEL" =~ ^gateway-ci-linux-x64-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]] || fail routing_label
+          [[ "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ]] || fail target_sha
+          [[ "$RUNNER_NAME" =~ ^gateway-ci-(nyc|sf)-[1-3]$ ]] || fail runner_name
+          [[ ! -S /var/run/docker.sock ]] || fail docker_socket
       - name: Check out exact target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/apps/gateway/test/ci-workflow.test.ts
+++ b/apps/gateway/test/ci-workflow.test.ts
@@ -1,8 +1,16 @@
 import { expect, test } from "bun:test";
-import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const workflowPath = join(import.meta.dir, "../../../.github/workflows/ci.yml");
+const validEnvironment = {
+  ROUTING_LABEL: "gateway-ci-linux-x64-12345678-1234-1234-1234-123456789abc",
+  TARGET_SHA: "a".repeat(40),
+  RUNNER_NAME: "gateway-ci-nyc-2",
+};
 
 function validationScripts(source: string): string[] {
   return [...source.matchAll(/      - name: Validate bounded gateway dispatch[\s\S]*?        run: \|\n((?:          .*\n)+)/g)].map(
@@ -10,11 +18,47 @@ function validationScripts(source: string): string[] {
   );
 }
 
+function runValidation(
+  script: string,
+  updates: Record<string, string> = {},
+  socketPath = join(tmpdir(), "gateway-ci-absent-docker.sock"),
+): number | null {
+  return spawnSync(
+    "bash",
+    ["-Eeuo", "pipefail", "-c", script.replace("/var/run/docker.sock", socketPath)],
+    {
+      encoding: "utf8",
+      env: { ...process.env, ...validEnvironment, ...updates },
+    },
+  ).status;
+}
+
+async function withUnixSocket(check: (socketPath: string) => void): Promise<void> {
+  const directory = await mkdtemp(join(tmpdir(), "gateway-ci-workflow-"));
+  const socketPath = join(directory, "docker.sock");
+  const server = createServer();
+  await new Promise<void>((resolve) => {
+    server.listen(socketPath, resolve);
+  });
+  try {
+    check(socketPath);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
 test("every fleet lane fails closed and admits either qualified site", async () => {
   const source = await readFile(workflowPath, "utf8");
+  const fleetRunsOn =
+    source.match(/^    runs-on: .*inputs\.routing_label \|\| 'ubuntu-24\.04' \}\}$/gm) ?? [];
   const scripts = validationScripts(source);
 
-  expect(scripts).toHaveLength(3);
+  expect(fleetRunsOn).toHaveLength(3);
+  expect(scripts).toHaveLength(fleetRunsOn.length);
+  expect(source).not.toContain("^gateway-ci-nyc-[1-3]$");
   for (const script of scripts) {
     const predicates = script
       .split("\n")
@@ -22,7 +66,15 @@ test("every fleet lane fails closed and admits either qualified site", async () 
       .filter((line) => line.startsWith("[["));
     expect(predicates).toHaveLength(4);
     expect(predicates.every((line) => /\]\] \|\| fail [a-z_]+$/.test(line))).toBe(true);
-    expect(script).toContain('^gateway-ci-(nyc|sf)-[1-3]$');
-    expect(script).not.toContain("gateway-ci-nyc-[1-3]");
+    expect(script).toContain("^gateway-ci-(nyc|sf)-[1-3]$");
+
+    expect(runValidation(script)).toBe(0);
+    expect(runValidation(script, { RUNNER_NAME: "gateway-ci-sf-2" })).toBe(0);
+    expect(runValidation(script, { ROUTING_LABEL: "gateway-ci-linux-x64-shared" })).toBe(2);
+    expect(runValidation(script, { TARGET_SHA: "A".repeat(40) })).toBe(2);
+    expect(runValidation(script, { RUNNER_NAME: "unknown-runner" })).toBe(2);
+    await withUnixSocket((socketPath) => {
+      expect(runValidation(script, {}, socketPath)).toBe(2);
+    });
   }
 });

--- a/apps/gateway/test/ci-workflow.test.ts
+++ b/apps/gateway/test/ci-workflow.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const workflowPath = join(import.meta.dir, "../../../.github/workflows/ci.yml");
+
+function validationScripts(source: string): string[] {
+  return [...source.matchAll(/      - name: Validate bounded gateway dispatch[\s\S]*?        run: \|\n((?:          .*\n)+)/g)].map(
+    (match) => match[1] ?? "",
+  );
+}
+
+test("every fleet lane fails closed and admits either qualified site", async () => {
+  const source = await readFile(workflowPath, "utf8");
+  const scripts = validationScripts(source);
+
+  expect(scripts).toHaveLength(3);
+  for (const script of scripts) {
+    const predicates = script
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith("[["));
+    expect(predicates).toHaveLength(4);
+    expect(predicates.every((line) => /\]\] \|\| fail [a-z_]+$/.test(line))).toBe(true);
+    expect(script).toContain('^gateway-ci-(nyc|sf)-[1-3]$');
+    expect(script).not.toContain("gateway-ci-nyc-[1-3]");
+  }
+});


### PR DESCRIPTION
## Change
- admit host-specific SF runner names in all three manual fleet jobs
- make the repeated routing, target, runner, and Docker-socket predicates explicitly fail closed
- add an executable invariant covering every fleet validation block

## Local proof
- actionlint passed
- focused Bun workflow invariant passed
- project typecheck passed
- all three blocks accepted NYC and SF runners and rejected unknown runners and a real Docker socket

Push and pull-request jobs remain GitHub-hosted.