### PR TITLE
chore(release): open the v0.2.0 stable campaign

### DIFF
--- a/.github/workflows/signed-release.yml
+++ b/.github/workflows/signed-release.yml
@@ -176,19 +176,26 @@ jobs:
           EOF
           elif [[ "$OMP_RELEASE_CHANNEL" == "stable" ]]; then
             cat > "$notes" <<EOF
-          ## v0.1.0 — narrowly supported stable release
+          ## v0.2.0 — narrowly supported stable release
 
-          This is the first non-prerelease OMP Session Gateway release. Stable describes the exact supported matrix below; it does not claim compatibility with unnamed hosts, browsers, OMP builds, or remote-access paths.
+          This release supersedes v0.1.0 as GitHub Latest. Stable describes the exact supported matrix below; it does not claim compatibility with unnamed hosts, browsers, OMP builds, or remote-access paths.
+
+          ### Highlights since v0.1.0
+
+          - Couch-first triage directory: FIFO Needs-you queue with an Up-next hero, device-local Hold for desk and reversible Dismiss here, and a Settings sheet for background alerts and notification detail.
+          - Long transcripts render incrementally in the embedded collaboration client: the initial snapshot defers to one loading placeholder and the transcript windows to the newest entries with a Show earlier control.
+          - The pinned collaboration client ships in the precached application shell and warms while the directory idles, so View/Control taps pay only for the no-store launch request and relay connect.
+          - Bounded transport recovery hardening for Android Chrome, including backoff ceilings, prolonged-outage guidance, and native EventSource reconnection support.
 
           ### Advertised combinations
 
           | role | combination |
           |---|---|
-          | host | Debian 13 (trixie) x86-64, systemd 257, kernel 6.12.94+deb13-amd64 |
-          | host | macOS 26.6.1 arm64 (Mac14,3) |
-          | client | Chrome 151.0.7922.171 on Android 17 (Pixel 10 Pro) |
+          | host | Debian 13 (trixie) x86-64 |
+          | host | macOS arm64 (Mac14,3) |
+          | client | Chrome on Android (Pixel 10 Pro) |
 
-          Per-lane evidence and the qualifying candidate are recorded in docs/RELEASE_STATUS.md and docs/COMPATIBILITY.md at this source commit.
+          Exact qualified OS, browser, and kernel builds, per-lane evidence, and the qualifying candidate are recorded in docs/RELEASE_STATUS.md and docs/COMPATIBILITY.md at this source commit.
 
           ### Required deployment preconditions
 
@@ -197,7 +204,7 @@ jobs:
 
           ### Known environment limitation
 
-          Exact candidate .23 recovered the same loaded page automatically after secure lock, an Airplane outage, and forced Doze, without a reload. Android Chrome can still wedge its process-wide network state outside those proven transitions. Native EventSource reconnection and the bounded snapshot fallback recover the qualified cases; after an uninterrupted prolonged visible outage the loaded shell exposes force-stop/reopen help. The release does not claim page JavaScript can restart a failed browser process.
+          Android Chrome can wedge its process-wide network state outside the qualified lock/Airplane/Doze transitions. Native EventSource reconnection and the bounded snapshot fallback recover the qualified cases; after an uninterrupted prolonged visible outage the loaded shell exposes force-stop/reopen help. The release does not claim page JavaScript can restart a failed browser process.
           Windows remains unadvertised. Background Web Push delivery remains best-effort and is not part of the stable core support claim.
 
           ### Install or upgrade
@@ -206,7 +213,7 @@ jobs:
 
           ### Rollback
 
-          Run bun apps/gateway/src/cli.js rollback when the predecessor is present in managed installation history. Otherwise reinstall the signed v0.1.0-beta.1 archive with the deployment's existing origin and allowlist. Gateway rollback does not roll back the separately activated patched OMP executable.
+          Run bun apps/gateway/src/cli.js rollback when the predecessor is present in managed installation history. Otherwise reinstall the signed v0.1.0 stable archive with the deployment's existing origin and allowlist. Gateway rollback does not roll back the separately activated patched OMP executable.
 
           - Source commit: $GITHUB_SHA
           - OMP baseline: $upstream_commit (tag $upstream_tag) with the included patch
@@ -311,10 +318,9 @@ jobs:
 
           ### Changes to test
 
-          - The PWA adds device-local **Hold for desk** for an exact ask while preserving authoritative gateway attention, pending counts, and notifications on other devices.
-          - Reversible **Dismiss here** hides a non-attention row only on the current device; the OMP process keeps running and remains included in live totals.
-          - Failed in-shell advancement keeps the current ask queued, preserves the capability-bearing collaboration shell, and exposes an explicit retry.
-          - Local couch-routing records are bounded to identifiers and timestamps; capabilities, prompts, transcripts, titles, paths, and models are never persisted.
+          - Couch-flow visual pass: full-width session rows with a compact per-row Dismiss control, readable ask previews, a real empty state, and a Settings sheet for background alerts and notification detail.
+          - Embedded-client transcript windowing: the initial snapshot defers to one loading placeholder and long histories render behind a Show earlier control.
+          - The pinned collaboration client is precached with the application shell and warmed while the directory idles.
           - Other unreleased repository changes are recorded in CHANGELOG.md at this source commit.
 
           ### Required OMP prerequisite
@@ -330,7 +336,7 @@ jobs:
 
           ### Rollback
 
-          Run bun apps/gateway/src/cli.js rollback when the predecessor is present in managed installation history. Otherwise reinstall the signed v0.1.0-beta.1 archive with the deployment's existing origin and allowlist.
+          Run bun apps/gateway/src/cli.js rollback when the predecessor is present in managed installation history. Otherwise reinstall the signed v0.1.0 stable archive with the deployment's existing origin and allowlist.
 
           Verification instructions: https://github.com/$GITHUB_REPOSITORY/blob/$GITHUB_SHA/docs/RELEASE.md.
           EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable project changes will be documented here.
 
 The format is based on Keep a Changelog and Semantic Versioning.
 
-## [Unreleased]
+## [v0.2.0] — 2026-08-28
 
 ### Added
 

--- a/STABLE_RELEASE.lock.json
+++ b/STABLE_RELEASE.lock.json
@@ -1,20 +1,20 @@
 {
   "$schema": "./schemas/stable-release.schema.json",
   "schemaVersion": 1,
-  "version": "0.1.0",
-  "releaseTag": "v0.1.0",
-  "status": "qualified",
-  "candidateTag": "v0.1.0-prealpha.23",
-  "candidateSourceCommit": "434cddc443335d6da6476b43564db8230365e6fc",
-  "candidateArchiveSha256": "f98bad0ce2ae20d3892e560069b2fbfc4ab6d084a403b6aa57e41c628c25ce98",
-  "runtimeByteComparison": "passed",
+  "version": "0.2.0",
+  "releaseTag": "v0.2.0",
+  "status": "pending",
+  "candidateTag": null,
+  "candidateSourceCommit": null,
+  "candidateArchiveSha256": null,
+  "runtimeByteComparison": "pending",
   "evidence": {
-    "debian": "passed",
-    "macos": "passed",
-    "android": "passed",
-    "ompPublication": "passed",
-    "provenance": "passed",
-    "secretSinks": "passed"
+    "debian": "pending",
+    "macos": "pending",
+    "android": "pending",
+    "ompPublication": "pending",
+    "provenance": "pending",
+    "secretSinks": "pending"
   },
-  "approvedAt": "2026-08-22T17:21:03.191Z"
+  "approvedAt": null
 }

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omp-session-gateway/gateway",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omp-session-gateway/web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -54,7 +54,7 @@ Chrome.
 Run the exact host/client sequence from a clean, published Darwin-arm64 branch:
 
 ```sh
-bun run qualify:stable --tag v0.1.0-prealpha.23
+bun run qualify:stable --tag v0.2.0-prealpha.1
 ```
 
 The command re-verifies the signed tag, six release assets, checksums, three GitHub attestations, and three Sigstore bundles; dispatches or resumes the Debian workflow; discovers the retained Scaleway Mac by name; runs install, doctor, exposure, reboot, beta-to-candidate rollback, exact patched-OMP build/publication/revocation, physical-Pixel acceptance and forbidden-sink sweep, and a bounded relay smoke; then uninstalls and removes qualification-owned Mac state. It writes one mode-`0600` receipt at `~/.local/share/omp-session-gateway/qualification/<tag>/stable-qualification.json`.

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -1,10 +1,23 @@
 # Release status
 
-**Updated:** 2026-08-22<br>
-**Repository version:** `0.1.0`; stable publication source for **`v0.1.0`**<br>
-**Qualification predecessor:** **`v0.1.0-prealpha.23`**, independently verified<br>
-**Classification:** stable-qualified for the exact combinations below; no broader production claim<br>
-**Stable decision:** **GO, approved**, for the named support boundary and nothing else.
+**Updated:** 2026-08-28<br>
+**Repository version:** `0.2.0`; stable claim target **`v0.2.0`** (pending)<br>
+**Published stable:** **`v0.1.0`** remains GitHub Latest until the 0.2 campaign passes<br>
+**Classification:** v0.2.0 is **not qualified**; the v0.1.0 boundary below remains the only stable claim<br>
+**Stable decision (0.2):** **PENDING** — `STABLE_RELEASE.lock.json` is `pending` and blocks a `v0.2.0` tag.
+
+### Stable 0.2 — qualification pending
+
+**Target tag:** `v0.2.0`, to be published as a non-prerelease and GitHub Latest only after this
+section records a passed campaign.<br>
+**Planned candidate:** the first published `v0.2.0-prealpha.<n>` engineering tag.<br>
+**Rollback predecessor:** published stable `v0.1.0`.<br>
+**Machine gate:** `STABLE_RELEASE.lock.json` is `pending`; `release-policy.ts` refuses a stable
+tag until every commit-bound field passes and the ledger records approval.<br>
+**Planned evidence:** the same lanes as 0.1 — signed candidate artifacts, Debian disposable-host
+lifecycle, retained `Mac14,3` lifecycle with cross-version `v0.1.0 → candidate` upgrade/rollback,
+exact patched-OMP publication/revocation, physical Pixel acceptance with the forbidden-sink sweep,
+and a bounded default-relay smoke, recorded here before ledger approval.
 
 ### Stable 0.1 — GO
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omp-session-gateway",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "packageManager": "bun@1.3.14",

--- a/packages/collab-client/package.json
+++ b/packages/collab-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omp-session-gateway/collab-client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omp-session-gateway/protocol",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/schemas/stable-release.schema.json
+++ b/schemas/stable-release.schema.json
@@ -20,10 +20,10 @@
   "properties": {
     "$schema": { "const": "./schemas/stable-release.schema.json" },
     "schemaVersion": { "const": 1 },
-    "version": { "const": "0.1.0" },
-    "releaseTag": { "const": "v0.1.0" },
+    "version": { "const": "0.2.0" },
+    "releaseTag": { "const": "v0.2.0" },
     "status": { "enum": ["pending", "qualified"] },
-    "candidateTag": { "pattern": "^v0\\.1\\.0-prealpha\\.[1-9][0-9]*$" },
+    "candidateTag": { "type": ["string", "null"], "pattern": "^v0\\.2\\.0-prealpha\\.[1-9][0-9]*$" },
     "candidateSourceCommit": { "type": ["string", "null"], "pattern": "^[0-9a-f]{40}$" },
     "candidateArchiveSha256": { "type": ["string", "null"], "pattern": "^[0-9a-f]{64}$" },
     "runtimeByteComparison": { "enum": ["pending", "passed"] },

--- a/scripts/build-release.test.ts
+++ b/scripts/build-release.test.ts
@@ -225,7 +225,7 @@ test("the recorded qualification comes from a closed channel set that fails shut
   expect(RELEASE_QUALIFICATIONS.beta).toContain("docs/COMPATIBILITY.md at this source commit");
   expect(RELEASE_QUALIFICATIONS.beta).toContain("UPSTREAM.lock.json");
   expect(RELEASE_QUALIFICATIONS.beta).toContain("not stable or production-qualified");
-  expect(RELEASE_QUALIFICATIONS.stable).toStartWith("qualified stable 0.1;");
+  expect(RELEASE_QUALIFICATIONS.stable).toStartWith("qualified stable 0.2;");
   expect(RELEASE_QUALIFICATIONS.stable).toContain("docs/COMPATIBILITY.md at this source commit");
   expect(RELEASE_QUALIFICATIONS.stable).toContain("UPSTREAM.lock.json");
   expect(RELEASE_QUALIFICATIONS.stable).toContain("environment limitations and exclusions still apply");

--- a/scripts/build-release.ts
+++ b/scripts/build-release.ts
@@ -5,7 +5,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { findCapabilityLeaks } from "./capability-leak-rules.ts";
 
-export const PRODUCT_VERSION = "0.1.0";
+export const PRODUCT_VERSION = "0.2.0";
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const defaultReleaseRoot = join(root, "dist", "release");
 const archiveBase = `omp-session-gateway-${PRODUCT_VERSION}-bun`;
@@ -392,7 +392,7 @@ export const RELEASE_QUALIFICATIONS = {
   beta:
     "qualified beta; supported only for the hosts and client recorded in docs/COMPATIBILITY.md at this source commit, and only against the exact patched OMP baseline recorded in UPSTREAM.lock.json; not stable or production-qualified",
   stable:
-    "qualified stable 0.1; supported only for the hosts and client recorded in docs/COMPATIBILITY.md at this source commit, and only against the exact patched OMP baseline recorded in UPSTREAM.lock.json; documented environment limitations and exclusions still apply",
+    "qualified stable 0.2; supported only for the hosts and client recorded in docs/COMPATIBILITY.md at this source commit, and only against the exact patched OMP baseline recorded in UPSTREAM.lock.json; documented environment limitations and exclusions still apply",
 } as const;
 
 export type ReleaseChannel = keyof typeof RELEASE_QUALIFICATIONS;

--- a/scripts/provision-linux-qual.sh
+++ b/scripts/provision-linux-qual.sh
@@ -833,11 +833,23 @@ report_imported_images() {
 
 # ---------------------------------------------------------------------------- qualification lanes
 
+# Release asset names carry the tag's own MAJOR.MINOR.PATCH. Deriving from the tag rather than the
+# checkout's package.json keeps every lane valid when the repository has already moved past the
+# candidate under test (and lets rollback pair a v0.1.0 predecessor with a 0.2.x candidate).
+version_from_tag() {
+  local version="${1#v}"
+  version="${version%%-*}"
+  case "$version" in
+    *[!0-9.]* | "" | .* | *. ) die "cannot derive a release version from tag $1" ;;
+  esac
+  printf '%s' "$version"
+}
+
 release_version() {
   if [ -n "${OMP_QUAL_VERSION:-}" ]; then
     printf '%s' "$OMP_QUAL_VERSION"
   else
-    jq -r '.version' package.json
+    version_from_tag "${OMP_QUAL_RELEASE_TAG:-}"
   fi
 }
 
@@ -1497,7 +1509,7 @@ lane_migration() {
     return 0
   fi
 
-  version="$(release_version)"
+  version="$(version_from_tag "$previous_tag")"
   archive="omp-session-gateway-${version}-bun.tar"
   sbom="omp-session-gateway-${version}.spdx.json"
   local_dir="$STATE_DIR/release/$previous_tag"
@@ -1533,9 +1545,16 @@ bun=~/.bun/bin/bun
 # download cannot be installed even though this lane staged it separately.
 cd ~/candidate-prev
 sha256sum --check SHA256SUMS >/dev/null
-identity="https://github.com/${REPO_SLUG}/.github/workflows/release.yml@refs/tags/${PREV_TAG}"
-~/tools/cosign verify-blob --bundle "${ARCHIVE}.sigstore.json" --certificate-identity "$identity" \
-  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" "$ARCHIVE" >/dev/null 2>&1
+verified=0
+for workflow in signed-release.yml release.yml; do
+  identity="https://github.com/${REPO_SLUG}/.github/workflows/${workflow}@refs/tags/${PREV_TAG}"
+  if ~/tools/cosign verify-blob --bundle "${ARCHIVE}.sigstore.json" --certificate-identity "$identity" \
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" "$ARCHIVE" >/dev/null 2>&1; then
+    verified=1
+    break
+  fi
+done
+[ "$verified" -eq 1 ] || { echo "predecessor Sigstore verification failed for $PREV_TAG" >&2; exit 1; }
 show "predecessor verified" "checksum and signature for $PREV_TAG"
 
 rm -rf ~/runtime-prev && mkdir -p ~/runtime-prev

--- a/scripts/qualify-macos-host.sh
+++ b/scripts/qualify-macos-host.sh
@@ -87,7 +87,7 @@ die() {
 
 readonly HOST="${OMP_MAC_HOST:-}"
 readonly TAG="${OMP_MAC_TAG:-}"
-readonly PREVIOUS_TAG="${OMP_MAC_PREVIOUS_TAG:-v0.1.0-beta.1}"
+readonly PREVIOUS_TAG="${OMP_MAC_PREVIOUS_TAG:-v0.1.0}"
 readonly LOGIN="${OMP_MAC_LOGIN:-}"
 readonly EXPECTED_ARCHIVE_SHA256="${OMP_MAC_ARCHIVE_SHA256:-}"
 readonly SESSION_LABEL="${OMP_MAC_SESSION_LABEL:-omp-stable-pixel-qualification}"
@@ -115,6 +115,17 @@ esac
 case "$TAG:$PREVIOUS_TAG" in
   *[!A-Za-z0-9._:-]*) die "OMP_MAC_TAG and OMP_MAC_PREVIOUS_TAG must be plain release tags" ;;
 esac
+
+# Release asset names carry the tag's own MAJOR.MINOR.PATCH: a 0.2 candidate ships
+# omp-session-gateway-0.2.0-* while its v0.1.0 rollback predecessor keeps 0.1.0 names.
+tag_version() {
+  local version="${1#v}"
+  version="${version%%-*}"
+  case "$version" in
+    *[!0-9.]* | "" | .* | *. ) die "cannot derive a release version from tag $1" ;;
+  esac
+  printf '%s' "$version"
+}
 count_file_occurrences() {
   python3 - "$1" "$2" <<'PY'
 from pathlib import Path
@@ -234,11 +245,13 @@ lane_artifact() {
   mkdir -p "$dir"
   ( cd "$dir" && gh release download "$TAG" --repo "$REPO_SLUG" ) ||
     die "could not download release $TAG from $REPO_SLUG."
+  local candidate_version
+  candidate_version="$(tag_version "$TAG")"
   for asset in \
-    omp-session-gateway-0.1.0-bun.tar \
-    omp-session-gateway-0.1.0-bun.tar.sigstore.json \
-    omp-session-gateway-0.1.0.spdx.json \
-    omp-session-gateway-0.1.0.spdx.json.sigstore.json \
+    "omp-session-gateway-$candidate_version-bun.tar" \
+    "omp-session-gateway-$candidate_version-bun.tar.sigstore.json" \
+    "omp-session-gateway-$candidate_version.spdx.json" \
+    "omp-session-gateway-$candidate_version.spdx.json.sigstore.json" \
     SHA256SUMS SHA256SUMS.sigstore.json; do
     [ -f "$dir/$asset" ] || die "release $TAG is missing exact asset $asset"
   done
@@ -246,7 +259,7 @@ lane_artifact() {
     die "release $TAG did not download exactly six assets"
   ( cd "$dir" && shasum -a 256 -c SHA256SUMS >/dev/null 2>&1 ) ||
     die "checksums do not verify for $TAG. Refusing to install unverified bytes."
-  archive="omp-session-gateway-0.1.0-bun.tar"
+  archive="omp-session-gateway-$candidate_version-bun.tar"
   actual_archive_sha256="$(verified_archive_sha256 "$dir/$archive")"
   measure "archive sha256" "$actual_archive_sha256"
 
@@ -459,18 +472,19 @@ verify_rollback_bundle() {
 }
 
 prepare_rollback_tag() {
-  local root="$1" tag="$2" asset
+  local root="$1" tag="$2" asset tag_release_version
   local dir="$root/$tag"
+  tag_release_version="$(tag_version "$tag")"
   rm -rf "$dir"
   mkdir -p "$dir"
   gh release download "$tag" --repo "$REPO_SLUG" --dir "$dir" --clobber \
-    -p omp-session-gateway-0.1.0-bun.tar \
-    -p omp-session-gateway-0.1.0-bun.tar.sigstore.json \
+    -p "omp-session-gateway-$tag_release_version-bun.tar" \
+    -p "omp-session-gateway-$tag_release_version-bun.tar.sigstore.json" \
     -p SHA256SUMS -p SHA256SUMS.sigstore.json >/dev/null ||
     die "could not stage rollback assets for $tag"
   ( cd "$dir" && shasum -a 256 -c SHA256SUMS --ignore-missing >/dev/null ) ||
     die "rollback checksums failed for $tag"
-  for asset in omp-session-gateway-0.1.0-bun.tar SHA256SUMS; do
+  for asset in "omp-session-gateway-$tag_release_version-bun.tar" SHA256SUMS; do
     verify_rollback_bundle "$tag" "$dir" "$asset" ||
       die "rollback Sigstore verification failed for $asset at $tag"
   done

--- a/scripts/qualify-macos-host.test.ts
+++ b/scripts/qualify-macos-host.test.ts
@@ -19,8 +19,8 @@ function environment(archiveSha256: string): Record<string, string | undefined> 
   return {
     ...process.env,
     OMP_MAC_HOST: "synthetic@example.invalid",
-    OMP_MAC_TAG: "v0.1.0-prealpha.21",
-    OMP_MAC_PREVIOUS_TAG: "v0.1.0-beta.1",
+    OMP_MAC_TAG: "v0.2.0-prealpha.21",
+    OMP_MAC_PREVIOUS_TAG: "v0.1.0",
     OMP_MAC_LOGIN: "synthetic@example.invalid",
     OMP_MAC_ARCHIVE_SHA256: archiveSha256,
     OMP_MAC_SUDO_PW: sudoPassword,

--- a/scripts/qualify-rollback.sh
+++ b/scripts/qualify-rollback.sh
@@ -49,10 +49,8 @@
 set -euo pipefail
 
 REPO="alphastorm/omp-session-gateway"
-OLD_TAG="${OMP_ROLLBACK_OLD_TAG:-v0.1.0-alpha.1}"
-NEW_TAG="${OMP_ROLLBACK_NEW_TAG:-v0.1.0-prealpha.20}"
-ARCHIVE="omp-session-gateway-0.1.0-bun.tar"
-ARCHIVE_ROOT="omp-session-gateway-0.1.0-bun"
+OLD_TAG="${OMP_ROLLBACK_OLD_TAG:-v0.1.0}"
+NEW_TAG="${OMP_ROLLBACK_NEW_TAG:-v0.2.0-prealpha.1}"
 LABEL="omp-session-gateway"
 QUAL_BASE="${OMP_ROLLBACK_QUAL_BASE:-/tmp/omp-rollback-qual}"
 ARTIFACT_ROOT="${OMP_ROLLBACK_ARTIFACT_ROOT:-}"
@@ -374,23 +372,43 @@ step_isolation_gate() {
   fi
 }
 
+# Release asset names carry each tag's own MAJOR.MINOR.PATCH, so a cross-version
+# rollback pair (v0.1.0 predecessor, 0.2.x candidate) resolves different archives.
+tag_version() {
+  local version="${1#v}"
+  version="${version%%-*}"
+  case "$version" in
+    *[!0-9.]* | "" | .* | *. ) die "cannot derive a release version from tag $1" ;;
+  esac
+  printf '%s' "$version"
+}
+
+archive_for() {
+  printf 'omp-session-gateway-%s-bun.tar' "$(tag_version "$1")"
+}
+
+archive_root_for() {
+  printf 'omp-session-gateway-%s-bun' "$(tag_version "$1")"
+}
+
 fetch_tag() { # tag destination
-  local tag="$1" dest="$2" source asset workflow verified
+  local tag="$1" dest="$2" source asset workflow verified archive
+  archive="$(archive_for "$tag")"
   mkdir -p "$dest"
   (
     cd "$dest"
     if [ -n "$ARTIFACT_ROOT" ]; then
       source="$ARTIFACT_ROOT/$tag"
-      for asset in "$ARCHIVE" "$ARCHIVE.sigstore.json" SHA256SUMS SHA256SUMS.sigstore.json; do
+      for asset in "$archive" "$archive.sigstore.json" SHA256SUMS SHA256SUMS.sigstore.json; do
         [ -f "$source/$asset" ] || { printf 'preloaded rollback asset missing: %s/%s\n' "$source" "$asset" >&2; exit 1; }
         cp "$source/$asset" .
       done
     else
       gh release download "$tag" -R "$REPO" -D . --clobber \
-        -p "$ARCHIVE" -p "$ARCHIVE.sigstore.json" -p SHA256SUMS -p SHA256SUMS.sigstore.json >/dev/null
+        -p "$archive" -p "$archive.sigstore.json" -p SHA256SUMS -p SHA256SUMS.sigstore.json >/dev/null
     fi
     shasum -a 256 -c SHA256SUMS --ignore-missing >/dev/null
-    for asset in "$ARCHIVE" SHA256SUMS; do
+    for asset in "$archive" SHA256SUMS; do
       verified=0
       for workflow in signed-release.yml release.yml; do
         if cosign verify-blob \
@@ -405,9 +423,9 @@ fetch_tag() { # tag destination
       [ "$verified" -eq 1 ] || { printf 'cosign verify-blob failed for %s at %s\n' "$asset" "$tag" >&2; exit 1; }
     done
     mkdir -p extract
-    tar -xf "$ARCHIVE" -C extract
+    tar -xf "$archive" -C extract
   ) || die "download or verification failed for $tag"
-  fact "$tag archive sha256" "$(digest_of "$dest/$ARCHIVE")"
+  fact "$tag archive sha256" "$(digest_of "$dest/$(archive_for "$tag")")"
   fact "$tag SHA256SUMS + cosign" "shasum -c OK; verify-blob OK (archive, SHA256SUMS)"
 }
 
@@ -417,8 +435,8 @@ step_artifacts() {
   NEW_DIR="$SCRATCH/dl/$NEW_TAG"
   fetch_tag "$OLD_TAG" "$OLD_DIR"
   fetch_tag "$NEW_TAG" "$NEW_DIR"
-  OLD_CLI="$OLD_DIR/extract/$ARCHIVE_ROOT/apps/gateway/src/cli.js"
-  NEW_CLI="$NEW_DIR/extract/$ARCHIVE_ROOT/apps/gateway/src/cli.js"
+  OLD_CLI="$OLD_DIR/extract/$(archive_root_for "$OLD_TAG")/apps/gateway/src/cli.js"
+  NEW_CLI="$NEW_DIR/extract/$(archive_root_for "$NEW_TAG")/apps/gateway/src/cli.js"
   [ -f "$OLD_CLI" ] && [ -f "$NEW_CLI" ] || die "extracted archives do not contain apps/gateway/src/cli.js"
   fact "$OLD_TAG cli.js" "$(wc -c <"$OLD_CLI" | tr -d ' ') bytes"
   fact "$NEW_TAG cli.js" "$(wc -c <"$NEW_CLI" | tr -d ' ') bytes"

--- a/scripts/qualify-rollback.test.ts
+++ b/scripts/qualify-rollback.test.ts
@@ -38,12 +38,12 @@ test.skipIf(!POSIX)("rollback cleanup succeeds when no LaunchAgent is loaded", a
 
 test.skipIf(!POSIX)("rollback consumes preloaded verified assets without GitHub authentication", async () => {
   const temporaryRoot = await mkdtemp(join(tmpdir(), "omp-rollback-preload-test-"));
-  const tag = "v0.1.0-prealpha.21";
+  const tag = "v0.2.0-prealpha.21";
   const artifactRoot = join(temporaryRoot, "artifacts");
   const tagRoot = join(artifactRoot, tag);
   const destination = join(temporaryRoot, "destination");
   const bin = join(temporaryRoot, "bin");
-  const archiveName = "omp-session-gateway-0.1.0-bun.tar";
+  const archiveName = "omp-session-gateway-0.2.0-bun.tar";
   const archive = Buffer.alloc(1024);
   const archiveDigest = createHash("sha256").update(archive).digest("hex");
   const ghMarker = join(temporaryRoot, "gh-called");

--- a/scripts/release-policy.test.ts
+++ b/scripts/release-policy.test.ts
@@ -4,14 +4,14 @@ import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { assertStableReleaseQualification, releasePolicy } from "./release-policy.ts";
 
-const VERSION = "0.1.0";
+const VERSION = "0.2.0";
 const qualifiedManifest = () => ({
   $schema: "./schemas/stable-release.schema.json",
   schemaVersion: 1,
   version: VERSION,
-  releaseTag: "v0.1.0",
+  releaseTag: "v0.2.0",
   status: "qualified",
-  candidateTag: "v0.1.0-prealpha.21",
+  candidateTag: "v0.2.0-prealpha.21",
   candidateSourceCommit: "b".repeat(40),
   candidateArchiveSha256: "c".repeat(64),
   runtimeByteComparison: "passed",
@@ -28,7 +28,7 @@ const qualifiedManifest = () => ({
 
 describe("release tag policy", () => {
   test("publishes only the bare version as stable and latest", () => {
-    expect(releasePolicy("v0.1.0", VERSION)).toEqual({
+    expect(releasePolicy("v0.2.0", VERSION)).toEqual({
       channel: "stable",
       prerelease: false,
       latest: true,
@@ -37,13 +37,13 @@ describe("release tag policy", () => {
 
   test("keeps every engineering, alpha, and beta shape out of Latest", () => {
     const expected = [
-      ["v0.1.0-prealpha.1", "pre-alpha"],
-      ["v0.1.0-prealpha.23", "pre-alpha"],
-      ["v0.1.0-alpha", "alpha"],
-      ["v0.1.0-alpha.2", "alpha"],
-      ["v0.1.0-beta", "beta"],
-      ["v0.1.0-beta.7", "beta"],
-      ["provenance-test-v0.1.0.12", "pre-alpha"],
+      ["v0.2.0-prealpha.1", "pre-alpha"],
+      ["v0.2.0-prealpha.23", "pre-alpha"],
+      ["v0.2.0-alpha", "alpha"],
+      ["v0.2.0-alpha.2", "alpha"],
+      ["v0.2.0-beta", "beta"],
+      ["v0.2.0-beta.7", "beta"],
+      ["provenance-test-v0.2.0.12", "pre-alpha"],
     ] as const;
     for (const [tag, channel] of expected) {
       expect(releasePolicy(tag, VERSION)).toEqual({ channel, prerelease: true, latest: false });
@@ -53,15 +53,15 @@ describe("release tag policy", () => {
   test("rejects unknown, ambiguous, zero-indexed, and cross-version tags", () => {
     for (const tag of [
       "",
-      "v0.1.0-rc.1",
-      "v0.1.0-prealpha.0",
-      "v0.1.0-prealpha.01",
-      "v0.1.0-alpha.0",
-      "v0.1.0-beta.0",
-      "v0.1.0-stable",
-      "v0.1.1",
-      "V0.1.0",
-      "v0.1.0 ",
+      "v0.2.0-rc.1",
+      "v0.2.0-prealpha.0",
+      "v0.2.0-prealpha.01",
+      "v0.2.0-alpha.0",
+      "v0.2.0-beta.0",
+      "v0.2.0-stable",
+      "v0.2.1",
+      "V0.2.0",
+      "v0.2.0 ",
     ]) {
       expect(() => releasePolicy(tag, VERSION)).toThrow(/^tag must be /);
     }
@@ -76,26 +76,30 @@ describe("release tag policy", () => {
   test("refuses stable publication until every commit-bound qualification field passes", () => {
     const pending = qualifiedManifest();
     pending.status = "pending";
-    expect(() => assertStableReleaseQualification(pending, "v0.1.0", VERSION)).toThrow(
+    expect(() => assertStableReleaseQualification(pending, "v0.2.0", VERSION)).toThrow(
       "stable release qualification is pending",
     );
     const incomplete = qualifiedManifest();
     incomplete.evidence.android = "pending";
-    expect(() => assertStableReleaseQualification(incomplete, "v0.1.0", VERSION)).toThrow(
+    expect(() => assertStableReleaseQualification(incomplete, "v0.2.0", VERSION)).toThrow(
       "stable release evidence is incomplete",
     );
   });
 
-  test("repository manifest enables only the exact qualified stable candidate", async () => {
+  test("repository manifest gates stable publication on its recorded status", async () => {
     const manifest: unknown = await Bun.file(new URL("../STABLE_RELEASE.lock.json", import.meta.url)).json();
-    expect(() => assertStableReleaseQualification(manifest, "v0.1.0", VERSION)).not.toThrow();
-    expect(manifest).toMatchObject({
-      status: "qualified",
-      candidateTag: "v0.1.0-prealpha.23",
-      candidateSourceCommit: "434cddc443335d6da6476b43564db8230365e6fc",
-      candidateArchiveSha256: "f98bad0ce2ae20d3892e560069b2fbfc4ab6d084a403b6aa57e41c628c25ce98",
-      runtimeByteComparison: "passed",
-    });
+    expect(manifest).toMatchObject({ version: VERSION, releaseTag: "v0.2.0" });
+    const status = (manifest as Record<string, unknown>).status;
+    if (status === "qualified") {
+      // Ledger-approved campaign: the bare stable tag is authorized.
+      expect(() => assertStableReleaseQualification(manifest, "v0.2.0", VERSION)).not.toThrow();
+    } else {
+      // Pending campaign: stable publication must fail closed until every field passes.
+      expect(status).toBe("pending");
+      expect(() => assertStableReleaseQualification(manifest, "v0.2.0", VERSION)).toThrow(
+        "stable release qualification is pending",
+      );
+    }
   });
 
   test("CLI emits stable GitHub environment values only with a qualified manifest", async () => {
@@ -104,7 +108,7 @@ describe("release tag policy", () => {
       const manifestPath = join(temporaryRoot, "qualification.json");
       await writeFile(manifestPath, JSON.stringify(qualifiedManifest()));
       const subprocess = Bun.spawn(
-        [process.execPath, "scripts/release-policy.ts", "v0.1.0", VERSION, manifestPath],
+        [process.execPath, "scripts/release-policy.ts", "v0.2.0", VERSION, manifestPath],
         {
           cwd: new URL("..", import.meta.url).pathname,
           stdout: "pipe",

--- a/scripts/release-state.test.ts
+++ b/scripts/release-state.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import { assertReleaseState } from "./release-state.ts";
 
-const TAG = "v0.1.0";
+const TAG = "v0.2.0";
 function assets(): { name: string; state: string; digest: string }[] {
   const names = [
     "SHA256SUMS",
     "SHA256SUMS.sigstore.json",
-    "omp-session-gateway-0.1.0-bun.tar",
-    "omp-session-gateway-0.1.0-bun.tar.sigstore.json",
-    "omp-session-gateway-0.1.0.spdx.json",
-    "omp-session-gateway-0.1.0.spdx.json.sigstore.json",
+    "omp-session-gateway-0.2.0-bun.tar",
+    "omp-session-gateway-0.2.0-bun.tar.sigstore.json",
+    "omp-session-gateway-0.2.0.spdx.json",
+    "omp-session-gateway-0.2.0.spdx.json.sigstore.json",
   ];
   return names.map((name, index) => ({ name, state: "uploaded", digest: "sha256:" + String(index + 1).repeat(64) }));
 }

--- a/scripts/release-state.ts
+++ b/scripts/release-state.ts
@@ -1,10 +1,10 @@
 const EXPECTED_ASSETS = [
   "SHA256SUMS",
   "SHA256SUMS.sigstore.json",
-  "omp-session-gateway-0.1.0-bun.tar",
-  "omp-session-gateway-0.1.0-bun.tar.sigstore.json",
-  "omp-session-gateway-0.1.0.spdx.json",
-  "omp-session-gateway-0.1.0.spdx.json.sigstore.json",
+  "omp-session-gateway-0.2.0-bun.tar",
+  "omp-session-gateway-0.2.0-bun.tar.sigstore.json",
+  "omp-session-gateway-0.2.0.spdx.json",
+  "omp-session-gateway-0.2.0.spdx.json.sigstore.json",
 ] as const;
 
 export async function releaseAssetDigests(root: string): Promise<Record<string, string>> {

--- a/scripts/stable-qualification.test.ts
+++ b/scripts/stable-qualification.test.ts
@@ -19,7 +19,7 @@ import {
   type ProtectedFileSnapshot,
 } from "./stable-qualification.ts";
 
-const TAG = "v0.1.0-prealpha.21";
+const TAG = "v0.2.0-prealpha.21";
 const COMMIT = "a".repeat(40);
 const REPOSITORY_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
@@ -39,14 +39,25 @@ describe("stable qualification arguments", () => {
   test("accepts the one-command stable candidate shape with bounded defaults", () => {
     const options = parseStableQualificationArgs(["--tag", TAG], {});
     expect(options.tag).toBe(TAG);
-    expect(options.previousTag).toBe("v0.1.0-beta.1");
+    expect(options.previousTag).toBe("v0.1.0");
     expect(options.macName).toBe("omp-macqual-01");
     expect(options.relaySeconds).toBe(60);
   });
 
-  test("rejects stable, rc, and zero-indexed candidate tags", () => {
-    for (const tag of ["v0.1.0", "v0.1.0-rc.1", "v0.1.0-prealpha.0"]) {
+  test("rejects stable, rc, zero-indexed, and prior-version candidate tags", () => {
+    for (const tag of ["v0.2.0", "v0.2.0-rc.1", "v0.2.0-prealpha.0", "v0.1.0-prealpha.25"]) {
       expect(() => parseStableQualificationArgs(["--tag", tag], {})).toThrow("--tag must match");
+    }
+  });
+
+  test("accepts only the published stable or a 0.2 prerelease as the rollback predecessor", () => {
+    expect(parseStableQualificationArgs(["--tag", TAG, "--previous-tag", "v0.2.0-prealpha.1"], {}).previousTag).toBe(
+      "v0.2.0-prealpha.1",
+    );
+    for (const previous of ["v0.1.0-beta.1", "v0.1.0-alpha.1", "v0.2.0", ""]) {
+      expect(() => parseStableQualificationArgs(["--tag", TAG, "--previous-tag", previous], {})).toThrow(
+        "--previous-tag",
+      );
     }
   });
 

--- a/scripts/stable-qualification.ts
+++ b/scripts/stable-qualification.ts
@@ -5,8 +5,10 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const REPOSITORY = "alphastorm/omp-session-gateway";
-const VERSION = "0.1.0";
-const PREVIOUS_TAG = "v0.1.0-beta.1";
+const VERSION = "0.2.0";
+// Rollback predecessor: the published stable release the candidate must migrate from and roll
+// back to. For the 0.2 campaign that is the bare v0.1.0 stable, not a 0.1 prerelease.
+const PREVIOUS_TAG = "v0.1.0";
 const SIGNED_WORKFLOW = "signed-release.yml";
 const DEBIAN_WORKFLOW = "droplet-qualification.yml";
 const DEBIAN_RUN_TITLE_PREFIX = "Stable qualification";
@@ -182,12 +184,15 @@ export function parseStableQualificationArgs(
     else if (argument === "--previous-tag") previousTag = argv[++index] ?? "";
     else throw new Error(`unknown argument: ${argument ?? ""}`);
   }
-  if (tag === undefined) throw new Error("usage: bun run qualify:stable --tag v0.1.0-prealpha.<n>");
-  if (!/^v0\.1\.0-prealpha\.[1-9][0-9]*$/u.test(tag)) {
-    throw new Error("--tag must match v0.1.0-prealpha.<positive integer>");
+  if (tag === undefined) throw new Error("usage: bun run qualify:stable --tag v0.2.0-prealpha.<n>");
+  if (!/^v0\.2\.0-prealpha\.[1-9][0-9]*$/u.test(tag)) {
+    throw new Error("--tag must match v0.2.0-prealpha.<positive integer>");
   }
-  if (!/^v0\.1\.0-(?:alpha(?:\.[1-9][0-9]*)?|beta(?:\.[1-9][0-9]*)?|prealpha\.[1-9][0-9]*)$/u.test(previousTag)) {
-    throw new Error("--previous-tag must name an exact published 0.1 prerelease");
+  if (
+    previousTag !== "v0.1.0" &&
+    !/^v0\.2\.0-(?:alpha(?:\.[1-9][0-9]*)?|beta(?:\.[1-9][0-9]*)?|prealpha\.[1-9][0-9]*)$/u.test(previousTag)
+  ) {
+    throw new Error("--previous-tag must name the published v0.1.0 stable or an exact 0.2 prerelease");
   }
   const receiptRoot = resolve(
     environment.OMP_STABLE_QUALIFICATION_DIR ??


### PR DESCRIPTION
## Summary
Opens the stable v0.2.0 campaign (candidate `v0.2.0-prealpha.1`, rollback predecessor = published stable `v0.1.0`).

- Bump all workspaces + `PRODUCT_VERSION` to 0.2.0; release/asset validators (`release-state.ts`, orchestrator `ASSET_NAMES`) follow.
- Generalize qualification for cross-version pairs: `qualify-macos-host.sh`, `qualify-rollback.sh`, and `provision-linux-qual.sh` now derive asset names from each tag's own version (candidate 0.2.0 assets, predecessor 0.1.0 assets), and Linux lane 4 accepts both historical signing workflow identities like macOS already did. `provision-linux-qual.sh` derives the candidate version from the dispatched tag instead of the checkout's package.json, so the cron defaults keep working.
- `stable-qualification.ts` accepts `v0.2.0-prealpha.<n>` with default predecessor `v0.1.0`.
- `STABLE_RELEASE.lock.json` + schema reset to a **pending** 0.2.0 claim; `release-policy.ts` fails a bare `v0.2.0` tag closed until ledger approval (new phase-aware test encodes this).
- Release-notes templates rewritten for the 0.2 stable/prealpha channels; CHANGELOG cut to `[v0.2.0] — 2026-08-28`; RELEASE_STATUS opens the pending 0.2 section while keeping the v0.1.0 GO record as the only stable claim.

## Verification
- `bun run check` green on the clean tree (492 tests incl. byte-identical release rebuild, leak scans).
- `bash -n` on all three qualification shell scripts; focused release-script suites green.