### PR TITLE
feat(collab): add direct camera choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog and Semantic Versioning.
 
 ## [Unreleased]
 
+### Changed
+
+- Make the Photo action explicitly offer **Take photo** and **Choose existing**. The camera path
+  requests the rear-facing system camera while the library path remains an unrestricted image
+  picker, avoiding Android's one-input camera-or-library ambiguity.
+
 ## [v0.3.0-prealpha.1] — 2026-08-29
 
 ### Added

--- a/apps/web/e2e/launch.e2e.ts
+++ b/apps/web/e2e/launch.e2e.ts
@@ -85,8 +85,9 @@ async function attachSyntheticPhoto(
   page: Page,
   label: string,
   mimeType: "image/jpeg" | "image/png" | "image/webp" = "image/jpeg",
+  source: "camera" | "library" = "library",
 ): Promise<void> {
-  await page.locator(".sh-photo-input").evaluate(async (element, options) => {
+  await page.locator(".sh-photo-input-" + source).evaluate(async (element, options) => {
     const input = element as HTMLInputElement;
     const canvas = document.createElement("canvas");
     canvas.width = 2_400;
@@ -806,15 +807,51 @@ test("embedded active ask matches the original 3d shell interaction", async ({ p
     });
     await expect(page.locator(".sh-composer-ask-embedded")).toHaveCount(0);
 
-    const photoInput = page.locator(".sh-photo-input");
-    const photoTrigger = page.getByRole("button", { name: "Take or attach a photo" });
+    const cameraInput = page.locator(".sh-photo-input-camera");
+    const photoInput = page.locator(".sh-photo-input-library");
+    const photoTrigger = page.getByRole("button", { name: "Add a photo" });
     const promptInput = page.locator(".sh-composer-input");
     const promptSend = page.locator(".sh-composer > .sh-composer-inner .sh-btn-primary");
+    await expect(cameraInput).toHaveAttribute("accept", "image/jpeg,image/png,image/webp");
+    await expect(cameraInput).toHaveAttribute("capture", "environment");
     await expect(photoInput).toHaveAttribute("accept", "image/jpeg,image/png,image/webp");
     await expect(photoInput).not.toHaveAttribute("capture", /.+/u);
     await expect(photoTrigger).toBeEnabled();
+    await photoTrigger.click();
+    await expect(photoTrigger).toHaveAttribute("aria-expanded", "true");
+    const takePhoto = page.getByRole("button", { name: /Take photo/u });
+    const chooseExisting = page.getByRole("button", { name: /Choose existing/u });
+    await expect(takePhoto).toBeVisible();
+    await expect(chooseExisting).toBeVisible();
+    for (const choice of [takePhoto, chooseExisting]) {
+      const bounds = await choice.boundingBox();
+      expect(bounds?.height).toBeGreaterThanOrEqual(44);
+    }
+    await takePhoto.focus();
+    await page.keyboard.press("Escape");
+    await expect(photoTrigger).toHaveAttribute("aria-expanded", "false");
+    await expect(photoTrigger).toBeFocused();
+    await photoTrigger.click();
+    await expect(takePhoto).toBeVisible();
+    const cameraChooserPromise = page.waitForEvent("filechooser");
+    await takePhoto.click();
+    const cameraChooser = await cameraChooserPromise;
+    expect(await cameraChooser.element().getAttribute("capture")).toBe("environment");
+    await cameraChooser.setFiles([]);
+    await expect(photoTrigger).toHaveAttribute("aria-expanded", "false");
 
-    await attachSyntheticPhoto(page, "CONNECTOR A");
+    await photoTrigger.click();
+    const libraryChooserPromise = page.waitForEvent("filechooser");
+    await chooseExisting.click();
+    const libraryChooser = await libraryChooserPromise;
+    expect(await libraryChooser.element().getAttribute("capture")).toBeNull();
+    await libraryChooser.setFiles([]);
+    await expect(photoTrigger).toHaveAttribute("aria-expanded", "false");
+
+    await photoTrigger.click();
+
+    await attachSyntheticPhoto(page, "CONNECTOR A", "image/jpeg", "camera");
+    await expect(photoTrigger).toHaveAttribute("aria-expanded", "false");
     const preview = page.locator(".sh-photo img");
     await expect(preview).toBeVisible();
     await expect.poll(() => preview.evaluate(image => ({

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -125,8 +125,11 @@ Preferred integration:
 5. return to the directory on reload because the capability is intentionally not recoverable.
 
 In a writable Control session, the same pinned client may collect up to four photos through the
-system camera/photo chooser. It rejects source dimensions above an 8,192px edge or 20 megapixels,
-then decodes and canvas-re-encodes JPEG, PNG, or WebP input in volatile browser memory, stripping
+Photo action's explicit source panel. **Take photo** uses a dedicated file input with
+`capture="environment"`; **Choose existing** uses a separate image input without `capture` so
+Android never has to infer camera-versus-library intent from one control. It rejects source
+dimensions above an 8,192px edge or 20 megapixels, then decodes and canvas-re-encodes JPEG, PNG, or
+WebP input in volatile browser memory, stripping
 EXIF/location metadata while bounding each normalized JPEG to a 2,048px edge and 1 MiB. The
 composer passes an optional note plus those images through OMP's existing encrypted v3
 `prompt.images` frame directly to the host, then retains the draft until the host echoes the

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -421,6 +421,9 @@ Requirements:
   20 megapixels, re-encode to a maximum 2,048px edge in browser memory so source filenames and
   EXIF/location metadata do not cross the relay, and drop preview/base64 references on remove,
   host-confirmed transcript echo, or client disposal;
+- expose separate user actions and hidden inputs for **Take photo**
+  (`capture="environment"`) and **Choose existing** (no `capture`); both feed the same bounded
+  preparation path, and cancelling either chooser sends nothing;
 - retain a sent photo draft until an exact `collab-prompt` transcript entry acknowledges its text
   and image blocks after the recorded pre-send entry; if that baseline is absent during reconnect,
   no older identical entry may acknowledge the draft. After five seconds without acknowledgement,

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -172,6 +172,11 @@ to be zeroized. After send, the normalized image
 is ordinary OMP prompt content and may persist in the host transcript and at the selected model
 provider under those systems' normal retention policies. The original phone file is not uploaded.
 
+The Photo action uses two hidden file inputs behind explicit user choices. **Take photo** adds the
+browser `capture="environment"` hint; **Choose existing** omits `capture`. Native file-input
+capture launches the operating-system camera UI and does not grant script-level camera access, so
+the gateway keeps `Permissions-Policy: camera=()` and never invokes `getUserMedia`.
+
 ## 6. Capability handling
 
 Mandatory rules:

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -53,6 +53,9 @@
 
 - JPEG, PNG, and WebP inputs at or below an 8,192px edge and 20 megapixels normalize to JPEG no
   larger than a 2,048px edge or 1 MiB;
+- the Photo control exposes two 44px choices; **Take photo** targets the environment camera input,
+  **Choose existing** targets the no-capture library input, Escape closes the panel and returns
+  focus, and cancelling either picker prepares nothing;
 - unsupported, empty, over-24-MiB, over-dimension, undecodable, and over-detailed inputs fail
   visibly before decode or relay send;
 - at most four volatile previews are retained; remove, host-confirmed send, and unmount drop
@@ -115,7 +118,7 @@ Bounded title/project canaries are allowed in encrypted push and visible notific
 - collab-web parse/connect against mock relay;
 - view client write attempt is rejected;
 - control prompt/interrupt against mock/real OMP host.
-- system camera/photo selection -> metadata-free bounded JPEG preview -> encrypted `prompt.images`
+- explicit camera and existing-photo selection -> metadata-free bounded JPEG preview -> encrypted `prompt.images`
   frame -> real OMP host image prompt, with no gateway HTTP or service-worker media request;
 - a pending response operation before any writer exists -> metadata attention -> later Control replay -> exactly one settlement -> authoritative clear;
 - concurrent response operations and multiple Control writers preserve one boolean and settle each request once;
@@ -138,7 +141,8 @@ Bounded title/project canaries are allowed in encrypted push and visible notific
 1. Open View for process A; transcript streams and write controls are unavailable/rejected.
 2. Open Control for process B; submit a benign prompt and interrupt it.
 3. Host tools continue to execute on the desktop process, not the phone.
-4. From the Pixel Control composer, choose the camera, take a photo, add a note, preview it, and send.
+4. From the Pixel Control composer, open Photo and exercise both **Take photo** and
+   **Choose existing**. Take a rear-camera photo, add a note, preview it, and send.
    Repeat without a note. The host receives one bounded JPEG each time and the active model can
    inspect it; View exposes no enabled photo action.
 5. Drop one send before host acknowledgement and verify the exact draft remains until Retry is

--- a/packages/collab-client/README.md
+++ b/packages/collab-client/README.md
@@ -20,9 +20,11 @@ placeholder until the guest snapshot completes, then mounts only its newest 150 
 older rows mount.
 
 Control sessions expose the existing OMP v3 `prompt.images` path as a phone-first photo action.
-The browser opens the system camera/photo chooser, rejects source dimensions above an 8,192px edge
-or 20 megapixels, and normalizes up to four JPEG, PNG, or WebP inputs to metadata-free JPEGs with a
-2,048px edge and 1 MiB per-image cap. Volatile previews stay available until the host echoes the
+The Photo action opens an explicit two-choice panel: **Take photo** invokes a rear-camera capture
+input, while **Choose existing** opens the ordinary photo library/file picker. The browser rejects
+source dimensions above an 8,192px edge or 20 megapixels and normalizes up to four JPEG, PNG, or
+WebP inputs to metadata-free JPEGs with a 2,048px edge and 1 MiB per-image cap. Volatile previews
+stay available until the host echoes the
 sent transcript entry; a lost send retains the exact draft for retry. The gateway HTTP service and
 service worker never receive media. Removing, acknowledged sending, or leaving drops preview
 references; the normalized image then follows ordinary OMP transcript and model-provider handling

--- a/packages/collab-client/upstream/UPSTREAM.json
+++ b/packages/collab-client/upstream/UPSTREAM.json
@@ -20,6 +20,7 @@
     "Embed under gateway chrome without a competing client header, rail, or lifecycle overlay",
     "Present an embedded active Ask in the client's sole composer without a duplicate transcript card",
     "Capture, metadata-strip, bound, preview, and send phone photos through the existing encrypted image-prompt frame",
+    "Offer separate rear-camera capture and existing-photo inputs behind one accessible Photo source panel",
     "Reject oversized decoded image dimensions before browser decode and use CSP-compatible data previews",
     "Retain photo drafts until the host transcript acknowledges delivery and expose bounded retry",
     "Enforce view-link read-only state inside every mutating guest-client method",

--- a/packages/collab-client/upstream/src/components/shell/Composer.tsx
+++ b/packages/collab-client/upstream/src/components/shell/Composer.tsx
@@ -1,5 +1,5 @@
 import { COLLAB_PROMPT_MESSAGE_TYPE, type ImageContent, type SessionEntry } from "@oh-my-pi/pi-wire";
-import { Camera, SendHorizontal, Square, X } from "lucide-react";
+import { Camera, ImagePlus, Images, SendHorizontal, Square, X } from "lucide-react";
 import type { ChangeEvent, KeyboardEvent, PointerEvent as ReactPointerEvent, ReactNode, RefObject } from "react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { GuestClient, GuestSnapshot } from "../../lib/client";
@@ -272,8 +272,11 @@ export function Composer({ client, snapshot, embedded = false }: ComposerProps):
 	const [photoError, setPhotoError] = useState<string | null>(null);
 	const [pendingPhotoPrompt, setPendingPhotoPrompt] = useState<PendingPhotoPrompt | null>(null);
 	const [photoConfirmationExpired, setPhotoConfirmationExpired] = useState(false);
+	const [photoSourceOpen, setPhotoSourceOpen] = useState(false);
 	const taRef = useRef<HTMLTextAreaElement | null>(null);
-	const photoInputRef = useRef<HTMLInputElement | null>(null);
+	const cameraInputRef = useRef<HTMLInputElement | null>(null);
+	const libraryInputRef = useRef<HTMLInputElement | null>(null);
+	const photoTriggerRef = useRef<HTMLButtonElement | null>(null);
 	const photosRef = useRef<readonly PreparedPhoto[]>([]);
 	const mountedRef = useRef(true);
 	const { composingRef, onCompositionStart, onCompositionEnd } = useCompositionGuard();
@@ -341,9 +344,14 @@ export function Composer({ client, snapshot, embedded = false }: ComposerProps):
 		return () => clearTimeout(timer);
 	}, [pendingPhotoPrompt]);
 
+	useEffect(() => {
+		if (!canAddPhoto) setPhotoSourceOpen(false);
+	}, [canAddPhoto]);
+
 	const selectPhotos = useCallback(async (event: ChangeEvent<HTMLInputElement>): Promise<void> => {
 		const files = [...(event.currentTarget.files ?? [])];
 		event.currentTarget.value = "";
+		setPhotoSourceOpen(false);
 		if (files.length === 0 || pendingPhotoPrompt !== null) return;
 		const available = MAX_PHOTO_ATTACHMENTS - photosRef.current.length;
 		if (available <= 0) {
@@ -387,6 +395,7 @@ export function Composer({ client, snapshot, embedded = false }: ComposerProps):
 	}, []);
 
 	const send = useCallback((): void => {
+		setPhotoSourceOpen(false);
 		const trimmed = text.trim();
 		const selectedPhotos = photosRef.current;
 		if (
@@ -518,10 +527,66 @@ export function Composer({ client, snapshot, embedded = false }: ComposerProps):
 					{photoError && <div className="sh-photo-error" role="alert">{photoError}</div>}
 				</div>
 			)}
+			{photoSourceOpen && canAddPhoto && (
+				<div
+					id="sh-photo-source-choices"
+					className="sh-photo-source-chooser"
+					role="group"
+					aria-label="Add a photo"
+					onKeyDown={event => {
+						if (event.key !== "Escape") return;
+						setPhotoSourceOpen(false);
+						photoTriggerRef.current?.focus();
+					}}
+				>
+					<div className="sh-photo-source-options">
+						<button
+							type="button"
+							className="sh-photo-source-option"
+							onClick={() => {
+								setPhotoSourceOpen(false);
+								cameraInputRef.current?.click();
+							}}
+							onPointerDown={captureComposerPointer}
+						>
+							<Camera size={18} aria-hidden="true" />
+							<span className="sh-photo-source-copy">
+								<span className="sh-photo-source-label">Take photo</span>
+								<span className="sh-photo-source-detail">Open rear camera</span>
+							</span>
+						</button>
+						<button
+							type="button"
+							className="sh-photo-source-option"
+							onClick={() => {
+								setPhotoSourceOpen(false);
+								libraryInputRef.current?.click();
+							}}
+							onPointerDown={captureComposerPointer}
+						>
+							<Images size={18} aria-hidden="true" />
+							<span className="sh-photo-source-copy">
+								<span className="sh-photo-source-label">Choose existing</span>
+								<span className="sh-photo-source-detail">Photo library or files</span>
+							</span>
+						</button>
+					</div>
+				</div>
+			)}
 			<div className="sh-composer-inner">
 				<input
-					ref={photoInputRef}
-					className="sh-photo-input"
+					ref={cameraInputRef}
+					className="sh-photo-input sh-photo-input-camera"
+					type="file"
+					accept="image/jpeg,image/png,image/webp"
+					capture="environment"
+					hidden
+					onChange={selectPhotos}
+					disabled={!canAddPhoto}
+				/>
+				<input
+					ref={libraryInputRef}
+					className="sh-photo-input sh-photo-input-library"
 					type="file"
 					accept="image/jpeg,image/png,image/webp"
 					hidden
@@ -529,11 +594,12 @@ export function Composer({ client, snapshot, embedded = false }: ComposerProps):
 					disabled={!canAddPhoto}
 				/>
 				<button
+					ref={photoTriggerRef}
 					type="button"
-					className={`sh-btn sh-photo-trigger${photos.length > 0 ? " sh-photo-trigger-active" : ""}`}
+					className={`sh-btn sh-photo-trigger${photos.length > 0 || photoSourceOpen ? " sh-photo-trigger-active" : ""}`}
 					onClick={() => {
 						setPhotoError(null);
-						photoInputRef.current?.click();
+						setPhotoSourceOpen(open => !open);
 					}}
 					onPointerDown={captureComposerPointer}
 					disabled={!canAddPhoto}
@@ -544,15 +610,18 @@ export function Composer({ client, snapshot, embedded = false }: ComposerProps):
 								? "Photo limit reached"
 								: "Take or attach a photo"
 					}
-					aria-label="Take or attach a photo"
+					aria-label="Add a photo"
+					aria-expanded={photoSourceOpen}
+					aria-controls={photoSourceOpen ? "sh-photo-source-choices" : undefined}
 				>
-					<Camera size={17} /> <span className="sh-btn-label">Photo</span>
+					<ImagePlus size={17} /> <span className="sh-btn-label">Photo</span>
 				</button>
 				<textarea
 					ref={taRef}
 					className="sh-composer-input"
 					value={text}
 					onChange={e => setText(e.target.value)}
+					onFocus={() => setPhotoSourceOpen(false)}
 					onKeyDown={onKeyDown}
 					onCompositionStart={onCompositionStart}
 					onCompositionEnd={onCompositionEnd}

--- a/packages/collab-client/upstream/src/components/shell/shell.css
+++ b/packages/collab-client/upstream/src/components/shell/shell.css
@@ -368,6 +368,60 @@
 	margin: 0 auto 8px;
 }
 
+.sh-photo-source-chooser {
+	max-width: 880px;
+	margin: 0 auto 8px;
+}
+
+.sh-photo-source-options {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 8px;
+	max-width: 480px;
+}
+
+.sh-photo-source-option {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-width: 0;
+	min-height: 56px;
+	padding: 8px 12px;
+	color: var(--fg);
+	text-align: left;
+	background: var(--bg-inset);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-lg);
+}
+
+.sh-photo-source-option:hover,
+.sh-photo-source-option:focus-visible {
+	border-color: var(--ring);
+	background: var(--bg-overlay);
+}
+
+.sh-photo-source-option svg {
+	flex: none;
+	color: var(--accent);
+}
+
+.sh-photo-source-copy {
+	display: grid;
+	gap: 2px;
+	min-width: 0;
+}
+
+.sh-photo-source-label {
+	font-size: 13px;
+	font-weight: 600;
+}
+
+.sh-photo-source-detail {
+	font-size: 11px;
+	line-height: 1.25;
+	color: var(--fg-muted);
+}
+
 .sh-photo-strip {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
## Outcome
- make Photo open an explicit two-choice panel
- Take photo targets a dedicated capture=environment input for the rear camera
- Choose existing targets a separate no-capture photo-library/file input
- keep both paths on the existing bounded normalization, encrypted relay, acknowledgement, and retry flow

## UX
- two 56px source choices fit the measured Pixel viewport with no horizontal overflow
- Escape closes the panel and restores focus; returning to the composer also closes it
- View remains disabled and Control-only

## Verification
- bunx bun@1.3.14 run check: 503 tests, typecheck, build, and leak scans
- full browser suite: 24/24 across Pixel 411x816 and narrow 390x844
- focused E2E intercepts both native file-chooser events, verifies camera capture versus library omission, cancellation, keyboard dismissal, touch targets, and both processing paths