### PR TITLE
docs(release): record direct-camera pre-alpha smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog and Semantic Versioning.
 
 ## [Unreleased]
 
+## [v0.3.0-prealpha.2] — 2026-08-30
+
 ### Changed
 
 - Make the Photo action explicitly offer **Take photo** and **Choose existing**. The camera path

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -4,9 +4,9 @@
 
 **Current release:** stable-qualified `v0.2.1` for the exact matrix below.<br>
 **Stable candidate:** signed `v0.2.1-prealpha.2`, fully qualified and approved.<br>
-**Engineering release:** published `v0.3.0-prealpha.1` adds the phone photo composer and has
-only the exact local Darwin/desktop/Pixel-viewport smoke recorded below; none of the stable evidence
-transfers to its changed collaboration-client bytes.<br>
+**Engineering release:** published `v0.3.0-prealpha.2` adds explicit direct-camera and
+existing-photo choices to the phone photo composer and has only the exact local
+Darwin/desktop/Pixel-viewport smoke recorded below; none of the stable evidence transfers.<br>
 **0.3.0 engineering/qualification predecessor:** published stable `v0.2.1`.<br>
 **v0.2.1 stable campaign rollback predecessor:** published stable `v0.2.0`.<br>
 **Qualification predecessor:** signed stable candidate `v0.2.1-prealpha.2`.<br>
@@ -71,6 +71,7 @@ explicit, and the 0.2 campaign adds its own row:
 | `v0.2.1-prealpha.1` | `0.2.1-3ea58e234b6d` | **Rejected before qualification.** Build, attest, and signing passed; draft validation still expected 0.2.0 asset names and deleted the draft. | Signed diagnostic tag and transparency records retained; no GitHub release survived and no host/client qualification ran. |
 | `v0.2.1-prealpha.2` | `0.2.1-f09e3566c238` | **Qualified and approved for `v0.2.1`.** Final phone hierarchy, coherent product versioning, predecessor-bound receipts, and stable runtime equivalence gate. | Archive SHA-256 `9fd5e49b9819ab4dfc82f978fcd9e8382b83d5b821bb341c6b6e6979ff42c7fa`; release run `33206359784`, Debian `33207184350`, macOS `doctor` 17/17 and rollback 20/20 from v0.2.0, physical Pixel recovery/leak sweep, patched-OMP publication/revocation, 60s relay smoke, and cleanup passed. |
 | `v0.3.0-prealpha.1` | `0.3.0-1a8a3212e195` | **Published pre-alpha; locally smoke-tested, not qualified.** Phone photo chooser/composer using existing OMP v3 image prompts. | Archive SHA-256 `60750b2b5f21d4e99dbd1a4d05230f4aa3f4d79b15c113d08aa68042a54c5fed`; release run `33281549543`; checksums, six immutable assets, three attestations, and three bundles verified; local Darwin install/doctor 17/17 and real patched-host desktop plus measured Pixel-viewport sends passed. No physical Android run. |
+| `v0.3.0-prealpha.2` | `0.3.0-d259ea06c7fe` | **Published pre-alpha direct-camera follow-up; locally smoke-tested, not qualified.** Explicit Take photo and Choose existing paths. | Archive SHA-256 `ca05549aecdf0d2e01f2b5d6820729222e29b38e92aa4ee1582c009e195c6fff`; release run `33283594409`; provenance and six assets verified; local Darwin install/doctor 17/17 and real patched-host Pixel-viewport camera-input JPEG plus library-input PNG sends passed. Native Android camera launch not exercised. |
 
 [`RELEASE_STATUS.md`](RELEASE_STATUS.md) is the source of truth for evidence and release decisions.
 This document defines the supported boundary. Where they disagree, the ledger is authoritative.

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -9,14 +9,37 @@ exact qualified combinations below and no broader production claim<br>
 
 ### 0.3.0 engineering track — unqualified
 
-Published engineering release `v0.3.0-prealpha.1` adds a bounded phone-camera/photo composer to
-the pinned collaboration client.
+Published engineering release `v0.3.0-prealpha.2` adds an explicit direct-camera versus
+existing-photo choice to the bounded phone photo composer introduced in `v0.3.0-prealpha.1`.
 It uses the existing encrypted OMP v3 image-prompt frame and does not change gateway IPC/HTTP,
 capability handling, the controller/publisher patch, or `COLLAB_PROTO`. No 0.2.1 qualification
 evidence transfers to these changed client bytes. The exact source, archive, local activation, and
 real patched-host browser flow are recorded below; the physical Pixel camera chooser and the full
 qualification matrix have not run. The release remains pre-alpha and cannot replace or widen the
 stable support claim below.
+
+### v0.3.0-prealpha.2 — published direct-camera follow-up
+
+**Source:** `a9ef7e03934986bf9a3ecc12eb87a707d35e846b`.<br>
+**Archive SHA-256:** `ca05549aecdf0d2e01f2b5d6820729222e29b38e92aa4ee1582c009e195c6fff`.<br>
+**Release run:** [`33283594409`](https://github.com/alphastorm/omp-session-gateway/actions/runs/33283594409), passed.<br>
+**Classification:** published immutable prerelease, not Latest; the exact local smoke below does
+not transfer stable qualification.
+
+The release published six assets. Checksums, all immutable asset digests, three GitHub build
+attestations, and three Sigstore bundles verified against the signed tag. The published archive
+installed under pinned Bun 1.3.14 as `0.3.0-d259ea06c7fe`; config and publisher-token bytes were
+unchanged, `status` was active/ready/non-diverged, and `doctor` passed 17/17.
+
+An owned exact patched-OMP v17.4.1 fixture proved the activated released client kept Photo disabled
+in View, upgraded to Control, and rendered two 56px Pixel-width choices without overflow.
+**Take photo** targeted the dedicated `capture="environment"` input; **Choose existing** targeted
+the no-capture input. Synthetic camera-JPEG and existing-photo PNG sends both traversed the default
+relay, received exact host transcript acknowledgement, rendered two transcript images, and cleared
+their drafts. Fixture revocation and scoped cleanup passed.
+
+No physical ADB device was attached. The native Android camera application launch remains the one
+unobserved handoff; the activated release now exposes that path for the user's direct Pixel test.
 
 ### v0.3.0-prealpha.1 — published engineering release
 

--- a/packages/collab-client/test/composer.test.ts
+++ b/packages/collab-client/test/composer.test.ts
@@ -1,8 +1,19 @@
 import type { AssistantMessage, ImageContent, SessionEntry } from "@oh-my-pi/pi-wire";
-import { describe, expect, test } from "bun:test";
-import { photoPromptAcknowledged } from "../upstream/src/components/shell/Composer";
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { Composer, photoPromptAcknowledged } from "../upstream/src/components/shell/Composer";
 import { recommendedOptionIndex } from "../upstream/src/components/shell/ask-recommendation";
-import type { ActiveTool, GuestSnapshot } from "../upstream/src/lib/client";
+import type { ActiveTool, GuestClient, GuestSnapshot } from "../upstream/src/lib/client";
+import {
+  type MiniElement,
+  click,
+  mount,
+  query,
+  queryAll,
+  restoreDomGlobals,
+  textOf,
+  unmountAll,
+} from "./react-dom-harness";
 
 const QUESTION = "How should ADR-0036 proceed?";
 const OPTIONS = [
@@ -109,6 +120,14 @@ function snapshot(overrides: Partial<GuestSnapshot> = {}): GuestSnapshot {
   };
 }
 
+afterEach(async () => {
+  await unmountAll();
+});
+
+afterAll(() => {
+  restoreDomGlobals();
+});
+
 describe("collaboration ask recommendations", () => {
   test("finds an explicit recommendation on the matching active option", () => {
     const current = snapshot({
@@ -158,5 +177,59 @@ describe("photo prompt acknowledgements", () => {
         afterEntryId: null,
       }),
     ).toBeTrue();
+  });
+});
+
+describe("photo source chooser", () => {
+  test("routes explicit camera and library choices to separate inputs", async () => {
+    const client = {
+      sendAbort(): void {},
+      sendAgentCmd(): void {},
+      sendPrompt(): void {},
+      sendUiResponse(): void {},
+    } as unknown as GuestClient;
+    const tree = await mount(
+      createElement(Composer, {
+        client,
+        snapshot: snapshot({ uiRequest: null, working: false }),
+        embedded: true,
+      }),
+    );
+    const trigger = query(tree.container, "sh-photo-trigger");
+    const cameraInput = query(tree.container, "sh-photo-input-camera");
+    const libraryInput = query(tree.container, "sh-photo-input-library");
+    if (trigger === null || cameraInput === null || libraryInput === null) {
+      throw new Error("photo chooser controls did not render");
+    }
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(cameraInput.getAttribute("capture")).toBe("environment");
+    expect(libraryInput.getAttribute("capture")).toBeNull();
+
+    let cameraClicks = 0;
+    let libraryClicks = 0;
+    (cameraInput as MiniElement & { click(): void }).click = () => {
+      cameraClicks += 1;
+    };
+    (libraryInput as MiniElement & { click(): void }).click = () => {
+      libraryClicks += 1;
+    };
+
+    await click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    const choices = queryAll(tree.container, "sh-photo-source-option");
+    expect(choices.map(choice => textOf(choice))).toEqual([
+      "Take photoOpen rear camera",
+      "Choose existingPhoto library or files",
+    ]);
+    await click(choices[0] as MiniElement);
+    expect(cameraClicks).toBe(1);
+    expect(libraryClicks).toBe(0);
+    expect(query(tree.container, "sh-photo-source-options")).toBeNull();
+
+    await click(trigger);
+    await click(queryAll(tree.container, "sh-photo-source-option")[1] as MiniElement);
+    expect(cameraClicks).toBe(1);
+    expect(libraryClicks).toBe(1);
+    expect(query(tree.container, "sh-photo-source-options")).toBeNull();
   });
 });

--- a/packages/collab-client/test/composer.test.ts
+++ b/packages/collab-client/test/composer.test.ts
@@ -1,19 +1,8 @@
 import type { AssistantMessage, ImageContent, SessionEntry } from "@oh-my-pi/pi-wire";
-import { afterAll, afterEach, describe, expect, test } from "bun:test";
-import { createElement } from "react";
-import { Composer, photoPromptAcknowledged } from "../upstream/src/components/shell/Composer";
+import { describe, expect, test } from "bun:test";
+import { photoPromptAcknowledged } from "../upstream/src/components/shell/Composer";
 import { recommendedOptionIndex } from "../upstream/src/components/shell/ask-recommendation";
-import type { ActiveTool, GuestClient, GuestSnapshot } from "../upstream/src/lib/client";
-import {
-  type MiniElement,
-  click,
-  mount,
-  query,
-  queryAll,
-  restoreDomGlobals,
-  textOf,
-  unmountAll,
-} from "./react-dom-harness";
+import type { ActiveTool, GuestSnapshot } from "../upstream/src/lib/client";
 
 const QUESTION = "How should ADR-0036 proceed?";
 const OPTIONS = [
@@ -120,14 +109,6 @@ function snapshot(overrides: Partial<GuestSnapshot> = {}): GuestSnapshot {
   };
 }
 
-afterEach(async () => {
-  await unmountAll();
-});
-
-afterAll(() => {
-  restoreDomGlobals();
-});
-
 describe("collaboration ask recommendations", () => {
   test("finds an explicit recommendation on the matching active option", () => {
     const current = snapshot({
@@ -180,56 +161,3 @@ describe("photo prompt acknowledgements", () => {
   });
 });
 
-describe("photo source chooser", () => {
-  test("routes explicit camera and library choices to separate inputs", async () => {
-    const client = {
-      sendAbort(): void {},
-      sendAgentCmd(): void {},
-      sendPrompt(): void {},
-      sendUiResponse(): void {},
-    } as unknown as GuestClient;
-    const tree = await mount(
-      createElement(Composer, {
-        client,
-        snapshot: snapshot({ uiRequest: null, working: false }),
-        embedded: true,
-      }),
-    );
-    const trigger = query(tree.container, "sh-photo-trigger");
-    const cameraInput = query(tree.container, "sh-photo-input-camera");
-    const libraryInput = query(tree.container, "sh-photo-input-library");
-    if (trigger === null || cameraInput === null || libraryInput === null) {
-      throw new Error("photo chooser controls did not render");
-    }
-    expect(trigger.getAttribute("aria-expanded")).toBe("false");
-    expect(cameraInput.getAttribute("capture")).toBe("environment");
-    expect(libraryInput.getAttribute("capture")).toBeNull();
-
-    let cameraClicks = 0;
-    let libraryClicks = 0;
-    (cameraInput as MiniElement & { click(): void }).click = () => {
-      cameraClicks += 1;
-    };
-    (libraryInput as MiniElement & { click(): void }).click = () => {
-      libraryClicks += 1;
-    };
-
-    await click(trigger);
-    expect(trigger.getAttribute("aria-expanded")).toBe("true");
-    const choices = queryAll(tree.container, "sh-photo-source-option");
-    expect(choices.map(choice => textOf(choice))).toEqual([
-      "Take photoOpen rear camera",
-      "Choose existingPhoto library or files",
-    ]);
-    await click(choices[0] as MiniElement);
-    expect(cameraClicks).toBe(1);
-    expect(libraryClicks).toBe(0);
-    expect(query(tree.container, "sh-photo-source-options")).toBeNull();
-
-    await click(trigger);
-    await click(queryAll(tree.container, "sh-photo-source-option")[1] as MiniElement);
-    expect(cameraClicks).toBe(1);
-    expect(libraryClicks).toBe(1);
-    expect(query(tree.container, "sh-photo-source-options")).toBeNull();
-  });
-});

--- a/packages/collab-client/test/transcript.test.ts
+++ b/packages/collab-client/test/transcript.test.ts
@@ -20,6 +20,7 @@ import {
 const { TRANSCRIPT_WINDOW, TRANSCRIPT_WINDOW_STEP, Transcript } = await import(
   "../upstream/src/components/transcript/Transcript"
 );
+const { Composer } = await import("../upstream/src/components/shell/Composer");
 const { Session } = await import("../upstream/src/app");
 
 const USAGE = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { total: 0 } };
@@ -260,6 +261,55 @@ function guestSnapshot(overrides: Partial<GuestSnapshot> = {}): GuestSnapshot {
     ...overrides,
   };
 }
+
+describe("photo source chooser", () => {
+  test("routes explicit camera and library choices to separate inputs", async () => {
+    const guest = new FakeGuest(guestSnapshot({ phase: "live" }));
+    const tree = await mount(
+      createElement(Composer, {
+        client: guest.client,
+        snapshot: guest.getSnapshot(),
+        embedded: true,
+      }),
+    );
+    const trigger = query(tree.container, "sh-photo-trigger");
+    const cameraInput = query(tree.container, "sh-photo-input-camera");
+    const libraryInput = query(tree.container, "sh-photo-input-library");
+    if (trigger === null || cameraInput === null || libraryInput === null) {
+      throw new Error("photo chooser controls did not render");
+    }
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(cameraInput.getAttribute("capture")).toBe("environment");
+    expect(libraryInput.getAttribute("capture")).toBeNull();
+
+    let cameraClicks = 0;
+    let libraryClicks = 0;
+    (cameraInput as MiniElement & { click(): void }).click = () => {
+      cameraClicks += 1;
+    };
+    (libraryInput as MiniElement & { click(): void }).click = () => {
+      libraryClicks += 1;
+    };
+
+    await click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    const choices = queryAll(tree.container, "sh-photo-source-option");
+    expect(choices.map(choice => textOf(choice))).toEqual([
+      "Take photoOpen rear camera",
+      "Choose existingPhoto library or files",
+    ]);
+    await click(choices[0] as MiniElement);
+    expect(cameraClicks).toBe(1);
+    expect(libraryClicks).toBe(0);
+    expect(query(tree.container, "sh-photo-source-options")).toBeNull();
+
+    await click(trigger);
+    await click(queryAll(tree.container, "sh-photo-source-option")[1] as MiniElement);
+    expect(cameraClicks).toBe(1);
+    expect(libraryClicks).toBe(1);
+    expect(query(tree.container, "sh-photo-source-options")).toBeNull();
+  });
+});
 
 describe("embedded session first paint", () => {
   test("defers the transcript until the guest snapshot completes, then keeps it across a reconnect", async () => {


### PR DESCRIPTION
Record v0.3.0-prealpha.2 publication, provenance, pinned local activation, and real patched-host Pixel-viewport smoke for both Take photo and Choose existing. Physical Android camera-app launch remains explicitly unqualified; stable v0.2.1 remains Latest.