### PR TITLE
docs(release): approve the v0.2.0 stable ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ and opens the exact encrypted OMP collaboration surface — without QR codes or 
 
 </div>
 
-> **Qualified stable v0.1.0.**
-> [v0.1.0](https://github.com/alphastorm/omp-session-gateway/releases/tag/v0.1.0) is the
+> **Qualified stable v0.2.0.**
+> [v0.2.0](https://github.com/alphastorm/omp-session-gateway/releases/tag/v0.2.0) is the
 > current GitHub Latest release. It was promoted from exact signed candidate
-> `v0.1.0-prealpha.23` after the recorded Debian 13 x86-64, macOS 26.6.1 arm64, and Chrome 151 /
+> `v0.2.0-prealpha.1` after the recorded Debian 13 x86-64, macOS 26.6.1 arm64, and Chrome 151 /
 > Android 17 Pixel matrix passed and candidate-to-stable runtime equivalence was verified.
 > Tailscale Serve with the TUN-mode client, Funnel disabled, and exact patched OMP v17.4.1 remain
 > mandatory. Windows, background Push qualification, Portal Tunnel, userspace networking, and
@@ -149,15 +149,16 @@ stable release below; its support boundary remains deliberately narrow.
 
 | | Current claim |
 |---|---|
-| Current release | [`v0.1.0`](https://github.com/alphastorm/omp-session-gateway/releases/tag/v0.1.0), GitHub Latest |
-| Qualification | Runtime-equivalent to independently qualified signed candidate `v0.1.0-prealpha.23` |
+| Current release | [`v0.2.0`](https://github.com/alphastorm/omp-session-gateway/releases/tag/v0.2.0), GitHub Latest |
+| Qualification | Runtime-equivalent to independently qualified signed candidate `v0.2.0-prealpha.1` |
 | Hosts | Debian 13 (trixie) x86-64 · macOS 26.6.1 arm64 |
-| Client | Chrome `151.0.7922.171` on Android 17 (Pixel 10 Pro) |
+| Client | Chrome `151.0.7922.173` on Android 17 (Pixel 10 Pro) |
 | Remote path | Tailscale Serve over tailnet HTTPS, TUN-mode client, Funnel disabled |
 | OMP baseline | Exact `v17.4.1` plus the repository's pinned patch and versioned `omp-gateway-patched` route |
 
-**Upstream baseline.** Stable v0.1.0 uses exact OMP v17.4.1 at
-`9350b7990d26ebf69a604edc82d8558ef04adf30`, observed and qualified on **2026-08-21**.
+**Upstream baseline.** Stable v0.2.0 uses exact OMP v17.4.1 at
+`9350b7990d26ebf69a604edc82d8558ef04adf30`, observed on **2026-08-21** and re-qualified on
+**2026-08-28**.
 Stock OMP is insufficient; the required versioned build/activation route is
 [patches/oh-my-pi/README.md](patches/oh-my-pi/README.md#supported-01-prerequisite-route-linux-and-macos).
 Earlier published prereleases remain immutable at their recorded baselines. Exact package and source

--- a/STABLE_RELEASE.lock.json
+++ b/STABLE_RELEASE.lock.json
@@ -3,18 +3,18 @@
   "schemaVersion": 1,
   "version": "0.2.0",
   "releaseTag": "v0.2.0",
-  "status": "pending",
-  "candidateTag": null,
-  "candidateSourceCommit": null,
-  "candidateArchiveSha256": null,
-  "runtimeByteComparison": "pending",
+  "status": "qualified",
+  "candidateTag": "v0.2.0-prealpha.1",
+  "candidateSourceCommit": "db88afb2ca18b0822648012bb6da50fd596f294c",
+  "candidateArchiveSha256": "149fc1b88a22b9cb1781bcb6219f2c1e41cafc867cb4eefe0a1e04b07eceeea2",
+  "runtimeByteComparison": "passed",
   "evidence": {
-    "debian": "pending",
-    "macos": "pending",
-    "android": "pending",
-    "ompPublication": "pending",
-    "provenance": "pending",
-    "secretSinks": "pending"
+    "debian": "passed",
+    "macos": "passed",
+    "android": "passed",
+    "ompPublication": "passed",
+    "provenance": "passed",
+    "secretSinks": "passed"
   },
-  "approvedAt": null
+  "approvedAt": "2026-08-28T09:02:57.000Z"
 }

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -2,12 +2,12 @@
 
 ## Current claim
 
-**Current release:** stable-qualified `v0.1.0` for the exact matrix below.<br>
-**Stable candidate:** signed `v0.1.0-prealpha.23`, fully qualified and approved.<br>
-**Rollback predecessor:** qualified `v0.1.0-beta.1`.<br>
-**Qualification predecessor:** signed stable candidate `v0.1.0-prealpha.23`.<br>
+**Current release:** stable-qualified `v0.2.0` for the exact matrix below.<br>
+**Stable candidate:** signed `v0.2.0-prealpha.1`, fully qualified and approved.<br>
+**Rollback predecessor:** published stable `v0.1.0`.<br>
+**Qualification predecessor:** signed stable candidate `v0.2.0-prealpha.1`.<br>
 **Advertised combinations:** Debian 13 (trixie) x86-64 and macOS 26.6.1 arm64 hosts, with Chrome
-151.0.7922.171 on Android 17 (Pixel 10 Pro). Nothing else is advertised.
+151.0.7922.173 on Android 17 (Pixel 10 Pro). Nothing else is advertised.
 
 Tailscale Serve over tailnet HTTPS is the only supported remote path. Funnel must remain disabled
 and Tailscale must run its TUN-mode client; userspace-networking tailscaled does not establish the
@@ -21,16 +21,18 @@ route. Stock OMP is unsupported. Upstreaming and paired packaging are not gates 
 matrix under ADR-024 and ADR-025.
 
 The stable support claim comes from one exact signed-candidate qualification, not row counts or
-transferred beta labels. Candidate `v0.1.0-prealpha.23` at source
-`434cddc443335d6da6476b43564db8230365e6fc` passed every lane exactly once:
+transferred beta labels. Candidate `v0.2.0-prealpha.1` at source
+`db88afb2ca18b0822648012bb6da50fd596f294c` passed every lane exactly once:
 
-- release run [`32586209795`](https://github.com/alphastorm/omp-session-gateway/actions/runs/32586209795)
+- release run [`33155940416`](https://github.com/alphastorm/omp-session-gateway/actions/runs/33155940416)
   verified the signed tag, six assets, checksums, three GitHub attestations, three Cosign bundles,
-  and archive SHA-256 `f98bad0ce2ae20d3892e560069b2fbfc4ab6d084a403b6aa57e41c628c25ce98`;
-- Debian run [`32586459902`](https://github.com/alphastorm/omp-session-gateway/actions/runs/32586459902)
-  passed the complete disposable Debian 13 x86-64 lifecycle and teardown;
-- `Mac14,3` / macOS 26.6.1 arm64 passed `doctor` 17/17, rollback 20/20, persistence, exact
-  artifact checks, patched-OMP publication/revocation, uninstall, and cleanup;
+  and archive SHA-256 `149fc1b88a22b9cb1781bcb6219f2c1e41cafc867cb4eefe0a1e04b07eceeea2`;
+- Debian run [`33156664373`](https://github.com/alphastorm/omp-session-gateway/actions/runs/33156664373)
+  passed the complete disposable Debian 13 x86-64 lifecycle, including the cross-version `v0.1.0`
+  predecessor migration, and teardown;
+- `Mac14,3` / macOS 26.6.1 arm64 passed `doctor` 17/17, rollback 20/20 against the published
+  `v0.1.0` stable predecessor, persistence, exact artifact checks, patched-OMP
+  publication/revocation, uninstall, and cleanup;
 - the physical Pixel rendered same-page automatic lock, Airplane, and forced-Doze recovery without
   a reload or competing recovery fetch; its seven-sink capability sweep was clean;
 - exact patched OMP v17.4.1 published generation-1 View and Control, returned `200 no-store`,
@@ -40,7 +42,7 @@ transferred beta labels. Candidate `v0.1.0-prealpha.23` at source
 Windows source/lifecycle checks pass, but Windows remains unadvertised and outside this stable
 matrix. No beta evidence is being used as a substitute for a missing stable-candidate lane.
 
-Known limits remain part of the claim. Exact candidate `.23` recovered same-page automatically
+Known limits remain part of the claim. Exact candidate `v0.2.0-prealpha.1` recovered same-page automatically
 after the qualified lock, Airplane, and forced-Doze transitions. Chrome for Android can still wedge
 its process-wide network state after some abrupt transitions while Android remains healthy. Native
 EventSource reconnection and the bounded snapshot fallback recover the proven cases; after 45
@@ -51,7 +53,8 @@ back to Session detail. Background Web Push remains outside the stable core clai
 self-hosted/proxied relays, Funnel, userspace networking, shared mutually untrusted local accounts,
 and every unnamed platform/browser/version remain unsupported.
 
-A signed artifact proves origin, not fitness. Candidate history for this point release is explicit:
+A signed artifact proves origin, not fitness. Candidate history for the 0.1 point release is
+explicit, and the 0.2 campaign adds its own row:
 
 | Candidate | Build | Disposition | Verification |
 |---|---|---|---|
@@ -61,6 +64,7 @@ A signed artifact proves origin, not fitness. Candidate history for this point r
 | `v0.1.0-prealpha.21` | `0.1.0-a98c526c40a3` | **Rejected.** Final qualification passed artifact, Debian, macOS, and relay lanes but failed the physical Android lane; cleanup passed. | Archive SHA-256 `cb7da13531875b879c3ab1c2451b58683199263877a74475f539258dfdcba33c`; Debian run `32565941928`; receipt `v0.1.0-prealpha.21.failed-32565941928-187994c`. |
 | `v0.1.0-prealpha.22` | `0.1.0-489b58e4b862` | **Rejected.** Lock and Doze did not recover, Airplane recovery took 170,210 ms, and no outage status rendered; cleanup passed. | Archive SHA-256 `194958b5b7affce27163145ca90b5cc14c6952ebb0bbf15b43878c351c6c69db`; release run `32579082734` attempt 2; Debian run `32579748768`. |
 | `v0.1.0-prealpha.23` | `0.1.0-434cddc44333` | **Qualified and approved for `v0.1.0`.** Native EventSource reconnection plus bounded snapshot fallback passed explicit no-reload recovery. | Archive SHA-256 `f98bad0ce2ae20d3892e560069b2fbfc4ab6d084a403b6aa57e41c628c25ce98`; signed tag/assets/attestations/bundles, exact rebuild, Debian/macOS/Pixel/patched-OMP/relay lanes, seven-sink sweep, and cleanup all passed exactly once. |
+| `v0.2.0-prealpha.1` | `0.2.0-db88afb2ca18` | **Qualified and approved for `v0.2.0`.** Couch-flow visual pass, Settings sheet, transcript windowing, and shell-precached collab client; cross-version `v0.1.0` rollback pair. | Archive SHA-256 `149fc1b88a22b9cb1781bcb6219f2c1e41cafc867cb4eefe0a1e04b07eceeea2`; signed tag/assets/attestations/bundles, Debian run `33156664373` incl. `v0.1.0` migration, macOS `doctor` 17/17 and rollback 20/20, Pixel lock/Airplane/Doze recovery with a clean seven-sink sweep, patched-OMP publication/revocation, 60s relay smoke, and cleanup all passed exactly once. |
 
 [`RELEASE_STATUS.md`](RELEASE_STATUS.md) is the source of truth for evidence and release decisions.
 This document defines the supported boundary. Where they disagree, the ledger is authoritative.
@@ -90,6 +94,7 @@ Published releases and unreleased development targets use separate immutable ups
 | `0.1.0`, published as `v0.1.0-alpha.1` | `can1357/oh-my-pi@858f7dd91fff9b84cf8a2c6a6bb85aa0e6d03a55` | `v17.3.8` | coding-agent `17.3.8`; wire `17.3.8` | collab-web `16.3.6` from the same source commit | 1 | Exact-commit alpha qualification only |
 | `0.1.0`, published as `v0.1.0-beta.1` | `can1357/oh-my-pi@9350b7990d26ebf69a604edc82d8558ef04adf30` | `v17.4.1` | coding-agent `17.4.1`; wire `17.4.1` | collab-web `16.3.6` from the same source commit | 1 | Exact-commit beta qualification through the versioned patched-binary route |
 | `0.1.0`, published as `v0.1.0` | `can1357/oh-my-pi@9350b7990d26ebf69a604edc82d8558ef04adf30` | `v17.4.1` | coding-agent `17.4.1`; wire `17.4.1` | collab-web `16.3.6` from the same source commit | 1 | Exact-commit stable qualification with patch tree `a5cfc80fcc0df1ca6e430c125371bcae43d5e5f7` through the versioned patched-binary route |
+| `0.2.0`, published as `v0.2.0` | `can1357/oh-my-pi@9350b7990d26ebf69a604edc82d8558ef04adf30` | `v17.4.1` | coding-agent `17.4.1`; wire `17.4.1` | collab-web `16.3.6` from the same source commit | 1 | Exact-commit stable qualification with patch tree `a5cfc80fcc0df1ca6e430c125371bcae43d5e5f7` through the versioned patched-binary route |
 
 v17.3.8 remains the immutable alpha baseline. Exact v17.4.1 source and patch tree are independently
 qualified for beta and stable through the versioned executable route. No other OMP release, commit,
@@ -114,13 +119,14 @@ Android, browser, or signed-artifact qualification. Any platform row whose evide
 2026-08-19 is therefore **NOT RUN** for this pin until re-executed, and an unchanged row is never
 coverage of `v17.3.8`.
 
-Re-execution is current at stable candidate `.23`. On 2026-08-22 it passed the complete Debian
-signed-artifact lifecycle; the complete macOS install, persistence, rollback, and cleanup sequence;
-exact v17.4.1 patched-OMP publication/revocation; physical Pixel same-page lock, Airplane, and
-forced-Doze recovery; the seven-sink capability sweep; and the bounded relay smoke. The protected
+Re-execution is current at stable candidate `v0.2.0-prealpha.1`. On 2026-08-28 it passed the
+complete Debian signed-artifact lifecycle including the cross-version `v0.1.0` predecessor
+migration; the complete macOS install, persistence, rollback, and cleanup sequence; exact v17.4.1
+patched-OMP publication/revocation; physical Pixel same-page lock, Airplane, and forced-Doze
+recovery; the seven-sink capability sweep; and the bounded relay smoke. The protected
 28,800-second long-window result remains transferable because relay host/client, collab-web, and
 wire bytes are unchanged. Issue #65 stays open for other process-wide Chrome failures, not as a
-qualification exception for the transitions `.23` actually passed.
+qualification exception for the transitions the candidate actually passed.
 
 The immutable source paths, versions, observation date, and upstream findings live in
 [`UPSTREAM.lock.json`](../UPSTREAM.lock.json). The gateway integration currently requires:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -3,11 +3,11 @@
 ## Pre-alpha, alpha, beta, and stable artifacts
 
 The repository produces working Bun-runtime engineering candidates and advertised alpha, beta,
-and stable releases. v0.1.0 is the current stable publication and GitHub Latest. Its support claim
+and stable releases. v0.2.0 is the current stable publication and GitHub Latest. Its support claim
 is bound to the signed predecessor and exact evidence in `STABLE_RELEASE.lock.json` and
 `RELEASE_STATUS.md`; generated artifacts never promote themselves.
 
-Stable 0.1 is a bounded support claim, not an expansion to platform families. It covers only the
+Stable 0.2 is a bounded support claim, not an expansion to platform families. It covers only the
 hosts, Android client, TUN-mode Tailscale Serve path, and exact patched OMP baseline recorded in
 COMPATIBILITY.md at the release commit. Windows, background Push qualification, Portal Tunnel,
 userspace networking, Funnel, self-hosted/proxied relays, stock OMP, and every unnamed combination
@@ -19,10 +19,11 @@ Upstreaming and paired packaging remain deferred under ADR-024 and ADR-025. Ever
 process must use the exact verified binary; the gateway release alone cannot add the missing stock
 OMP controller/publication seam.
 
-Gateway rollback does not implicitly switch OMP. A stable-to-beta rollback retains the same exact
-v17.4.1 patched OMP prerequisite; use managed gateway rollback when the beta archive remains in
-installation history, otherwise reinstall v0.1.0-beta.1. Any change to the active OMP binary or
-symlink remains the separate documented manual operation.
+Gateway rollback does not implicitly switch OMP. A rollback to the v0.1.0 stable predecessor
+retains the same exact v17.4.1 patched OMP prerequisite; use managed gateway rollback when the
+predecessor archive remains in installation history, otherwise reinstall the signed v0.1.0
+archive. Any change to the active OMP binary or symlink remains the separate documented manual
+operation.
 
 ## Release gates
 
@@ -41,7 +42,7 @@ Every advertised release requires:
 - complete checksums, SBOM, GitHub attestations, Cosign bundles, signed tag, and reproducible build
   verification.
 
-Stable v0.1.0 additionally requires that the exact signed tag's tree contain a fully passed
+Stable v0.2.0 additionally requires that the exact signed tag's tree contain a fully passed
 STABLE_RELEASE.lock.json candidate tag/source/archive digest, runtime-byte comparison, Debian,
 retained Mac14,3, physical Pixel, patched-OMP publication, provenance, and secret-sink evidence.
 The workflow asserts checked-out HEAD equals the event SHA, checks candidate ancestry and the
@@ -85,12 +86,12 @@ origin. The Android qualification PIN stays in the documented macOS Keychain ser
 Zero, unauthorized, or ambiguous adb devices are refused before release download, host mutation, or
 fixture creation; set `OMP_ANDROID_SERIAL` when more than one authorized device is attached.
 
-For v0.1.0, run:
+For the current stable, run:
 
 ```sh
 bunx bun@1.3.14 run smoke:release -- \
-  --tag v0.1.0 \
-  --archive-sha256 925957ab636eb611649bafb3b6bac85061eefd3127dd756a9377123333eda262
+  --tag v0.2.0 \
+  --archive-sha256 <the omp-session-gateway-0.2.0-bun.tar digest from the published SHA256SUMS>
 ```
 
 The command verifies the annotated tag, GitHub Latest state, all six release asset digests,

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -1,23 +1,56 @@
 # Release status
 
 **Updated:** 2026-08-28<br>
-**Repository version:** `0.2.0`; stable claim target **`v0.2.0`** (pending)<br>
-**Published stable:** **`v0.1.0`** remains GitHub Latest until the 0.2 campaign passes<br>
-**Classification:** v0.2.0 is **not qualified**; the v0.1.0 boundary below remains the only stable claim<br>
-**Stable decision (0.2):** **PENDING** — `STABLE_RELEASE.lock.json` is `pending` and blocks a `v0.2.0` tag.
+**Repository version:** `0.2.0`; stable publication source for **`v0.2.0`**<br>
+**Qualification predecessor:** **`v0.2.0-prealpha.1`**, independently verified<br>
+**Classification:** stable-qualified for the exact combinations below; no broader production claim<br>
+**Stable decision:** **GO, approved**, for the named support boundary and nothing else.
 
-### Stable 0.2 — qualification pending
+### Stable 0.2 — GO
 
-**Target tag:** `v0.2.0`, to be published as a non-prerelease and GitHub Latest only after this
-section records a passed campaign.<br>
-**Planned candidate:** the first published `v0.2.0-prealpha.<n>` engineering tag.<br>
-**Rollback predecessor:** published stable `v0.1.0`.<br>
-**Machine gate:** `STABLE_RELEASE.lock.json` is `pending`; `release-policy.ts` refuses a stable
-tag until every commit-bound field passes and the ledger records approval.<br>
-**Planned evidence:** the same lanes as 0.1 — signed candidate artifacts, Debian disposable-host
-lifecycle, retained `Mac14,3` lifecycle with cross-version `v0.1.0 → candidate` upgrade/rollback,
-exact patched-OMP publication/revocation, physical Pixel acceptance with the forbidden-sink sweep,
-and a bounded default-relay smoke, recorded here before ledger approval.
+**Target tag:** `v0.2.0`, published as a non-prerelease and GitHub Latest.<br>
+**Machine gate:** `STABLE_RELEASE.lock.json` is qualified for candidate `v0.2.0-prealpha.1`.<br>
+**Candidate source:** `db88afb2ca18b0822648012bb6da50fd596f294c`.<br>
+**Candidate archive SHA-256:** `149fc1b88a22b9cb1781bcb6219f2c1e41cafc867cb4eefe0a1e04b07eceeea2`.<br>
+**Rollback predecessor:** published stable `v0.1.0`; the Mac lane exercised the cross-version
+`v0.1.0 → v0.2.0-prealpha.1` upgrade and rollback pair.<br>
+**Support boundary:** Debian 13 x86-64, macOS 26.6.1 arm64 on `Mac14,3`, Chrome
+`151.0.7922.173` on Android 17 / Pixel 10 Pro, TUN-mode Tailscale Serve, and exact patched OMP
+v17.4.1 source `9350b7990d26ebf69a604edc82d8558ef04adf30` with patched tree
+`a5cfc80fcc0df1ca6e430c125371bcae43d5e5f7`. Windows, stock OMP, background Push, Funnel,
+Portal Tunnel, userspace networking, alternate/self-hosted relays, and paired OMP packaging remain
+unsupported.
+
+One orchestrator process ran from published branch `main` at
+`fb375fad33cba7945e3455a9d43c2fcb30874db7` and wrote the mode-`0600` receipt
+`~/.local/share/omp-session-gateway/qualification/v0.2.0-prealpha.1/stable-qualification.json`.
+It completed `passed` at `2026-08-28T09:01:38.902Z`; every lane ran exactly once:
+
+- release run [`33155940416`](https://github.com/alphastorm/omp-session-gateway/actions/runs/33155940416)
+  published six prerelease/not-Latest assets; the signed tag, checksums, all six GitHub asset
+  digests, three GitHub attestations, and three Cosign bundles verified against the exact
+  candidate archive SHA-256 above;
+- Debian run [`33156664373`](https://github.com/alphastorm/omp-session-gateway/actions/runs/33156664373)
+  passed the full disposable-host lifecycle on Debian 13 (trixie), kernel `6.12.94+deb13-amd64`,
+  systemd 257, including the cross-version `v0.1.0` predecessor migration lane, and destroyed its
+  droplet and ephemeral SSH key;
+- retained `Mac14,3` / macOS 26.6.1 arm64 passed `doctor` 17/17, rollback invariants 20/20,
+  persistence, exact archive/native checks (archive equal to the candidate digest; native addon
+  `7fd4e3f822ff5b1fb890c27ec8a7e19166902f70c81eb4d303061fefe26766f1`), patched-OMP build,
+  publication/revocation, uninstall, and Serve/source cleanup;
+- the exact patched OMP published generation-1 View and Control, returned `200 no-store`, and
+  revoked before cleanup;
+- the Pixel 10 Pro (`Chrome 151.0.7922.173`) rendered the same page throughout: lock/resume
+  recovered in 8,793 ms, a visible Airplane outage recovered in 8,274 ms, and forced Doze
+  recovered in 8,360 ms; the seven-sink capability sweep planted 7, detected 7, and ended clean;
+- the default relay stayed live for 60 seconds with two transitions; and
+- final cleanup measured zero gateway processes/listeners and zero patched-OMP processes.
+
+The first `v0.2.0-prealpha.1` qualification dispatch failed closed at the Debian preflight
+(cross-version predecessor asset naming, fixed in
+[#146](https://github.com/alphastorm/omp-session-gateway/pull/146)) without creating a droplet or
+touching the Mac; its archived receipt recorded no Mac effects and the passing run above started
+from a fresh receipt.
 
 ### Stable 0.1 — GO
 


### PR DESCRIPTION
Ledger approval for the passed `v0.2.0-prealpha.1` qualification (receipt completed 2026-08-28T09:01:38.902Z, every lane passed exactly once). Turns STABLE_RELEASE.lock.json qualified, records per-lane evidence in RELEASE_STATUS.md, and moves COMPATIBILITY/README/RELEASE claims to the v0.2.0 boundary. `bun run check` green.