### PR TITLE
fix(release): derive asset names from tag

### DIFF
--- a/scripts/release-state.test.ts
+++ b/scripts/release-state.test.ts
@@ -2,14 +2,16 @@ import { describe, expect, test } from "bun:test";
 import { assertReleaseState } from "./release-state.ts";
 
 const TAG = "v0.2.0";
-function assets(): { name: string; state: string; digest: string }[] {
+function assets(tag = TAG): { name: string; state: string; digest: string }[] {
+  const version = /^v([0-9]+[.][0-9]+[.][0-9]+)/u.exec(tag)?.[1];
+  if (version === undefined) throw new Error("test tag has no version");
   const names = [
     "SHA256SUMS",
     "SHA256SUMS.sigstore.json",
-    "omp-session-gateway-0.2.0-bun.tar",
-    "omp-session-gateway-0.2.0-bun.tar.sigstore.json",
-    "omp-session-gateway-0.2.0.spdx.json",
-    "omp-session-gateway-0.2.0.spdx.json.sigstore.json",
+    `omp-session-gateway-${version}-bun.tar`,
+    `omp-session-gateway-${version}-bun.tar.sigstore.json`,
+    `omp-session-gateway-${version}.spdx.json`,
+    `omp-session-gateway-${version}.spdx.json.sigstore.json`,
   ];
   return names.map((name, index) => ({ name, state: "uploaded", digest: "sha256:" + String(index + 1).repeat(64) }));
 }
@@ -30,6 +32,22 @@ describe("GitHub release state", () => {
   test("accepts a complete not-Latest stable draft and a published Latest release", () => {
     expect(() => assertReleaseState(release(), null, expectedState(true, false, false))).not.toThrow();
     expect(() => assertReleaseState(release({ draft: false }), TAG, expectedState(false, false, true))).not.toThrow();
+  });
+
+  test("derives prerelease asset names from the tag version", () => {
+    const tag = "v0.2.1-prealpha.1";
+    const candidateAssets = assets(tag);
+    const candidate = release({ tag_name: tag, prerelease: true, assets: candidateAssets });
+    const assetDigests = Object.fromEntries(candidateAssets.map(asset => [asset.name, asset.digest]));
+    expect(() =>
+      assertReleaseState(candidate, TAG, {
+        tag,
+        draft: true,
+        prerelease: true,
+        latest: false,
+        assetDigests,
+      }),
+    ).not.toThrow();
   });
 
   test("rejects wrong flags, premature Latest, and missing assets", () => {

--- a/scripts/release-state.ts
+++ b/scripts/release-state.ts
@@ -1,15 +1,20 @@
-const EXPECTED_ASSETS = [
-  "SHA256SUMS",
-  "SHA256SUMS.sigstore.json",
-  "omp-session-gateway-0.2.0-bun.tar",
-  "omp-session-gateway-0.2.0-bun.tar.sigstore.json",
-  "omp-session-gateway-0.2.0.spdx.json",
-  "omp-session-gateway-0.2.0.spdx.json.sigstore.json",
-] as const;
+function expectedAssets(tag: string): readonly string[] {
+  const match = /^v([0-9]+[.][0-9]+[.][0-9]+)(?:-|$)/u.exec(tag);
+  if (match === null) throw new Error("release tag does not contain a numeric version");
+  const version = match[1];
+  return [
+    "SHA256SUMS",
+    "SHA256SUMS.sigstore.json",
+    `omp-session-gateway-${version}-bun.tar`,
+    `omp-session-gateway-${version}-bun.tar.sigstore.json`,
+    `omp-session-gateway-${version}.spdx.json`,
+    `omp-session-gateway-${version}.spdx.json.sigstore.json`,
+  ];
+}
 
-export async function releaseAssetDigests(root: string): Promise<Record<string, string>> {
+export async function releaseAssetDigests(root: string, tag: string): Promise<Record<string, string>> {
   const digests: Record<string, string> = {};
-  for (const name of EXPECTED_ASSETS) {
+  for (const name of expectedAssets(tag)) {
     const hasher = new Bun.CryptoHasher("sha256");
     hasher.update(await Bun.file(root + "/" + name).arrayBuffer());
     digests[name] = "sha256:" + hasher.digest("hex");
@@ -35,6 +40,7 @@ export function assertReleaseState(
     readonly assetDigests: Readonly<Record<string, string>>;
   },
 ): void {
+  const expectedAssetNames = expectedAssets(expected.tag);
   const release = record(value, "GitHub release");
   if (
     release.tag_name !== expected.tag ||
@@ -44,7 +50,7 @@ export function assertReleaseState(
   ) {
     throw new Error("GitHub release flags do not match the validated policy");
   }
-  if (!Array.isArray(release.assets) || release.assets.length !== EXPECTED_ASSETS.length) {
+  if (!Array.isArray(release.assets) || release.assets.length !== expectedAssetNames.length) {
     throw new Error("GitHub release does not contain exactly six assets");
   }
   const names: string[] = [];
@@ -64,10 +70,10 @@ export function assertReleaseState(
     names.push(asset.name);
   }
   names.sort();
-  if (names.some((name, index) => name !== EXPECTED_ASSETS[index])) {
+  if (names.some((name, index) => name !== expectedAssetNames[index])) {
     throw new Error("GitHub release asset names do not match the stable contract");
   }
-  if (Object.keys(expected.assetDigests).sort().some((name, index) => name !== EXPECTED_ASSETS[index])) {
+  if (Object.keys(expected.assetDigests).sort().some((name, index) => name !== expectedAssetNames[index])) {
     throw new Error("Expected release asset digests do not match the stable contract");
   }
 }
@@ -115,7 +121,7 @@ if (import.meta.main) {
       draft: draft === "true",
       prerelease: prerelease === "true",
       latest: latest === "true",
-      assetDigests: await releaseAssetDigests(assetRoot),
+      assetDigests: await releaseAssetDigests(assetRoot, tag),
     });
     console.log("verified release state for " + tag);
   } catch (error) {


### PR DESCRIPTION
## Problem
`v0.2.1-prealpha.1` built, attested, and signed successfully, then draft validation looked for hardcoded `0.2.0` asset names and deleted the draft. The signed candidate tag remains diagnostic evidence and is not Latest.

## Fix
Derive the six expected asset names from the validated numeric version in the release tag. Add a `v0.2.1-prealpha.1` regression while preserving stable `v0.2.0` coverage.

## Verification
- focused release-state/workflow tests: 10 passed
- `bun run check` under Bun 1.3.14: 495 passed
- capability and identifier leak scans passed

After merge, the replacement tag will be `v0.2.1-prealpha.2`; the failed `.1` tag will not be rewritten.