### PR TITLE
docs(release): record v0.3.0 pre-alpha smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog and Semantic Versioning.
 
 ## [Unreleased]
 
+## [v0.3.0-prealpha.1] — 2026-08-29
+
 ### Added
 
 - Add a phone-first photo composer to Control sessions: one tap opens the system camera/photo

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -4,8 +4,9 @@
 
 **Current release:** stable-qualified `v0.2.1` for the exact matrix below.<br>
 **Stable candidate:** signed `v0.2.1-prealpha.2`, fully qualified and approved.<br>
-**Engineering head:** `0.3.0` adds the phone photo composer and is unqualified pre-alpha work;
-none of the stable evidence transfers to its changed collaboration-client bytes.<br>
+**Engineering release:** published `v0.3.0-prealpha.1` adds the phone photo composer and has
+only the exact local Darwin/desktop/Pixel-viewport smoke recorded below; none of the stable evidence
+transfers to its changed collaboration-client bytes.<br>
 **0.3.0 engineering/qualification predecessor:** published stable `v0.2.1`.<br>
 **v0.2.1 stable campaign rollback predecessor:** published stable `v0.2.0`.<br>
 **Qualification predecessor:** signed stable candidate `v0.2.1-prealpha.2`.<br>
@@ -69,6 +70,7 @@ explicit, and the 0.2 campaign adds its own row:
 | `v0.2.0-prealpha.1` | `0.2.0-db88afb2ca18` | **Qualified and approved for `v0.2.0`.** Couch-flow visual pass, Settings sheet, transcript windowing, and shell-precached collab client; cross-version `v0.1.0` rollback pair. | Archive SHA-256 `149fc1b88a22b9cb1781bcb6219f2c1e41cafc867cb4eefe0a1e04b07eceeea2`; signed tag/assets/attestations/bundles, Debian run `33156664373` incl. `v0.1.0` migration, macOS `doctor` 17/17 and rollback 20/20, Pixel lock/Airplane/Doze recovery with a clean seven-sink sweep, patched-OMP publication/revocation, 60s relay smoke, and cleanup all passed exactly once. |
 | `v0.2.1-prealpha.1` | `0.2.1-3ea58e234b6d` | **Rejected before qualification.** Build, attest, and signing passed; draft validation still expected 0.2.0 asset names and deleted the draft. | Signed diagnostic tag and transparency records retained; no GitHub release survived and no host/client qualification ran. |
 | `v0.2.1-prealpha.2` | `0.2.1-f09e3566c238` | **Qualified and approved for `v0.2.1`.** Final phone hierarchy, coherent product versioning, predecessor-bound receipts, and stable runtime equivalence gate. | Archive SHA-256 `9fd5e49b9819ab4dfc82f978fcd9e8382b83d5b821bb341c6b6e6979ff42c7fa`; release run `33206359784`, Debian `33207184350`, macOS `doctor` 17/17 and rollback 20/20 from v0.2.0, physical Pixel recovery/leak sweep, patched-OMP publication/revocation, 60s relay smoke, and cleanup passed. |
+| `v0.3.0-prealpha.1` | `0.3.0-1a8a3212e195` | **Published pre-alpha; locally smoke-tested, not qualified.** Phone photo chooser/composer using existing OMP v3 image prompts. | Archive SHA-256 `60750b2b5f21d4e99dbd1a4d05230f4aa3f4d79b15c113d08aa68042a54c5fed`; release run `33281549543`; checksums, six immutable assets, three attestations, and three bundles verified; local Darwin install/doctor 17/17 and real patched-host desktop plus measured Pixel-viewport sends passed. No physical Android run. |
 
 [`RELEASE_STATUS.md`](RELEASE_STATUS.md) is the source of truth for evidence and release decisions.
 This document defines the supported boundary. Where they disagree, the ledger is authoritative.

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -9,12 +9,39 @@ exact qualified combinations below and no broader production claim<br>
 
 ### 0.3.0 engineering track — unqualified
 
-The 0.3.0 source adds a bounded phone-camera/photo composer to the pinned collaboration client.
+Published engineering release `v0.3.0-prealpha.1` adds a bounded phone-camera/photo composer to
+the pinned collaboration client.
 It uses the existing encrypted OMP v3 image-prompt frame and does not change gateway IPC/HTTP,
 capability handling, the controller/publisher patch, or `COLLAB_PROTO`. No 0.2.1 qualification
-evidence transfers to these changed client bytes. Any 0.3.0 artifact remains pre-alpha until its
-exact source, archive, local activation, physical Pixel flow, and forbidden-sink checks are
-recorded; it cannot replace or widen the stable support claim below.
+evidence transfers to these changed client bytes. The exact source, archive, local activation, and
+real patched-host browser flow are recorded below; the physical Pixel camera chooser and the full
+qualification matrix have not run. The release remains pre-alpha and cannot replace or widen the
+stable support claim below.
+
+### v0.3.0-prealpha.1 — published engineering release
+
+**Source:** `790658ee914658d742ff0b369fd6b33b78efd9ea`.<br>
+**Archive SHA-256:** `60750b2b5f21d4e99dbd1a4d05230f4aa3f4d79b15c113d08aa68042a54c5fed`.<br>
+**Release run:** [`33281549543`](https://github.com/alphastorm/omp-session-gateway/actions/runs/33281549543), passed.<br>
+**Classification:** published immutable prerelease, not Latest; unqualified beyond the exact smoke
+below. Stable `v0.2.1` remains GitHub Latest and the 0.3.0 rollback/qualification predecessor.
+
+The release published six assets. `SHA256SUMS` verified the archive and SPDX document; all six
+immutable asset digests, three GitHub build attestations, and three Sigstore bundles verified
+against the signed tag and `signed-release.yml` identity.
+
+The published archive installed on the configured Darwin arm64 workstation as
+`0.3.0-1a8a3212e195` under pinned Bun 1.3.14. Private config and publisher-token SHA-256 values
+remained byte-identical, `status` reported active/ready/non-diverged, and `doctor` passed 17/17.
+An owned exact patched-OMP v17.4.1 fixture published View and Control through the default relay.
+The released client proved View disabled the photo path, upgraded to Control, normalized and sent a
+2,048px captioned desktop image and a 2,048px image-only Pixel-viewport image, received byte-exact
+host transcript acknowledgement, cleared each retained draft, rendered transcript images within
+the viewport, and showed no horizontal overflow. Fixture revocation and scoped cleanup passed.
+
+The measured `411 × 816` Pixel layout and desktop Chromium surface are smoke evidence only. No ADB
+device was attached, so physical camera/photo chooser behavior, Android process lifecycle, and the
+full forbidden-sink sweep remain unproven for these exact bytes.
 
 Candidate `v0.2.1-prealpha.1` built, attested, and signed successfully, then failed closed while
 validating its draft because `release-state.ts` still expected `0.2.0` asset names. The workflow


### PR DESCRIPTION
## Evidence recorded
- immutable prerelease v0.3.0-prealpha.1, exact source/archive digest, six assets, attestations, and Sigstore verification
- active Darwin runtime 0.3.0-1a8a3212e195 under pinned Bun 1.3.14 with private config/token unchanged and doctor 17/17
- real patched OMP v17.4.1 View/Control publication and host-acknowledged desktop plus measured Pixel-viewport photo sends
- explicit physical Pixel/ADB and full qualification exclusions

Stable v0.2.1 remains Latest and supported; this does not promote the 0.3.0 bytes.