### PR TITLE
fix(gateway): report the true product version from installations and diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable project changes will be documented here.
 
 The format is based on Keep a Changelog and Semantic Versioning.
 
+## [Unreleased]
+
+### Fixed
+
+- Report the true product version from managed installations and diagnostics: the published
+  v0.2.0 archive still names its version directories, `status` output, and doctor bundles
+  `0.1.0-<content-hash>` because two runtime constants sat outside the release version sweep.
+  Install and rollback identity bind to the content hash and source commit, so behavior was
+  unaffected; a version-coherence test now fails `bun run check` when any constant lags
+  `package.json`.
+
 ## [v0.2.0] — 2026-08-28
 
 ### Added

--- a/apps/gateway/src/diagnostics.ts
+++ b/apps/gateway/src/diagnostics.ts
@@ -3,7 +3,7 @@ import { open } from "node:fs/promises";
 import { PROTOCOL_VERSION } from "@omp-session-gateway/protocol";
 
 export const DIAGNOSTICS_FORMAT_VERSION = 1 as const;
-export const PRODUCT_VERSION = "0.1.0";
+export const PRODUCT_VERSION = "0.2.0";
 
 export interface DoctorReport {
   readonly service: "omp-session-gateway";

--- a/apps/gateway/src/installation.ts
+++ b/apps/gateway/src/installation.ts
@@ -5,7 +5,7 @@ import { basename, dirname, extname, join, relative, resolve, sep } from "node:p
 import { fileURLToPath } from "node:url";
 import type { GatewayConfig } from "./config.ts";
 
-export const GATEWAY_VERSION = "0.1.0";
+export const GATEWAY_VERSION = "0.2.0";
 const VERSION_PATTERN = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/u;
 const VERSION_NAME_PATTERN =
   /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?-[0-9a-f]{12}$/u;

--- a/apps/gateway/test/installation.test.ts
+++ b/apps/gateway/test/installation.test.ts
@@ -5,6 +5,7 @@ import { basename, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import type { GatewayConfig } from "../src/config.ts";
 import {
+  GATEWAY_VERSION,
   type InstalledRuntime,
   activateRuntime,
   activationHistory,
@@ -87,7 +88,7 @@ test("stages immutable content-addressed runtimes and atomically advances the cu
     const source = await sourceFixture(root);
     const first = await stageRuntimePayload(gatewayConfig, source);
     expect(first.previous).toBeUndefined();
-    expect(first.directory).toMatch(/0\.1\.0-[0-9a-f]{12}$/u);
+    expect(basename(first.directory)).toMatch(new RegExp(`^${GATEWAY_VERSION.replaceAll(".", "\\.")}-[0-9a-f]{12}$`, "u"));
     expect(first.readinessProtocol).toBe("instance-v1");
     expect((await lstat(first.cliPath)).isFile()).toBe(true);
     expect((await lstat(join(first.directory, "bun.lock"))).isFile()).toBe(true);

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -52,6 +52,14 @@ The first `v0.2.0-prealpha.1` qualification dispatch failed closed at the Debian
 touching the Mac; its archived receipt recorded no Mac effects and the passing run above started
 from a fresh receipt.
 
+**Known cosmetic defect in the published v0.2.0 archive:** `installation.ts`/`diagnostics.ts`
+carry a hardcoded `0.1.0` product constant, so managed-installation directories, `status`
+`activeVersion`, and diagnostics bundles from v0.2.0 report `0.1.0-<content-hash>` while running
+the exact v0.2.0 bytes. Install/rollback identity binds to the content hash and source commit —
+the qualified rollback and post-release smoke lanes passed with the defect present — so the
+support claim is unaffected. Fixed on `main` with a version-coherence test; the next release
+reports its true version.
+
 ### Stable 0.1 — GO
 
 **Target tag:** `v0.1.0`, published as a non-prerelease and GitHub Latest.<br>

--- a/scripts/version-coherence.test.ts
+++ b/scripts/version-coherence.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import { PRODUCT_VERSION as DIAGNOSTICS_VERSION } from "../apps/gateway/src/diagnostics.ts";
+import { GATEWAY_VERSION } from "../apps/gateway/src/installation.ts";
+import { PRODUCT_VERSION as RELEASE_VERSION } from "./build-release.ts";
+
+/**
+ * Every runtime and release constant must move with the package version in one commit. The v0.2.0
+ * campaign shipped an archive whose managed-installation metadata still reported 0.1.0 because
+ * these constants lived outside the version sweep; this test makes the next bump fail closed in
+ * `bun run check` instead of in a published artifact.
+ */
+test("runtime and release version constants match package.json", async () => {
+  const packageJson = (await Bun.file(new URL("../package.json", import.meta.url)).json()) as {
+    version: string;
+  };
+  expect(GATEWAY_VERSION).toBe(packageJson.version);
+  expect(DIAGNOSTICS_VERSION).toBe(packageJson.version);
+  expect(RELEASE_VERSION).toBe(packageJson.version);
+});


### PR DESCRIPTION
The published v0.2.0 archive names version directories, status activeVersion,
and doctor bundles 0.1.0-<content-hash> because GATEWAY_VERSION and the
diagnostics PRODUCT_VERSION sat outside the release version sweep. Identity
binds to the content hash and source commit, so install, rollback, and the
qualified lanes were unaffected. Bump both constants and add a
version-coherence test so bun run check fails closed when any runtime or
release constant lags package.json; disclose the cosmetic defect in the
release ledger.
