### PR TITLE
docs(release): record replacement candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on Keep a Changelog and Semantic Versioning.
   `package.json`.
 - Prevent long session titles from colliding with Control and connection state in the mobile
   collaboration shell by giving the title its own full-width header row.
+- Derive draft and published release asset names from the validated tag version; the first 0.2.1
+  candidate failed closed after signing when draft validation still looked for 0.2.0 filenames.
 
 ## [v0.2.0] — 2026-08-28
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -55,7 +55,7 @@ Chrome.
 Run the exact host/client sequence from a clean, published Darwin-arm64 branch:
 
 ```sh
-bun run qualify:stable --tag v0.2.1-prealpha.1
+bun run qualify:stable --tag v0.2.1-prealpha.2
 ```
 
 The command re-verifies the signed tag, six release assets, checksums, three GitHub attestations, and three Sigstore bundles; dispatches or resumes the Debian workflow; discovers the retained Scaleway Mac by name; runs install, doctor, exposure, reboot, stable-to-candidate rollback, exact patched-OMP build/publication/revocation, physical-Pixel acceptance and forbidden-sink sweep, and a bounded relay smoke; then uninstalls and removes qualification-owned Mac state. It writes one mode-`0600` receipt at `~/.local/share/omp-session-gateway/qualification/<tag>/stable-qualification.json`.

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -1,10 +1,16 @@
 # Release status
 
 **Updated:** 2026-08-28<br>
-**Repository candidate:** `v0.2.1-prealpha.1`; qualification pending, current stable is **`v0.2.0`**<br>
+**Repository candidate:** `v0.2.1-prealpha.2`; qualification pending, current stable is **`v0.2.0`**<br>
 **Qualification predecessor:** **`v0.2.0-prealpha.1`**, independently verified<br>
 **Classification:** `0.2.1` is an unqualified engineering candidate; the stable-qualified claim below applies only to `v0.2.0`<br>
 **Stable decision:** **GO, approved**, for the named support boundary and nothing else.
+
+Candidate `v0.2.1-prealpha.1` built, attested, and signed successfully, then failed closed while
+validating its draft because `release-state.ts` still expected `0.2.0` asset names. The workflow
+deleted the draft; the signed tag and transparency records remain diagnostic evidence. Candidate
+`v0.2.1-prealpha.2` derives the six expected assets from the validated tag version and is the only
+0.2.1 candidate eligible for qualification.
 
 ### Stable 0.2 — GO
 


### PR DESCRIPTION
## Summary
- mark `v0.2.1-prealpha.2` as the only qualification candidate
- record `.1` as a fail-closed draft-validation attempt with no surviving release
- point the operator qualification command at `.2`
- document the tag-derived asset-name regression fix

## Verification
- replacement `.2` signed release workflow passed
- `bun run check` under Bun 1.3.14: 495 passed
- candidate remains prerelease/not-Latest; current stable remains `v0.2.0`